### PR TITLE
Test for accounts

### DIFF
--- a/apps/trading-e2e/src/integration/markets-page.feature
+++ b/apps/trading-e2e/src/integration/markets-page.feature
@@ -16,6 +16,13 @@ Feature: Markets page
     When I click on "Suspended" market
     Then trading page for "suspended" market is displayed
 
+  Scenario: Accounts displayed when connected to wallet
+    Given I am on the trading page for an active market
+    And I connect to Vega Wallet
+    When I click on accounts tab
+    Then accounts are displayed
+    And I can see account for tEURO
+
   Scenario: Positions displayed
     Given I am on the trading page for an active market
     And I connect to Vega Wallet

--- a/apps/trading-e2e/src/support/pages/trading-page.ts
+++ b/apps/trading-e2e/src/support/pages/trading-page.ts
@@ -6,6 +6,7 @@ export default class TradingPage extends BasePage {
   orderbookTab = 'Orderbook';
   ordersTab = 'Orders';
   positionsTab = 'Positions';
+  accountsTab = 'Accounts';
   collateralTab = 'Collateral';
   tradesTab = 'Trades';
   completedTrades = 'Market-trades';
@@ -13,6 +14,10 @@ export default class TradingPage extends BasePage {
 
   clickOnOrdersTab() {
     cy.getByTestId(this.ordersTab).click();
+  }
+
+  clickOnAccountsTab() {
+    cy.getByTestId(this.accountsTab).click();
   }
 
   clickOnPositionsTab() {

--- a/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
@@ -5,10 +5,12 @@ import { generateMarkets } from '../mocks/generate-markets';
 import MarketsPage from '../pages/markets-page';
 import TradingPage from '../pages/trading-page';
 import PositionsList from '../trading-windows/positions-list';
+import AccountsList from '../trading-windows/accounts-list';
 
 const marketsPage = new MarketsPage();
 const tradingPage = new TradingPage();
 const positionsList = new PositionsList();
+const accountList = new AccountsList();
 
 const mockMarkets = () => {
   cy.mockGQL('Markets', (req) => {
@@ -52,4 +54,22 @@ When('I click on positions tab', () => {
 
 Then('positions are displayed', () => {
   positionsList.verifyPositionsDisplayed();
+});
+
+When('I click on accounts tab', () => {
+  tradingPage.clickOnAccountsTab();
+});
+
+Then('accounts are displayed', () => {
+  accountList.verifyAccountsDisplayed();
+});
+
+Then('I can see account for tEURO', () => {
+  accountList.verifySingleAccountDisplayed(
+    'General-tEURO-null',
+    'tEURO',
+    'General',
+    '—',
+    '1,000.00000'
+  );
 });

--- a/apps/trading-e2e/src/support/trading-windows/accounts-list.ts
+++ b/apps/trading-e2e/src/support/trading-windows/accounts-list.ts
@@ -1,0 +1,44 @@
+export default class AccountsList {
+  accountSymbolColId = 'asset.symbol';
+  accountTypeColId = 'type';
+  accountMarketNameColId = 'market.name';
+  accountBalanceColId = 'balance';
+
+  verifyAccountsDisplayed() {
+    cy.get(`[col-id='${this.accountSymbolColId}']`).each(($accountSymbol) => {
+      cy.wrap($accountSymbol).invoke('text').should('not.be.empty');
+    });
+    cy.get(`[col-id='${this.accountTypeColId}']`).each(($accountType) => {
+      cy.wrap($accountType).invoke('text').should('not.be.empty');
+    });
+    cy.get(`[col-id='${this.accountMarketNameColId}']`).each(
+      ($accountMarketName) => {
+        cy.wrap($accountMarketName).invoke('text').should('not.be.empty');
+      }
+    );
+    cy.get(`[col-id='${this.accountBalanceColId}']`).each(($accountBalance) => {
+      cy.wrap($accountBalance).invoke('text').should('not.be.empty');
+    });
+  }
+
+  verifySingleAccountDisplayed(
+    accountRowId: string,
+    accountSymbol: string,
+    accountType: string,
+    accountMarketName: string,
+    accountBalance: string
+  ) {
+    cy.get(`[row-id='${accountRowId}']`)
+      .find(`[col-id='${this.accountSymbolColId}']`)
+      .should('have.text', accountSymbol);
+    cy.get(`[row-id='${accountRowId}']`)
+      .find(`[col-id='${this.accountTypeColId}']`)
+      .should('have.text', accountType);
+    cy.get(`[row-id='${accountRowId}']`)
+      .find(`[col-id='${this.accountMarketNameColId}']`)
+      .should('have.text', accountMarketName);
+    cy.get(`[row-id='${accountRowId}']`)
+      .find(`[col-id='${this.accountBalanceColId}']`)
+      .should('have.text', accountBalance);
+  }
+}


### PR DESCRIPTION
Add test to validate accounts list 

Currently it's using the test wallet that has tEuro deposited into it. Might require it to be manually topped up if testnet gets restarted. 
Hopefully this won't be needed with Capsule

Related to #185 