### PR TITLE
Fix/Use the rationale field on Proposals

### DIFF
--- a/apps/token/src/lib/type-policies/proposal.spec.tsx
+++ b/apps/token/src/lib/type-policies/proposal.spec.tsx
@@ -1,25 +1,40 @@
+import { generateProposal } from '../../routes/governance/test-helpers/generate-proposals';
 import { getProposalName } from './proposal';
+
+const proposal = generateProposal();
 
 it('New market', () => {
   const name = getProposalName({
-    __typename: 'NewMarket',
-    decimalPlaces: 1,
-    instrument: {
-      __typename: 'InstrumentConfiguration',
-      name: 'Some market',
+    ...proposal,
+    terms: {
+      ...proposal.terms,
+      change: {
+        __typename: 'NewMarket',
+        decimalPlaces: 1,
+        instrument: {
+          __typename: 'InstrumentConfiguration',
+          name: 'Some market',
+        },
+        metadata: [],
+      },
     },
-    metadata: [],
   });
   expect(name).toEqual('New Market: Some market');
 });
 
 it('New asset', () => {
   const name = getProposalName({
-    __typename: 'NewAsset',
-    symbol: 'FAKE',
-    source: {
-      __typename: 'ERC20',
-      contractAddress: '0x0',
+    ...proposal,
+    terms: {
+      ...proposal.terms,
+      change: {
+        __typename: 'NewAsset',
+        symbol: 'FAKE',
+        source: {
+          __typename: 'ERC20',
+          contractAddress: '0x0',
+        },
+      },
     },
   });
   expect(name).toEqual('New Asset: FAKE');
@@ -27,19 +42,31 @@ it('New asset', () => {
 
 it('Update market', () => {
   const name = getProposalName({
-    __typename: 'UpdateMarket',
-    marketId: 'MarketId',
+    ...proposal,
+    terms: {
+      ...proposal.terms,
+      change: {
+        __typename: 'UpdateMarket',
+        marketId: 'MarketId',
+      },
+    },
   });
   expect(name).toEqual('Update Market: MarketId');
 });
 
 it('Update network', () => {
   const name = getProposalName({
-    __typename: 'UpdateNetworkParameter',
-    networkParameter: {
-      __typename: 'NetworkParameter',
-      key: 'key',
-      value: 'value',
+    ...proposal,
+    terms: {
+      ...proposal.terms,
+      change: {
+        __typename: 'UpdateNetworkParameter',
+        networkParameter: {
+          __typename: 'NetworkParameter',
+          key: 'key',
+          value: 'value',
+        },
+      },
     },
   });
   expect(name).toEqual('Update Network: key');
@@ -47,18 +74,31 @@ it('Update network', () => {
 
 it('Freeform network', () => {
   const name = getProposalName({
-    __typename: 'NewFreeform',
-    hash: '0x0',
-    url: 'Earl',
-    description: 'Something else',
+    ...proposal,
+    rationale: {
+      ...proposal.rationale,
+      hash: '0x0',
+    },
+    terms: {
+      ...proposal.terms,
+      change: {
+        __typename: 'NewFreeform',
+      },
+    },
   });
   expect(name).toEqual('Freeform: 0x0');
 });
 
 it("Renders unknown proposal if it's a different proposal type", () => {
   const name = getProposalName({
-    // @ts-ignore unknown proposal
-    __typename: 'Foo',
+    ...proposal,
+    terms: {
+      ...proposal.terms,
+      change: {
+        // @ts-ignore unknown proposal
+        __typename: 'Foo',
+      },
+    },
   });
   expect(name).toEqual('Unknown Proposal');
 });

--- a/apps/token/src/lib/type-policies/proposal.ts
+++ b/apps/token/src/lib/type-policies/proposal.ts
@@ -1,6 +1,8 @@
-import type { Proposals_proposals_terms_change } from '../../routes/governance/proposals/__generated__/Proposals';
+import type { Proposals_proposals } from '../../routes/governance/proposals/__generated__/Proposals';
 
-export function getProposalName(change: Proposals_proposals_terms_change) {
+export function getProposalName(proposal: Proposals_proposals) {
+  const { change } = proposal.terms;
+
   if (change.__typename === 'NewAsset') {
     return `New Asset: ${change.symbol}`;
   } else if (change.__typename === 'NewMarket') {
@@ -10,7 +12,7 @@ export function getProposalName(change: Proposals_proposals_terms_change) {
   } else if (change.__typename === 'UpdateNetworkParameter') {
     return `Update Network: ${change.networkParameter.key}`;
   } else if (change.__typename === 'NewFreeform') {
-    return `Freeform: ${change.hash}`;
+    return `Freeform: ${proposal.rationale.hash}`;
   }
 
   return 'Unknown Proposal';

--- a/apps/token/src/routes/governance/__generated__/ProposalFields.ts
+++ b/apps/token/src/routes/governance/__generated__/ProposalFields.ts
@@ -9,12 +9,39 @@ import { ProposalState, ProposalRejectionReason, VoteValue } from "@vegaprotocol
 // GraphQL fragment: ProposalFields
 // ====================================================
 
+export interface ProposalFields_rationale {
+  __typename: "ProposalRationale";
+  /**
+   * Link to a text file describing the proposal in depth.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  url: string | null;
+  /**
+   * Description to show a short title / something in case the link goes offline.
+   * This is to be between 0 and 1024 unicode characters.
+   * This is mandatory for all proposal.
+   */
+  description: string;
+  /**
+   * Cryptographically secure hash (SHA3-512) of the text pointed by the `url` property
+   * so that viewers can check that the text hasn't been changed over time.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  hash: string | null;
+}
+
 export interface ProposalFields_party {
   __typename: "Party";
   /**
    * Party identifier
    */
   id: string;
+}
+
+export interface ProposalFields_terms_change_NewFreeform {
+  __typename: "NewFreeform";
 }
 
 export interface ProposalFields_terms_change_NewMarket_instrument {
@@ -93,23 +120,7 @@ export interface ProposalFields_terms_change_UpdateNetworkParameter {
   networkParameter: ProposalFields_terms_change_UpdateNetworkParameter_networkParameter;
 }
 
-export interface ProposalFields_terms_change_NewFreeform {
-  __typename: "NewFreeform";
-  /**
-   * The URL containing content that describes the proposal
-   */
-  url: string;
-  /**
-   * A short description of what is being proposed
-   */
-  description: string;
-  /**
-   * The hash on the content of the URL
-   */
-  hash: string;
-}
-
-export type ProposalFields_terms_change = ProposalFields_terms_change_NewMarket | ProposalFields_terms_change_UpdateMarket | ProposalFields_terms_change_NewAsset | ProposalFields_terms_change_UpdateNetworkParameter | ProposalFields_terms_change_NewFreeform;
+export type ProposalFields_terms_change = ProposalFields_terms_change_NewFreeform | ProposalFields_terms_change_NewMarket | ProposalFields_terms_change_UpdateMarket | ProposalFields_terms_change_NewAsset | ProposalFields_terms_change_UpdateNetworkParameter;
 
 export interface ProposalFields_terms {
   __typename: "ProposalTerms";
@@ -271,6 +282,10 @@ export interface ProposalFields {
    * Error details of the rejectionReason
    */
   errorDetails: string | null;
+  /**
+   * Rationale behind the proposal
+   */
+  rationale: ProposalFields_rationale;
   /**
    * Party that prepared the proposal
    */

--- a/apps/token/src/routes/governance/components/proposal/proposal.tsx
+++ b/apps/token/src/routes/governance/components/proposal/proposal.tsx
@@ -19,7 +19,7 @@ export const Proposal = ({ proposal, terms }: ProposalProps) => {
 
   return (
     <>
-      <Heading title={getProposalName(proposal.terms.change)} />
+      <Heading title={getProposalName(proposal)} />
       <ProposalChangeTable proposal={proposal} />
       <VoteDetails proposal={proposal} />
       <ProposalVotesTable proposal={proposal} />

--- a/apps/token/src/routes/governance/components/proposals-list/proposals-list.tsx
+++ b/apps/token/src/routes/governance/components/proposals-list/proposals-list.tsx
@@ -26,7 +26,7 @@ export const ProposalsList = ({ proposals }: ProposalsListProps) => {
     return (
       <li className="last:mb-0 mb-24" key={proposal.id}>
         <Link to={proposal.id} className="underline">
-          <header>{getProposalName(proposal.terms.change)}</header>
+          <header>{getProposalName(proposal)}</header>
         </Link>
         <KeyValueTable muted={true}>
           <KeyValueTableRow>

--- a/apps/token/src/routes/governance/proposal-fragment.ts
+++ b/apps/token/src/routes/governance/proposal-fragment.ts
@@ -8,6 +8,11 @@ export const PROPOSALS_FRAGMENT = gql`
     datetime
     rejectionReason
     errorDetails
+    rationale {
+      url
+      description
+      hash
+    }
     party {
       id
     }
@@ -42,11 +47,6 @@ export const PROPOSALS_FRAGMENT = gql`
             key
             value
           }
-        }
-        ... on NewFreeform {
-          url
-          description
-          hash
         }
       }
     }

--- a/apps/token/src/routes/governance/proposal/__generated__/Proposal.ts
+++ b/apps/token/src/routes/governance/proposal/__generated__/Proposal.ts
@@ -9,12 +9,39 @@ import { ProposalState, ProposalRejectionReason, VoteValue } from "@vegaprotocol
 // GraphQL query operation: Proposal
 // ====================================================
 
+export interface Proposal_proposal_rationale {
+  __typename: "ProposalRationale";
+  /**
+   * Link to a text file describing the proposal in depth.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  url: string | null;
+  /**
+   * Description to show a short title / something in case the link goes offline.
+   * This is to be between 0 and 1024 unicode characters.
+   * This is mandatory for all proposal.
+   */
+  description: string;
+  /**
+   * Cryptographically secure hash (SHA3-512) of the text pointed by the `url` property
+   * so that viewers can check that the text hasn't been changed over time.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  hash: string | null;
+}
+
 export interface Proposal_proposal_party {
   __typename: "Party";
   /**
    * Party identifier
    */
   id: string;
+}
+
+export interface Proposal_proposal_terms_change_NewFreeform {
+  __typename: "NewFreeform";
 }
 
 export interface Proposal_proposal_terms_change_NewMarket_instrument {
@@ -93,23 +120,7 @@ export interface Proposal_proposal_terms_change_UpdateNetworkParameter {
   networkParameter: Proposal_proposal_terms_change_UpdateNetworkParameter_networkParameter;
 }
 
-export interface Proposal_proposal_terms_change_NewFreeform {
-  __typename: "NewFreeform";
-  /**
-   * The URL containing content that describes the proposal
-   */
-  url: string;
-  /**
-   * A short description of what is being proposed
-   */
-  description: string;
-  /**
-   * The hash on the content of the URL
-   */
-  hash: string;
-}
-
-export type Proposal_proposal_terms_change = Proposal_proposal_terms_change_NewMarket | Proposal_proposal_terms_change_UpdateMarket | Proposal_proposal_terms_change_NewAsset | Proposal_proposal_terms_change_UpdateNetworkParameter | Proposal_proposal_terms_change_NewFreeform;
+export type Proposal_proposal_terms_change = Proposal_proposal_terms_change_NewFreeform | Proposal_proposal_terms_change_NewMarket | Proposal_proposal_terms_change_UpdateMarket | Proposal_proposal_terms_change_NewAsset | Proposal_proposal_terms_change_UpdateNetworkParameter;
 
 export interface Proposal_proposal_terms {
   __typename: "ProposalTerms";
@@ -271,6 +282,10 @@ export interface Proposal_proposal {
    * Error details of the rejectionReason
    */
   errorDetails: string | null;
+  /**
+   * Rationale behind the proposal
+   */
+  rationale: Proposal_proposal_rationale;
   /**
    * Party that prepared the proposal
    */

--- a/apps/token/src/routes/governance/proposals/__generated__/Proposals.ts
+++ b/apps/token/src/routes/governance/proposals/__generated__/Proposals.ts
@@ -9,12 +9,39 @@ import { ProposalState, ProposalRejectionReason, VoteValue } from "@vegaprotocol
 // GraphQL query operation: Proposals
 // ====================================================
 
+export interface Proposals_proposals_rationale {
+  __typename: "ProposalRationale";
+  /**
+   * Link to a text file describing the proposal in depth.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  url: string | null;
+  /**
+   * Description to show a short title / something in case the link goes offline.
+   * This is to be between 0 and 1024 unicode characters.
+   * This is mandatory for all proposal.
+   */
+  description: string;
+  /**
+   * Cryptographically secure hash (SHA3-512) of the text pointed by the `url` property
+   * so that viewers can check that the text hasn't been changed over time.
+   * Optional except for FreeFrom proposal where it's mandatory.
+   * If set, the `url` property must be set.
+   */
+  hash: string | null;
+}
+
 export interface Proposals_proposals_party {
   __typename: "Party";
   /**
    * Party identifier
    */
   id: string;
+}
+
+export interface Proposals_proposals_terms_change_NewFreeform {
+  __typename: "NewFreeform";
 }
 
 export interface Proposals_proposals_terms_change_NewMarket_instrument {
@@ -93,23 +120,7 @@ export interface Proposals_proposals_terms_change_UpdateNetworkParameter {
   networkParameter: Proposals_proposals_terms_change_UpdateNetworkParameter_networkParameter;
 }
 
-export interface Proposals_proposals_terms_change_NewFreeform {
-  __typename: "NewFreeform";
-  /**
-   * The URL containing content that describes the proposal
-   */
-  url: string;
-  /**
-   * A short description of what is being proposed
-   */
-  description: string;
-  /**
-   * The hash on the content of the URL
-   */
-  hash: string;
-}
-
-export type Proposals_proposals_terms_change = Proposals_proposals_terms_change_NewMarket | Proposals_proposals_terms_change_UpdateMarket | Proposals_proposals_terms_change_NewAsset | Proposals_proposals_terms_change_UpdateNetworkParameter | Proposals_proposals_terms_change_NewFreeform;
+export type Proposals_proposals_terms_change = Proposals_proposals_terms_change_NewFreeform | Proposals_proposals_terms_change_NewMarket | Proposals_proposals_terms_change_UpdateMarket | Proposals_proposals_terms_change_NewAsset | Proposals_proposals_terms_change_UpdateNetworkParameter;
 
 export interface Proposals_proposals_terms {
   __typename: "ProposalTerms";
@@ -271,6 +282,10 @@ export interface Proposals_proposals {
    * Error details of the rejectionReason
    */
   errorDetails: string | null;
+  /**
+   * Rationale behind the proposal
+   */
+  rationale: Proposals_proposals_rationale;
   /**
    * Party that prepared the proposal
    */

--- a/apps/token/src/routes/governance/test-helpers/generate-proposals.ts
+++ b/apps/token/src/routes/governance/test-helpers/generate-proposals.ts
@@ -24,6 +24,12 @@ export function generateProposal(
       __typename: 'Party',
       id: faker.datatype.uuid(),
     },
+    rationale: {
+      __typename: 'ProposalRationale',
+      hash: faker.datatype.uuid(),
+      url: faker.internet.url(),
+      description: faker.lorem.words(),
+    },
     terms: {
       __typename: 'ProposalTerms',
       closingDatetime:

--- a/apps/token/src/routes/rewards/home/__generated__/Rewards.ts
+++ b/apps/token/src/routes/rewards/home/__generated__/Rewards.ts
@@ -46,7 +46,7 @@ export interface Rewards_party_rewardDetails_rewards_epoch {
 export interface Rewards_party_rewardDetails_rewards {
   __typename: "Reward";
   /**
-   * The asset for which this reward is associated
+   * The asset this reward is paid in
    */
   asset: Rewards_party_rewardDetails_rewards_asset;
   /**


### PR DESCRIPTION
# Related issues 🔗

Closes #[405](https://github.com/vegaprotocol/frontend-monorepo/issues/405)

# Description ℹ️

Change freeform params to use the rationale field from Proposals.

# Demo 📺

on STAGNET2:
<img width="1280" alt="Screen Shot 2022-05-17 at 10 16 33 AM" src="https://user-images.githubusercontent.com/105208209/168776769-5f90998e-11fe-4f71-9c50-5283851b658e.png">

<img width="1247" alt="Screen Shot 2022-05-17 at 10 28 55 AM" src="https://user-images.githubusercontent.com/105208209/168778976-58b35021-13d5-4bce-af6c-2f06d95656f5.png">

# Technical 👨‍🔧

- following the same as in https://github.com/vegaprotocol/token-frontend/pull/1290
