### PR TITLE
Feat/callout icon

### DIFF
--- a/libs/ui-toolkit/src/components/callout/callout.stories.tsx
+++ b/libs/ui-toolkit/src/components/callout/callout.stories.tsx
@@ -74,3 +74,18 @@ IconAndContent.args = {
     </div>
   ),
 };
+
+export const CustomIconAndContent = Template.bind({});
+CustomIconAndContent.args = {
+  intent: Intent.Help,
+  title: 'This is what this thing does',
+  icon: <span>✔️</span>,
+  children: (
+    <div className="flex flex-col">
+      <div>With a longer explaination</div>
+      <Button className="block mt-8" variant="secondary">
+        Action
+      </Button>
+    </div>
+  ),
+};

--- a/libs/ui-toolkit/src/components/callout/callout.tsx
+++ b/libs/ui-toolkit/src/components/callout/callout.tsx
@@ -1,23 +1,62 @@
+import type { ReactNode } from 'react';
 import classNames from 'classnames';
 import { getIntentShadow, Intent } from '../../utils/intent';
 import type { IconName } from '../icon';
 import { Icon } from '../icon';
 
-export interface CalloutProps {
+interface CalloutRootProps {
   children?: React.ReactNode;
   title?: React.ReactElement | string;
   intent?: Intent;
-  iconName?: IconName;
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
-export function Callout({
-  children,
-  title,
-  intent = Intent.Help,
-  iconName,
-  headingLevel,
-}: CalloutProps) {
+interface CalloutWithoutIcon extends CalloutRootProps {
+  iconName?: never;
+  icon?: never;
+}
+
+interface CalloutPropsWithIconName extends CalloutRootProps {
+  children?: React.ReactNode;
+  title?: React.ReactElement | string;
+  intent?: Intent;
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  iconName: IconName;
+  icon?: never;
+}
+
+interface CalloutPropsWithIcon extends CalloutRootProps {
+  children?: React.ReactNode;
+  title?: React.ReactElement | string;
+  intent?: Intent;
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  iconName?: never;
+  icon: ReactNode;
+}
+
+type CalloutProps =
+  | CalloutWithoutIcon
+  | CalloutPropsWithIconName
+  | CalloutPropsWithIcon;
+
+const getIconElement = (props: CalloutProps) => {
+  if (props.iconName) {
+    return (
+      <Icon
+        name={props.iconName}
+        className="fill-current ml-8 mr-16 mt-8"
+        size={20}
+      />
+    );
+  }
+  return props.icon;
+};
+
+export function Callout(props: CalloutProps) {
+  const { children, title, intent = Intent.Help, headingLevel } = props;
+
+  const icon = getIconElement(props);
+
   const className = classNames(
     'border',
     'border-black',
@@ -27,15 +66,12 @@ export function Callout({
     'p-16',
     getIntentShadow(intent),
     {
-      flex: !!iconName,
+      flex: !!icon,
     }
   );
   const TitleTag: keyof JSX.IntrinsicElements = headingLevel
     ? `h${headingLevel}`
     : 'div';
-  const icon = iconName && (
-    <Icon name={iconName} className="fill-current ml-8 mr-16 mt-8" size={20} />
-  );
   const body = (
     <>
       {title && <TitleTag className="text-h5 mt-0 mb-8">{title}</TitleTag>}


### PR DESCRIPTION
# Related issues 🔗

Closes [#274](https://github.com/vegaprotocol/frontend-monorepo/issues/274)

# Description ℹ️

Adds an icon prop to the callout component.

# Technical

New prop called `icon` as a react node. The callout now takes either an optional `icon` or an optional `iconName`, and renders either the passed in element, or an Icon component with the passed in name.

<img width="329" alt="Screen Shot 2022-05-09 at 7 23 51 PM" src="https://user-images.githubusercontent.com/105208209/167463932-39c0dd68-5311-4477-b281-db861da7bc1f.png">
