### PR TITLE
Fix/flakey cypress test runs

### DIFF
--- a/apps/trading-e2e/src/integration/markets-page.feature
+++ b/apps/trading-e2e/src/integration/markets-page.feature
@@ -8,10 +8,12 @@ Feature: Markets page
 
   Scenario: Select active market
     Given I am on the markets page
+    And I can view markets
     When I click on "Active" mocked market
     Then trading page for "active" market is displayed
 
   Scenario: Select suspended market
     Given I am on the markets page
+    And I can view markets
     When I click on "Suspended" mocked market
     Then trading page for "suspended" market is displayed

--- a/apps/trading-e2e/src/support/pages/markets-page.ts
+++ b/apps/trading-e2e/src/support/pages/markets-page.ts
@@ -24,6 +24,10 @@ export default class MarketPage extends BasePage {
       'Description',
     ];
 
+    // We need this to ensure that ag-grid is fully rendered before asserting
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100);
+
     cy.get(this.marketRowHeaderClassname)
       .each(($marketHeader, index) => {
         cy.wrap($marketHeader).should(

--- a/apps/trading-e2e/src/support/pages/markets-page.ts
+++ b/apps/trading-e2e/src/support/pages/markets-page.ts
@@ -10,6 +10,9 @@ export default class MarketPage extends BasePage {
   marketStateColId = 'data';
 
   validateMarketsAreDisplayed() {
+    // We need this to ensure that ag-grid is fully rendered before asserting
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000);
     cy.get('.ag-root-wrapper').should('be.visible');
   }
 
@@ -23,10 +26,6 @@ export default class MarketPage extends BasePage {
       'Mark price',
       'Description',
     ];
-
-    // We need this to ensure that ag-grid is fully rendered before asserting
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(100);
 
     cy.get(this.marketRowHeaderClassname)
       .each(($marketHeader, index) => {

--- a/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/markets-page.step.ts
@@ -6,6 +6,7 @@ import MarketsPage from '../pages/markets-page';
 const marketsPage = new MarketsPage();
 
 const mockMarkets = () => {
+  cy.log('Mocking markets query');
   cy.mockGQL('Markets', (req) => {
     if (hasOperationName(req, 'Markets')) {
       req.reply({
@@ -15,21 +16,19 @@ const mockMarkets = () => {
   });
 };
 
-beforeEach(() => {
-  mockMarkets();
-});
-
 Then('I navigate to markets page', () => {
+  mockMarkets();
   marketsPage.navigateToMarkets();
+  cy.wait('@Markets');
 });
 
 Given('I am on the markets page', () => {
+  mockMarkets();
   cy.visit('/markets');
   cy.wait('@Markets');
 });
 
 Then('I can view markets', () => {
-  cy.wait('@Markets');
   marketsPage.validateMarketsAreDisplayed();
 });
 


### PR DESCRIPTION
# Description ℹ️

Adds a wait for markets page tests which allows time for ag grids to render before making assertions

# Technical 👨‍🔧

This isn't the best solution, but I think good enough for now to get green builds
