### PR TITLE
change engines to allow anything above 16.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "husky install"
   },
   "engines": {
-    "node": "16.14.0"
+    "node": ">=16.14.0"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Add greater than, unless there is a good reason not to?

nvmrc remains the same