### PR TITLE
Fix/116 Clear current publick key on disconnect

### DIFF
--- a/apps/trading/hooks/use-vega-wallet-eager-connect.ts
+++ b/apps/trading/hooks/use-vega-wallet-eager-connect.ts
@@ -21,7 +21,10 @@ export function useEagerConnect() {
 
     // Developer hasn't provided this connector
     if (!connector) {
-      throw new Error(`Connector ${cfgObj?.connector} not configured`);
+      console.warn(
+        `Can't eager connect, connector: ${cfgObj.connector} not found`
+      );
+      return;
     }
 
     connect(Connectors[cfgObj.connector]);

--- a/libs/wallet/src/provider.test.tsx
+++ b/libs/wallet/src/provider.test.tsx
@@ -4,6 +4,7 @@ import { VegaKey } from '@vegaprotocol/vegawallet-service-api-client';
 import { RestConnector } from './connectors';
 import { useVegaWallet } from './hooks';
 import { VegaWalletProvider } from './provider';
+import { WALLET_KEY } from './storage-keys';
 
 const restConnector = new RestConnector();
 
@@ -93,4 +94,5 @@ test('Can connect, disconnect and retrieve keypairs', async () => {
   });
   expect(screen.getByTestId('current-keypair')).toBeEmptyDOMElement();
   expect(screen.queryByTestId('keypairs-list')).not.toBeInTheDocument();
+  expect(localStorage.getItem(WALLET_KEY)).toBe(null);
 });

--- a/libs/wallet/src/provider.tsx
+++ b/libs/wallet/src/provider.tsx
@@ -67,6 +67,7 @@ export const VegaWalletProvider = ({ children }: VegaWalletProviderProps) => {
       await connector.current?.disconnect();
       setKeypairs(null);
       connector.current = null;
+      LocalStorage.removeItem(WALLET_KEY);
       return true;
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
- Clears current public key from local storage on disconnect
- Don't throw an error in useEagerConnect if a config is not found

Closes #116 