### PR TITLE
test: update test for network parameters table (#300)

### DIFF
--- a/apps/explorer-e2e/src/integration/network-page.feature
+++ b/apps/explorer-e2e/src/integration/network-page.feature
@@ -9,15 +9,3 @@ Feature: Network parameters Page
     Given I am on mobile and open the toggle menu
     When I navigate to network parameters page
     Then network parameters page is correctly displayed
-
-  Scenario: Navigate to network parameters page and check each value is non-empty
-    Given I am on the homepage
-    When I navigate to network parameters page
-    Then network parameters page is correctly displayed
-    And each value is non-empty
-
-  Scenario: Navigate to network parameters page and check each value using mobile
-    Given I am on mobile and open the toggle menu
-    When I navigate to network parameters page
-    Then network parameters page is correctly displayed
-    And each value is non-empty

--- a/apps/explorer-e2e/src/support/pages/network-page.ts
+++ b/apps/explorer-e2e/src/support/pages/network-page.ts
@@ -3,35 +3,37 @@ import BasePage from './base-page';
 export default class NetworkParametersPage extends BasePage {
   networkParametersHeader = 'network-param-header';
   parameters = 'parameters';
-  jsonParamNameClassName = '.hljs-attr'
-  jsonParamValueStringClassName = '.hljs-string'
-  jsonParamValueNumberClassName = '.hljs-number'
-  parameterKeyValueRow = 'key-value-table-row'
+  jsonParamNameClassName = '.hljs-attr';
+  jsonParamValueStringClassName = '.hljs-string';
+  jsonParamValueNumberClassName = '.hljs-number';
+  parameterKeyValueRow = 'key-value-table-row';
 
   verifyNetworkParametersDisplayed() {
-    cy.getByTestId(this.networkParametersHeader).should('have.text', 'Network Parameters')
+    cy.getByTestId(this.networkParametersHeader).should(
+      'have.text',
+      'Network Parameters'
+    );
 
     cy.get(this.jsonParamNameClassName)
       .should('have.length.at.least', 21)
       .each(($paramName) => {
-        cy.wrap($paramName).should('not.be.empty')
-      })
+        cy.wrap($paramName).should('not.be.empty');
+      });
     cy.get(this.jsonParamValueStringClassName)
       .should('have.length.at.least', 7)
       .each(($paramValue) => {
-        cy.wrap($paramValue).should('not.be.empty')
-      })
+        cy.wrap($paramValue).should('not.be.empty');
+      });
 
-      cy.get(this.jsonParamValueNumberClassName)
+    cy.get(this.jsonParamValueNumberClassName)
       .should('have.length.at.least', 9)
       .each(($paramValue) => {
-        cy.wrap($paramValue).should('not.be.empty')
-      })
+        cy.wrap($paramValue).should('not.be.empty');
+      });
 
-    cy.getByTestId(this.parameterKeyValueRow)
-      .each(($row) => {
-        cy.wrap($row).find('dt').should('not.be.empty')
-        cy.wrap($row).find('dd').should('not.be.empty')
-      })
+    cy.getByTestId(this.parameterKeyValueRow).each(($row) => {
+      cy.wrap($row).find('dt').should('not.be.empty');
+      cy.wrap($row).find('dd').should('not.be.empty');
+    });
   }
 }

--- a/apps/explorer-e2e/src/support/pages/network-page.ts
+++ b/apps/explorer-e2e/src/support/pages/network-page.ts
@@ -3,20 +3,35 @@ import BasePage from './base-page';
 export default class NetworkParametersPage extends BasePage {
   networkParametersHeader = 'network-param-header';
   parameters = 'parameters';
+  jsonParamNameClassName = '.hljs-attr'
+  jsonParamValueStringClassName = '.hljs-string'
+  jsonParamValueNumberClassName = '.hljs-number'
+  parameterKeyValueRow = 'key-value-table-row'
 
   verifyNetworkParametersDisplayed() {
-    cy.getByTestId(this.networkParametersHeader).should(
-      'have.text',
-      'Network Parameters'
-    );
-    cy.getByTestId(this.parameters).should('not.be.empty');
-  }
+    cy.getByTestId(this.networkParametersHeader).should('have.text', 'Network Parameters')
 
-  eachValueIsNonEmpty() {
-    cy.getByTestId(this.parameters).then(($parameters) => {
-      $parameters.each((_index, element) => {
-        cy.wrap(element).should('not.be.empty');
-      });
-    });
+    cy.get(this.jsonParamNameClassName)
+      .should('have.length.at.least', 21)
+      .each(($paramName) => {
+        cy.wrap($paramName).should('not.be.empty')
+      })
+    cy.get(this.jsonParamValueStringClassName)
+      .should('have.length.at.least', 7)
+      .each(($paramValue) => {
+        cy.wrap($paramValue).should('not.be.empty')
+      })
+
+      cy.get(this.jsonParamValueNumberClassName)
+      .should('have.length.at.least', 9)
+      .each(($paramValue) => {
+        cy.wrap($paramValue).should('not.be.empty')
+      })
+
+    cy.getByTestId(this.parameterKeyValueRow)
+      .each(($row) => {
+        cy.wrap($row).find('dt').should('not.be.empty')
+        cy.wrap($row).find('dd').should('not.be.empty')
+      })
   }
 }

--- a/apps/explorer-e2e/src/support/step_definitions/network-page.step.ts
+++ b/apps/explorer-e2e/src/support/step_definitions/network-page.step.ts
@@ -9,7 +9,3 @@ When('I navigate to network parameters page', () => {
 Then('network parameters page is correctly displayed', () => {
   networkPage.verifyNetworkParametersDisplayed();
 });
-
-Then('each value is non-empty', () => {
-  networkPage.eachValueIsNonEmpty();
-});


### PR DESCRIPTION
# Related issues 🔗

Closes #300

# Description ℹ️

Small update to existing Cypress test for network parameters table to check that every field is displayed and not empty

Deleted some tests that were basically doing the same thing as existing test
