### PR TITLE
Remove custom ignore

### DIFF
--- a/ignore-netlify-build.js
+++ b/ignore-netlify-build.js
@@ -1,9 +1,0 @@
-const currentProject = process.env.NX_PROJECT_NAME;
-const execSync = require('child_process').execSync;
-const getAffected = `npx nx print-affected`;
-const output = execSync(getAffected).toString();
-//get the list of changed projects from the output
-const changedProjects = JSON.parse(output).projects; // array of affected projects
-process.exitCode = changedProjects.some((project) => project === currentProject)
-  ? 0
-  : 1;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
-[build]
-  ignore = "node ignore-netlify-build.js"
-
 [functions]
   included_files = ["!node_modules/@sentry/cli/sentry-cli"]


### PR DESCRIPTION
Bart, Dex & re-enabled the nx-ignore netlify plugin which successfully does the job.

We thought it broke builds, it doesn't.

- Remove netlify.toml ignore section
- Remove ignore script
