### PR TITLE
Feat/175: add explorer link to ui toolbox

### DIFF
--- a/libs/ui-toolkit/src/components/explorer-link/explorer-link.spec.tsx
+++ b/libs/ui-toolkit/src/components/explorer-link/explorer-link.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { ExplorerLink } from '.';
+
+it('renders a link with the children', () => {
+  render(<ExplorerLink entity="block">foo</ExplorerLink>);
+  expect(screen.getByText('foo')).toBeInTheDocument();
+});
+
+it('renders a link with the id when no children provided', () => {
+  render(<ExplorerLink entity="block" id="12345" />);
+  expect(screen.getByText('12345')).toBeInTheDocument();
+});
+
+it('renders a link with the collective entity path name when no id or children provided', () => {
+  render(<ExplorerLink entity="block" />);
+  expect(screen.getByText('blocks')).toBeInTheDocument();
+});
+
+it('links to a block url', () => {
+  const id = '12345';
+  render(<ExplorerLink entity="block" id={id}></ExplorerLink>);
+  expect(screen.getByTestId('explorer-link')).toHaveAttribute(
+    'href',
+    `${process.env['NX_EXPLORER_URL']}/blocks/${id}`
+  );
+});
+
+it('links to a party url', () => {
+  const id = '12345';
+  render(<ExplorerLink entity="party" id={id}></ExplorerLink>);
+  expect(screen.getByTestId('explorer-link')).toHaveAttribute(
+    'href',
+    `${process.env['NX_EXPLORER_URL']}/parties/${id}`
+  );
+});

--- a/libs/ui-toolkit/src/components/explorer-link/explorer-link.stories.tsx
+++ b/libs/ui-toolkit/src/components/explorer-link/explorer-link.stories.tsx
@@ -1,0 +1,26 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { ExplorerLink } from '.';
+
+export default {
+  title: 'ExplorerLink',
+  component: ExplorerLink,
+} as ComponentMeta<typeof ExplorerLink>;
+
+const Template: ComponentStory<typeof ExplorerLink> = (args) => (
+  <ExplorerLink {...args} />
+);
+
+export const Block = Template.bind({});
+Block.args = {
+  entity: 'block',
+  id: '1234',
+  children: 'View block in Explorer',
+};
+
+export const Party = Template.bind({});
+Party.args = {
+  entity: 'party',
+  id: '123456789',
+  children: 'View party in Explorer',
+};

--- a/libs/ui-toolkit/src/components/explorer-link/explorer-link.tsx
+++ b/libs/ui-toolkit/src/components/explorer-link/explorer-link.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, HTMLProps } from 'react';
 
 const EXPLORER_URL = process.env['NX_EXPLORER_URL'] as string;
 
-type ExplorerEntity = 'block' | 'party';
+type ExplorerEntity = 'block' | 'party' | 'transaction';
 
 type ExplorerLinkProps = HTMLProps<HTMLAnchorElement> & {
   entity: ExplorerEntity;
@@ -14,6 +14,7 @@ type ExplorerLinkProps = HTMLProps<HTMLAnchorElement> & {
 const entityUrlMap: Record<ExplorerEntity, string> = {
   block: 'blocks',
   party: 'parties',
+  transaction: 'txs',
 };
 
 /**

--- a/libs/ui-toolkit/src/components/explorer-link/explorer-link.tsx
+++ b/libs/ui-toolkit/src/components/explorer-link/explorer-link.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import type { ReactNode, HTMLProps } from 'react';
+
+const EXPLORER_URL = process.env['NX_EXPLORER_URL'] as string;
+
+type ExplorerEntity = 'block' | 'party';
+
+type ExplorerLinkProps = HTMLProps<HTMLAnchorElement> & {
+  entity: ExplorerEntity;
+  id?: string;
+  children?: ReactNode;
+};
+
+const entityUrlMap: Record<ExplorerEntity, string> = {
+  block: 'blocks',
+  party: 'parties',
+};
+
+/**
+ * Form an HTML link tag pointing to an appropriate Explorer page
+ */
+export const ExplorerLink = ({
+  id,
+  entity,
+  children,
+  className,
+  ...props
+}: ExplorerLinkProps) => {
+  const element = children ?? id ?? entityUrlMap[entity];
+  const anchorClasses =
+    typeof element === 'string'
+      ? classNames('underline', className)
+      : className;
+
+  const url = [EXPLORER_URL, entityUrlMap[entity], id]
+    .filter((chunk) => !!chunk)
+    .join('/');
+
+  return (
+    <a
+      data-testid="explorer-link"
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className={anchorClasses}
+      {...props}
+    >
+      {element}
+    </a>
+  );
+};
+
+ExplorerLink.displayName = 'EtherScanLink';

--- a/libs/ui-toolkit/src/components/explorer-link/index.ts
+++ b/libs/ui-toolkit/src/components/explorer-link/index.ts
@@ -1,0 +1,1 @@
+export { ExplorerLink } from './explorer-link';

--- a/libs/ui-toolkit/src/setup-test-env.ts
+++ b/libs/ui-toolkit/src/setup-test-env.ts
@@ -1,1 +1,2 @@
 process.env['NX_ETHERSCAN_URL'] = 'https://etherscan.io';
+process.env['NX_EXPLORER_URL'] = 'https://explorer.vega.xyz';


### PR DESCRIPTION
# Related issues 🔗

Closes #175 

# Description ℹ️

Adds a link based on explorer entities, similarly to the etherscan-link in the ui-toolbox.

# Demo 📺

<img width="196" alt="Screenshot 2022-05-20 at 19 00 24" src="https://user-images.githubusercontent.com/105208209/169586599-2ae32812-035b-47aa-b5bb-2fb1c8783aa7.png">
<img width="196" alt="Screenshot 2022-05-20 at 19 00 31" src="https://user-images.githubusercontent.com/105208209/169586602-e370da3d-5ae1-4887-864e-08c656f2fee7.png">

# Technical 👨‍🔧

Implemented this with using children, instead of "text" as a prop, felt a lot more semantic regarding how anchor tags behave in general, even if we plan to use it only with string values to render.
