### PR TITLE
Fix/Size of loader for deposit dialog

### DIFF
--- a/libs/ui-toolkit/src/components/transaction-dialog/transaction-dialog.tsx
+++ b/libs/ui-toolkit/src/components/transaction-dialog/transaction-dialog.tsx
@@ -73,7 +73,7 @@ export const TransactionDialog = ({
       },
       [TxState.Pending]: {
         title: t(`${name} pending`),
-        icon: <Loader />,
+        icon: <Loader size="small" />,
         intent: Intent.Progress,
       },
       [TxState.Complete]: {


### PR DESCRIPTION
- Just adds size={'small'}