### PR TITLE
Add license to stats readme

### DIFF
--- a/apps/stats/README.md
+++ b/apps/stats/README.md
@@ -1,3 +1,7 @@
 # Stats viewer
 
 https://status.vega.xyz
+
+# LICENSE
+
+MIT


### PR DESCRIPTION
Add a license field in the stats readme

Really this is a test for the Netlify NX ignore plugin

- Update README.md
