### PR TITLE
Disable SRI for stats

### DIFF
--- a/apps/stats/.fleek.json
+++ b/apps/stats/.fleek.json
@@ -9,7 +9,7 @@
   "build": {
     "baseDir": "",
     "publicDir": "dist/apps/stats/",
-    "command": "yarn && yarn nx run stats:build",
+    "command": "yarn && yarn nx run build:stats static",
     "rootDir": ""
   }
 }

--- a/apps/stats/project.json
+++ b/apps/stats/project.json
@@ -11,6 +11,7 @@
         "compiler": "babel",
         "outputPath": "dist/apps/stats",
         "index": "apps/stats/src/index.html",
+        "baseHref": "/",
         "main": "apps/stats/src/main.tsx",
         "polyfills": "apps/stats/src/polyfills.ts",
         "tsConfig": "apps/stats/tsconfig.app.json",
@@ -27,7 +28,6 @@
               "with": "apps/stats/src/environments/environment.prod.ts"
             }
           ],
-          "subresourceIntegrity": true,
           "optimization": true,
           "outputHashing": "all",
           "sourceMap": false,


### PR DESCRIPTION
Subresource Integrity breaks CSS for stats

Disabling the NX build option for SRI means the CSS loads correctly. We want SRI, but
having the stats page working is more important. This PR disables SRI. A followup ticket
will be created to work out what was wrong.

- Disable SRI in stats build
- Update fleek build command to match other projects


