### PR TITLE
chore(deps): update dependency pennant to v0.4.9

### DIFF
--- a/libs/candles-chart/src/lib/data-source.ts
+++ b/libs/candles-chart/src/lib/data-source.ts
@@ -1,7 +1,6 @@
 import type { ApolloClient } from '@apollo/client';
 import { gql } from '@apollo/client';
 import type { Candle, DataSource } from 'pennant';
-import { Interval } from 'pennant';
 
 import { addDecimal } from '@vegaprotocol/react-helpers';
 import type { Chart, ChartVariables } from './__generated__/Chart';
@@ -12,6 +11,7 @@ import type {
   CandlesSubVariables,
 } from './__generated__/CandlesSub';
 import type { Subscription } from 'zen-observable-ts';
+import { Interval } from '@vegaprotocol/types';
 
 export const CANDLE_FRAGMENT = gql`
   fragment CandleFields on Candle {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "immer": "^9.0.12",
     "lodash": "^4.17.21",
     "next": "^12.0.7",
-    "pennant": "0.4.7",
+    "pennant": "0.4.9",
     "postcss": "^8.4.6",
     "react": "17.0.2",
     "react-copy-to-clipboard": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16351,10 +16351,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-pennant@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.7.tgz#b1541f57d563c8a14f026292f6f88c059938f31a"
-  integrity sha512-HKpQS9wUMdH7aqdiOTwWwXAd2GhxKT1RF//f9utYhTuWFK5dK44EvWiaOTol+ddpN30GStK4KxO8s2OkeYLvPw==
+pennant@0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.9.tgz#2466d6d41deff85558a0f065b81c178046d39bca"
+  integrity sha512-WPPrBfS5ND59KHJVz8PXmZ480wnkpoAKAG7HGA56/vKilUritbQetFoVlzh1SgohaFnRwQVywCPQ8ohsHyzutQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@d3fc/d3fc-technical-indicator" "^8.0.1"


### PR DESCRIPTION
# Related issues 🔗

Closes #391.

# Description ℹ️

Fix size bug in depth chart in Safari.

# Technical 👨‍🔧

This includes a bug fix for the depth chart component not resizing to fill its container in browsers that do not support the `device-pixel-content-box` resize observer option, i.e. Safari.

It also cleans up the console logs to no longer give information about registering web components. In particular, this was cluttering up the NextJS build output.
