### PR TITLE
frontend-monorepo-184 Bottom margin for next/prev block links

### DIFF
--- a/apps/explorer/src/app/routes/blocks/id/block.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.tsx
@@ -36,7 +36,7 @@ const Block = () => {
       <RouteTitle data-testid="block-header">{t(`BLOCK ${block}`)}</RouteTitle>
       <RenderFetched error={error} loading={loading}>
         <>
-          <div className="grid grid-cols-2 gap-16">
+          <div className="grid grid-cols-2 gap-16 mb-24">
             <Link
               data-testid="previous-block"
               to={`/${Routes.BLOCKS}/${Number(block) - 1}`}


### PR DESCRIPTION
Closes #184 

Simple bit of margin. This:

<img width="991" alt="Screenshot 2022-03-31 at 17 01 23" src="https://user-images.githubusercontent.com/2410498/161103905-d3a51143-92bf-45aa-a5a1-bacaaf9f65cd.png">

becomes:

<img width="986" alt="Screenshot 2022-03-31 at 17 01 33" src="https://user-images.githubusercontent.com/2410498/161104218-0809711f-afd2-4c5d-896f-837b8b4647ae.png">


