### PR TITLE
chore(deps): update dependency pennant to v0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.21",
     "next": "^12.0.7",
     "nx": "^13.8.3",
-    "pennant": "0.4.5",
+    "pennant": "0.4.7",
     "postcss": "^8.4.6",
     "react": "17.0.2",
     "react-copy-to-clipboard": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6454,15 +6454,16 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-allotment@1.11.2-alpha.1:
-  version "1.11.2-alpha.1"
-  resolved "https://registry.yarnpkg.com/allotment/-/allotment-1.11.2-alpha.1.tgz#c284d45d106facb6ade03183efd7b30b1b0b2bb6"
-  integrity sha512-3lBTVZCwCfsyVGUWG1rlDJgT6N+xQzdibThrWSVEqD/nxUesOLJuP3443QhEj2EZYJNhMJpZBTbV2R+ijXqXdQ==
+allotment@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/allotment/-/allotment-1.12.1.tgz#1efa19967f3b955fb3db18d938925619f4e0f313"
+  integrity sha512-jEQ1hB0f+dMgEmzLWRcGjwek5w3PTWI1seYqgedyNQefX+u0xdoOsB6UKV6dTEcrAue5nx7wO87GTch3IaUqgw==
   dependencies:
     classnames "^2.3.0"
     eventemitter3 "^4.0.0"
     lodash.clamp "^4.0.0"
     lodash.debounce "^4.0.0"
+    lodash.isequal "^4.5.0"
     use-resize-observer "^8.0.0"
 
 alpha-lyrae@vegaprotocol/alpha-lyrae:
@@ -14586,6 +14587,11 @@ lodash.identity@3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.identity/-/lodash.identity-3.0.0.tgz#ad7bc6a4e647d79c972e1b80feef7af156267876"
   integrity sha1-rXvGpOZH15yXLhuA/u968VYmeHY=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -16312,10 +16318,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-pennant@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.5.tgz#8adf173f4f24d3de336ea51d277306c2ffdf859c"
-  integrity sha512-lZUKbHIb30kwHDxvVwu5BN4QTAImieIQrH/Olf5ONBneunyepwEd/fgQi2vXBXW9NawiLuc8v+OLbGW65DZRtw==
+pennant@0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.7.tgz#b1541f57d563c8a14f026292f6f88c059938f31a"
+  integrity sha512-HKpQS9wUMdH7aqdiOTwWwXAd2GhxKT1RF//f9utYhTuWFK5dK44EvWiaOTol+ddpN30GStK4KxO8s2OkeYLvPw==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@d3fc/d3fc-technical-indicator" "^8.0.1"
@@ -16336,7 +16342,7 @@ pennant@0.4.5:
     "@types/react" "^17.0.0"
     "@types/react-dom" "^17.0.0"
     "@types/react-virtualized-auto-sizer" "^1.0.0"
-    allotment "1.11.2-alpha.1"
+    allotment "1.12.1"
     classnames "^2.2.6"
     d3-array "2.3.3"
     d3-delaunay "^6.0.2"


### PR DESCRIPTION
Closes #287.

## Release notes

### [0.4.7](https://github.com/vegaprotocol/pennant/compare/v0.4.6...v0.4.7) (2022-04-22)


### Bug Fixes

* red candles should be filled ([#447](https://github.com/vegaprotocol/pennant/issues/447)) ([69ac677](https://github.com/vegaprotocol/pennant/commit/69ac67794fc1f7ae6ff19a53f35db1686e22e01a))
* use true black for background ([#448](https://github.com/vegaprotocol/pennant/issues/448)) ([852b9ff](https://github.com/vegaprotocol/pennant/commit/852b9ffb884870e9c6b4e7e9295c22eaddc8cc54))

### [0.4.6](https://github.com/vegaprotocol/pennant/compare/v0.4.5...v0.4.6) (2022-04-20)


### Features

* support multiple studies ([#438](https://github.com/vegaprotocol/pennant/issues/438)) ([e52dcb0](https://github.com/vegaprotocol/pennant/commit/e52dcb0fe022d180982e81f305535c74a72eb81b))


### Bug Fixes

* separate loading and initializing states ([#436](https://github.com/vegaprotocol/pennant/issues/436)) ([4714ed8](https://github.com/vegaprotocol/pennant/commit/4714ed84f0ab3f9655bfdafb45faeeb3555c15b0))