### PR TITLE
Check for 2dp on total staked

### DIFF
--- a/apps/explorer-e2e/src/support/pages/home-page.ts
+++ b/apps/explorer-e2e/src/support/pages/home-page.ts
@@ -49,7 +49,7 @@ export default class HomePage extends BasePage {
         cy.wrap($value).should('not.be.empty');
         if (index == 6) {
           // Total staked value
-          const totalStakedRegex = /^[0-9]*(\.[0-9]{0,2})?$/;
+          const totalStakedRegex = /^[0-9]+(\.[0-9]{0,2})?$/;
           cy.wrap($value).invoke('text').should('match', totalStakedRegex); // Check that value is number with 2dp
         }
       })


### PR DESCRIPTION
Small change to an existing test to check that total staked is now displayed as a number with 2 decimal precision. 

Closes: #267 