### PR TITLE
[stats] Set a default env

### DIFF
--- a/apps/stats/.env
+++ b/apps/stats/.env
@@ -1,0 +1,3 @@
+# App configuration variables
+NX_VEGA_ENV = 'MAINNET'
+NX_VEGA_REST = 'https://api.token.vega.xyz/'

--- a/apps/stats/.env.mainnet
+++ b/apps/stats/.env.mainnet
@@ -1,3 +1,2 @@
-# App configuration variables
-NX_VEGA_ENV = 'MAINNET'
-NX_VEGA_REST = 'https://api.token.vega.xyz/'
+# App configuration variables. No overrides for default urls
+PUBLIC_URL=.

--- a/apps/stats/project.json
+++ b/apps/stats/project.json
@@ -11,7 +11,6 @@
         "compiler": "babel",
         "outputPath": "dist/apps/stats",
         "index": "apps/stats/src/index.html",
-        "baseHref": "/",
         "main": "apps/stats/src/main.tsx",
         "polyfills": "apps/stats/src/polyfills.ts",
         "tsConfig": "apps/stats/tsconfig.app.json",
@@ -31,6 +30,7 @@
               "with": "apps/stats/src/environments/environment.prod.ts"
             }
           ],
+          "subresourceIntegrity": true,
           "optimization": true,
           "outputHashing": "all",
           "sourceMap": false,


### PR DESCRIPTION
I have been trying to fix the build of stats in a very specific environment, which requires a few tweaks

- Not force baseHref to `/`
- By default, connect to mainnet endpoints unless explicitly overriden

