### PR TITLE
test: increase timeout for token test

### DIFF
--- a/apps/token-e2e/src/integration/app.test.ts
+++ b/apps/token-e2e/src/integration/app.test.ts
@@ -4,7 +4,7 @@ describe('token', () => {
   beforeEach(() => cy.visit('/'));
 
   it('should always have a header title based on environment', () => {
-    cy.get('[data-testid="header-title"]').should(
+    cy.get('[data-testid="header-title"]', {timeout: 8000}).should(
       'have.text',
       `${fairgroundSet ? 'Fairground token' : '$VEGA TOKEN'}`
     );

--- a/apps/token-e2e/src/integration/app.test.ts
+++ b/apps/token-e2e/src/integration/app.test.ts
@@ -4,7 +4,7 @@ describe('token', () => {
   beforeEach(() => cy.visit('/'));
 
   it('should always have a header title based on environment', () => {
-    cy.get('[data-testid="header-title"]', {timeout: 8000}).should(
+    cy.get('[data-testid="header-title"]', { timeout: 8000 }).should(
       'have.text',
       `${fairgroundSet ? 'Fairground token' : '$VEGA TOKEN'}`
     );


### PR DESCRIPTION
# Description ℹ️

There is a failing test for token app where the test times out before the page is finished loading. The long load times are not reproducible locally. Timeout is increased to give the page more time to load in CI. 
