### PR TITLE
chore: use seperate cypress project id for trading app

### DIFF
--- a/apps/trading-e2e/cypress.json
+++ b/apps/trading-e2e/cypress.json
@@ -12,7 +12,7 @@
   "videosFolder": "../../dist/cypress/apps/trading-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/trading-e2e/screenshots",
   "chromeWebSecurity": false,
-  "projectId": "et4snf",
+  "projectId": "2gcsov",
 
   "env": {
     "ethereumProviderUrl": "https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8",


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Updates the trading-e2e cypress project id to point to a separate project

# Demo 📺

N/A

# Technical 👨‍🔧

N/A
