### PR TITLE
fix/415 Explorer syntax highlighter text colour broken

### DIFF
--- a/libs/tailwindcss-config/src/vega-custom-classes.js
+++ b/libs/tailwindcss-config/src/vega-custom-classes.js
@@ -18,7 +18,7 @@ const vegaCustomClasses = plugin(function ({ addUtilities }) {
     },
     '.dark .syntax-highlighter-wrapper .hljs': {
       background: '#2C2C2C',
-      color: theme.colors.vega.green.DEFAULT,
+      color: theme.colors.vega.green,
     },
     '.syntax-highlighter-wrapper .hljs-literal': {
       color: theme.colors.vega.pink,


### PR DESCRIPTION
Closes #415 

# Description ℹ️

Block Explorer syntax highlighter previously had a green text colour when using the dark theme. The vega colours in theme.js had a name change and this component was refactored incorrectly.

# Demo 📺

Before fix:

<img width="489" alt="Screenshot 2022-05-17 at 13 57 32" src="https://user-images.githubusercontent.com/2410498/168816170-c2c05453-6ac8-42e3-98a9-8e8274c48afa.png">

After fix:

<img width="506" alt="Screenshot 2022-05-17 at 13 57 43" src="https://user-images.githubusercontent.com/2410498/168816221-12f142dc-358d-4af7-b2b1-77265b8613cc.png">
