### PR TITLE
fix: correct decimal places in network params table

### DIFF
--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -48,7 +48,7 @@ export const renderRow = ({
       ) : isNaN(Number(value)) ? (
         value
       ) : BIG_NUMBER_PARAMS.includes(key) ? (
-        addDecimalsFormatNumber(Number(value), 4)
+        addDecimalsFormatNumber(Number(value), 18)
       ) : (
         formatNumber(Number(value), 4)
       )}


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Number of decimals for numbers that are in Vega tokens is incorrect in network parameters

# Demo 📺

![Screenshot 2022-05-17 at 13 38 19](https://user-images.githubusercontent.com/26136207/168812609-b6a5e182-cae7-4f1e-853e-7cc8bacd717f.png)

# Technical 👨‍🔧

N/A
