### PR TITLE
Fix typo in block explorer label

### DIFF
--- a/apps/explorer/src/app/routes/txs/id/tx-details.tsx
+++ b/apps/explorer/src/app/routes/txs/id/tx-details.tsx
@@ -55,7 +55,7 @@ export const TxDetails = ({ txData, pubKey, className }: TxDetailsProps) => {
         </TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>Encoded tnx</TableCell>
+        <TableCell>Encoded txn</TableCell>
         <TableCell modifier="bordered" data-testid="encoded-tnx">
           <TruncateInline
             text={txData.tx}


### PR DESCRIPTION
Transaction is usually `txn` not `tnx`.

- Update label