### PR TITLE
chore: update readme and allow env file for local variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Thumbs.db
 
 .local.env
 .env.local
+cypress.env.json

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Run `yarn nx run <my-app>-e2e:e2e` to execute the e2e tests with [cypress](https
 
 Run `nx test my-app` to execute the unit tests with [Jest](https://jestjs.io), or `nx affected:test` to execute just unit tests affected by a change. You can also use `--watch` with these test to run jest in watch mode, see [Jest executor](https://nx.dev/packages/jest/executors/jest) for all CLI flags.
 
+#### Note: below only needed for trading-e2e
+
+To run tests locally using your own wallets you can add the following environment variables to `Cypress.json`
+
+1. Change `tradingTestVegaWalletName` to your Vega wallet name
+2. Add `TRADING_TEST_VEGA_WALLET_PASSPHRASE` as your wallet passphrase
+3. Add `ETH_WALLET_MNEMONIC` as your Ethereum wallet mnemonic
+
 ### Formatting
 
 In CI linting, formatting and also run. These checks can be seen in the [CI workflow file](.github/workflows//test.yml).

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Run `yarn nx run <my-app>-e2e:e2e` to execute the e2e tests with [cypress](https
 
 Run `nx test my-app` to execute the unit tests with [Jest](https://jestjs.io), or `nx affected:test` to execute just unit tests affected by a change. You can also use `--watch` with these test to run jest in watch mode, see [Jest executor](https://nx.dev/packages/jest/executors/jest) for all CLI flags.
 
-#### Note: below only needed for trading-e2e
+#### Trading app E2E tests
 
-To run tests locally using your own wallets you can add the following environment variables to `Cypress.json`
+To run tests locally using your own wallets you can add the following environment variables to `cypress.json`
 
-1. Change `tradingTestVegaWalletName` to your Vega wallet name
+1. Change `TRADING_TEST_VEGA_WALLET_NAME` to your Vega wallet name
 2. Add `TRADING_TEST_VEGA_WALLET_PASSPHRASE` as your wallet passphrase
 3. Add `ETH_WALLET_MNEMONIC` as your Ethereum wallet mnemonic
 

--- a/apps/trading-e2e/cypress.json
+++ b/apps/trading-e2e/cypress.json
@@ -26,6 +26,7 @@
     "depositAsset": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
     "tsConfig": "tsconfig.json",
     "TAGS": "not @todo and not @ignore and not @manual",
-    "tBtcContract": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
+    "tBtcContract": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
+    "tradingTestVegaWalletName": "UI_Trading_Test"
   }
 }

--- a/apps/trading-e2e/cypress.json
+++ b/apps/trading-e2e/cypress.json
@@ -23,7 +23,7 @@
     "VEGA_PUBLIC_KEY2": "1a18cdcaaa4f44a57b35a4e9b77e0701c17a476f2b407620f8c17371740cf2e4",
     "TRUNCATED_VEGA_PUBLIC_KEY": "47836c…c7d278",
     "TRUNCATED_VEGA_PUBLIC_KEY2": "1a18cd…0cf2e4",
-    "TBTC_CONTRACT": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
+    "INVALID_DEPOSIT_TO_ADDRESS": "zzz85edfa7ffdb6ed996ca912e9258998e47bf3515c885cf3c63fb56b15de36f",
     "tsConfig": "tsconfig.json",
     "TAGS": "not @todo and not @ignore and not @manual"
   }

--- a/apps/trading-e2e/cypress.json
+++ b/apps/trading-e2e/cypress.json
@@ -16,17 +16,15 @@
   "defaultCommandTimeout": 10000,
 
   "env": {
-    "ethereumProviderUrl": "https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8",
-    "ethereumChainId": 3,
-    "invalidDepositToAddress": "zzz85edfa7ffdb6ed996ca912e9258998e47bf3515c885cf3c63fb56b15de36f",
-    "vegaPublicKey": "47836c253520d2661bf5bed6339c0de08fd02cf5d4db0efee3b4373f20c7d278",
-    "vegaPublicKey2": "1a18cdcaaa4f44a57b35a4e9b77e0701c17a476f2b407620f8c17371740cf2e4",
-    "truncatedVegaPubKey": "47836c…c7d278",
-    "truncatedVegaPubKey2": "1a18cd…0cf2e4",
-    "depositAsset": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
+    "TRADING_TEST_VEGA_WALLET_NAME": "UI_Trading_Test",
+    "ETHEREUM_PROVIDER_URL": "https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8",
+    "ETHEREUM_CHAIN_ID": 3,
+    "VEGA_PUBLIC_KEY": "47836c253520d2661bf5bed6339c0de08fd02cf5d4db0efee3b4373f20c7d278",
+    "VEGA_PUBLIC_KEY2": "1a18cdcaaa4f44a57b35a4e9b77e0701c17a476f2b407620f8c17371740cf2e4",
+    "TRUNCATED_VEGA_PUBLIC_KEY": "47836c…c7d278",
+    "TRUNCATED_VEGA_PUBLIC_KEY2": "1a18cd…0cf2e4",
+    "TBTC_CONTRACT": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
     "tsConfig": "tsconfig.json",
-    "TAGS": "not @todo and not @ignore and not @manual",
-    "tBtcContract": "5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c",
-    "tradingTestVegaWalletName": "UI_Trading_Test"
+    "TAGS": "not @todo and not @ignore and not @manual"
   }
 }

--- a/apps/trading-e2e/src/integration/deposits.feature
+++ b/apps/trading-e2e/src/integration/deposits.feature
@@ -64,25 +64,25 @@ Feature: Deposits to vega wallet
 
   Scenario: Invalid deposit public key validation error
     When I enter the following deposit details in deposit form
-      | asset  | tBTC TEST               |
-      | to     | invalidDepositToAddress |
-      | amount | 1                       |
+      | asset  | tBTC TEST                  |
+      | to     | INVALID_DEPOSIT_TO_ADDRESS |
+      | amount | 1                          |
     And I submit the form
     Then Invalid Vega key is shown
 
   Scenario: Deposit amount too small validation
     When I enter the following deposit details in deposit form
       | asset  | tBTC TEST                             |
-      | to     | invalidDepositToAddress               |
+      | to     | INVALID_DEPOSIT_TO_ADDRESS            |
       | amount | 0.00000000000000000000000000000000001 |
     And I submit the form
     Then Amount too small message shown
 
   Scenario: Deposit amount greater than approved amount validation
     When I enter the following deposit details in deposit form
-      | asset  | tBTC TEST               |
-      | to     | invalidDepositToAddress |
-      | amount | 788888888888888         |
+      | asset  | tBTC TEST                  |
+      | to     | INVALID_DEPOSIT_TO_ADDRESS |
+      | amount | 788888888888888            |
     And I submit the form
     And Insufficient amount message shown
   # Then Amount too small message shown
@@ -93,9 +93,9 @@ Feature: Deposits to vega wallet
 
   Scenario: Successful deposit
     When I enter the following deposit details in deposit form
-      | asset  | tBTC TEST     |
-      | to     | vegaPublicKey |
-      | amount | 1             |
+      | asset  | tBTC TEST       |
+      | to     | VEGA_PUBLIC_KEY |
+      | amount | 1               |
     And I submit the form
     And I can see the 'deposit pending' modal is shown
 

--- a/apps/trading-e2e/src/support/mocks/generate-accounts.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-accounts.ts
@@ -9,7 +9,7 @@ export const generateAccounts = (
   const defaultAccounts: Accounts = {
     party: {
       __typename: 'Party',
-      id: Cypress.env('vegaPublicKey'),
+      id: Cypress.env('VEGA_PUBLIC_KEY'),
       accounts: [
         {
           __typename: 'Account',

--- a/apps/trading-e2e/src/support/mocks/generate-orders.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-orders.ts
@@ -70,7 +70,7 @@ export const generateOrders = (override?: PartialDeep<Orders>): Orders => {
 
   const defaultResult = {
     party: {
-      id: Cypress.env('vegaPublicKey'),
+      id: Cypress.env('VEGA_PUBLIC_KEY'),
       orders,
       __typename: 'Party',
     },

--- a/apps/trading-e2e/src/support/mocks/generate-positions.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-positions.ts
@@ -118,7 +118,7 @@ export const generatePositions = (
 
   const defaultResult = {
     party: {
-      id: Cypress.env('vegaPublicKey'),
+      id: Cypress.env('VEGA_PUBLIC_KEY'),
       positions,
       __typename: 'Party',
     },

--- a/apps/trading-e2e/src/support/step_definitions/deposits.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/deposits.step.ts
@@ -5,6 +5,10 @@ import DepositsPage from '../pages/deposits-page';
 const depositsPage = new DepositsPage();
 const ethWallet = new EthereumWallet();
 
+const tBTC = Cypress.env('TBTC_CONTRACT');
+const invalidPublicKey =
+  'zzz85edfa7ffdb6ed996ca912e9258998e47bf3515c885cf3c63fb56b15de36f';
+
 beforeEach(() => {
   cy.mockWeb3Provider();
 });

--- a/apps/trading-e2e/src/support/step_definitions/deposits.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/deposits.step.ts
@@ -5,10 +5,6 @@ import DepositsPage from '../pages/deposits-page';
 const depositsPage = new DepositsPage();
 const ethWallet = new EthereumWallet();
 
-const tBTC = Cypress.env('TBTC_CONTRACT');
-const invalidPublicKey =
-  'zzz85edfa7ffdb6ed996ca912e9258998e47bf3515c885cf3c63fb56b15de36f';
-
 beforeEach(() => {
   cy.mockWeb3Provider();
 });

--- a/apps/trading-e2e/src/support/step_definitions/vega-wallet.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/vega-wallet.step.ts
@@ -23,14 +23,16 @@ beforeEach(() => {
 When('I connect to Vega Wallet', () => {
   vegaWallet.openVegaWalletConnectDialog();
   vegaWallet.fillInWalletForm(
-    Cypress.env('tradingTestVegaWalletName'),
+    Cypress.env('TRADING_TEST_VEGA_WALLET_NAME'),
     Cypress.env('TRADING_TEST_VEGA_WALLET_PASSPHRASE')
   );
   vegaWallet.clickConnectVegaWallet();
 });
 
 When('I open wallet dialog', () => {
-  vegaWallet.validatePublicKeyDisplayed(Cypress.env('truncatedVegaPubKey')); // Default Test wallet pub key
+  vegaWallet.validatePublicKeyDisplayed(
+    Cypress.env('TRUNCATED_VEGA_PUBLIC_KEY')
+  ); // Default Test wallet pub key
   vegaWallet.clickOnWalletConnectDialog();
 });
 
@@ -39,5 +41,7 @@ When('select a different public key', () => {
 });
 
 Then('public key is switched', () => {
-  vegaWallet.validatePublicKeyDisplayed(Cypress.env('truncatedVegaPubKey2')); // Second public key for test wallet
+  vegaWallet.validatePublicKeyDisplayed(
+    Cypress.env('TRUNCATED_VEGA_PUBLIC_KEY2')
+  ); // Second public key for test wallet
 });

--- a/apps/trading-e2e/src/support/step_definitions/vega-wallet.step.ts
+++ b/apps/trading-e2e/src/support/step_definitions/vega-wallet.step.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 When('I connect to Vega Wallet', () => {
   vegaWallet.openVegaWalletConnectDialog();
   vegaWallet.fillInWalletForm(
-    'UI_Trading_Test',
+    Cypress.env('tradingTestVegaWalletName'),
     Cypress.env('TRADING_TEST_VEGA_WALLET_PASSPHRASE')
   );
   vegaWallet.clickConnectVegaWallet();

--- a/libs/cypress/src/lib/eip1193-bridge.ts
+++ b/libs/cypress/src/lib/eip1193-bridge.ts
@@ -5,7 +5,7 @@ import { ethers } from 'ethers';
 
 // Address of the above key
 export class CustomizedBridge extends Eip1193Bridge {
-  chainId = Cypress.env('ethereumChainId');
+  chainId = Cypress.env('ETHEREUM_CHAIN_ID');
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async sendAsync(...args: any) {
@@ -109,8 +109,8 @@ const getAccount = (number = 0) => `m/44'/60'/0'/0/${number}`;
 
 const getProvider = () =>
   new JsonRpcProvider(
-    Cypress.env('ethereumProviderUrl'),
-    Cypress.env('ethereumChainId')
+    Cypress.env('ETHEREUM_PROVIDER_URL'),
+    Cypress.env('ETHEREUM_CHAIN_ID')
   );
 
 export const createBridge = () => {


### PR DESCRIPTION
# Related issues 🔗

Closes #422 

# Description ℹ️

- Updated Readme to allow people to run Cypress tests locally for the trading app
- Changed Cypress variable so it's easier to use different test wallet
- Added git ignore for local env file
- Added `cypress.env.json` file to 1Password so test team can run tests with shared secrets
- Tests passing locally with above file
