### PR TITLE
Test passing for trades list

### DIFF
--- a/apps/trading-e2e/src/integration/markets-page.feature
+++ b/apps/trading-e2e/src/integration/markets-page.feature
@@ -8,10 +8,10 @@ Feature: Markets page
 
   Scenario: Select active market
     Given I am on the markets page
-    When I click on an active market
-    Then I am on the trading page for an active market
+    When I click on "Active" market
+    Then trading page for "active" market is displayed
 
   Scenario: Select suspended market
     Given I am on the markets page
-    When I click on a suspended market
-    Then I am on the trading page for a suspended market
+    When I click on "Suspended" market
+    Then trading page for "suspended" market is displayed

--- a/apps/trading-e2e/src/support/pages/trading-page.ts
+++ b/apps/trading-e2e/src/support/pages/trading-page.ts
@@ -1,15 +1,15 @@
 import BasePage from './base-page';
 
 export default class TradingPage extends BasePage {
-  chartTab = 'chart';
-  ticketTab = 'ticket';
-  orderbookTab = 'orderbook';
-  ordersTab = 'orders';
-  positionsTab = 'positions';
-  collateralTab = 'collateral';
-  tradesTab = 'trades';
-  completedTrades = 'market-trades';
-  orderBookTab = 'orderbook';
+  chartTab = 'Chart';
+  ticketTab = 'Ticket';
+  orderbookTab = 'Orderbook';
+  ordersTab = 'Orders';
+  positionsTab = 'Positions';
+  collateralTab = 'Collateral';
+  tradesTab = 'Trades';
+  completedTrades = 'Market-trades';
+  orderBookTab = 'Prderbook';
 
   clickOnOrdersTab() {
     cy.getByTestId(this.ordersTab).click();

--- a/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
@@ -38,10 +38,6 @@ And('the market table is displayed', () => {
   marketsPage.validateMarketTableDisplayed();
 });
 
-When('I click on an active market', () => {
-  marketsPage.clickOnMarket('Active');
-});
-
-When('I click on a suspended market', () => {
-  marketsPage.clickOnMarket('Suspended');
+When('I click on {string} market', (Expectedmarket) => {
+  marketsPage.clickOnMarket(Expectedmarket);
 });

--- a/apps/trading-e2e/src/support/step_definitions/trading-page.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/trading-page.step.ts
@@ -1,4 +1,4 @@
-import { Given } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 import { hasOperationName } from '..';
 import { MarketState } from '@vegaprotocol/types';
 /* eslint-disable @nrwl/nx/enforce-module-boundaries */
@@ -9,6 +9,11 @@ import {
 } from '../../../../../libs/chart/src/__tests__';
 import { generateDealTicketQuery } from '../../../../../libs/deal-ticket/src/__tests__';
 import { generateMarket } from '../../../../trading/pages/markets/__tests__';
+import TradesList from '../trading-windows/trades-list';
+import TradingPage from '../pages/trading-page';
+
+const tradesList = new TradesList();
+const tradingPage = new TradingPage();
 /* eslint-enable @nrwl/nx/enforce-module-boundaries */
 
 const mockMarket = (state: MarketState) => {
@@ -65,4 +70,21 @@ Given('I am on the trading page for a suspended market', () => {
   cy.visit('/markets/market-id');
   cy.wait('@Market');
   cy.contains('Market: SUSPENDED MARKET');
+});
+
+Then('trading page for {string} market is displayed', (marketType) => {
+  switch (marketType) {
+    case 'active':
+      mockMarket(MarketState.Active);
+      cy.wait('@Market');
+      cy.contains('Market: ACTIVE MARKET');
+      break;
+    case 'suspended':
+      mockMarket(MarketState.Suspended);
+      cy.wait('@Market');
+      cy.contains('Market: SUSPENDED MARKET');
+      break;
+  }
+  tradingPage.clickOnTradesTab();
+  tradesList.verifyTradesListDisplayed();
 });

--- a/apps/trading-e2e/src/support/trading-windows/trades-list.js
+++ b/apps/trading-e2e/src/support/trading-windows/trades-list.js
@@ -1,0 +1,24 @@
+export default class TradesList {
+  colIdPrice = 'price';
+  colIdSize = 'size';
+  colIdCreatedAt = 'createdAt';
+
+  verifyTradesListDisplayed() {
+    cy.get(`[col-id=${this.colIdPrice}]`).each(($tradePrice) => {
+      cy.wrap($tradePrice).invoke('text').should('not.be.empty');
+    });
+    cy.get(`[col-id=${this.colIdSize}]`).each(($tradeSize) => {
+      cy.wrap($tradeSize).invoke('text').should('not.be.empty');
+    });
+
+    const dateTimeRegex =
+      /(\d{2})\/(\d{2})\/(\d{4}), (\d{2}):(\d{2}):(\d{2})/gm;
+    cy.get(`[col-id=${this.colIdCreatedAt}]`).each(($tradeDateTime, index) => {
+      if (index != 0) {
+        //ignore header
+        cy.log(index);
+        cy.wrap($tradeDateTime).invoke('text').should('match', dateTimeRegex);
+      }
+    });
+  }
+}

--- a/apps/trading-e2e/src/support/trading-windows/trades-list.ts
+++ b/apps/trading-e2e/src/support/trading-windows/trades-list.ts
@@ -16,7 +16,6 @@ export default class TradesList {
     cy.get(`[col-id=${this.colIdCreatedAt}]`).each(($tradeDateTime, index) => {
       if (index != 0) {
         //ignore header
-        cy.log(index);
         cy.wrap($tradeDateTime).invoke('text').should('match', dateTimeRegex);
       }
     });

--- a/apps/trading-e2e/src/support/trading-windows/trades-list.ts
+++ b/apps/trading-e2e/src/support/trading-windows/trades-list.ts
@@ -12,7 +12,7 @@ export default class TradesList {
     });
 
     const dateTimeRegex =
-      /(\d{2})\/(\d{2})\/(\d{4}), (\d{2}):(\d{2}):(\d{2})/gm;
+      /(\d{1,2})\/(\d{1,2})\/(\d{4}), (\d{1,2}):(\d{1,2}):(\d{1,2})/gm;
     cy.get(`[col-id=${this.colIdCreatedAt}]`).each(($tradeDateTime, index) => {
       if (index != 0) {
         //ignore header


### PR DESCRIPTION
Add additional assertion to existing step for checking that the trades list is displayed with no missing values.

Once we have capsule running, we could potentially have some more detailed tests to verify specific trades getting updated. One for follow up ticket if possible to do. 

Closes #141 