### PR TITLE
fix: [#445] use markPrice if there is no candle last

### DIFF
--- a/libs/market-list/src/lib/components/__generated__/index.ts
+++ b/libs/market-list/src/lib/components/__generated__/index.ts
@@ -1,4 +1,3 @@
 export * from './MarketDataFields';
 export * from './MarketDataSub';
-export * from './MarketList';
 export * from './Markets';

--- a/libs/market-list/src/lib/components/landing/landing-dialog.tsx
+++ b/libs/market-list/src/lib/components/landing/landing-dialog.tsx
@@ -1,33 +1,11 @@
-import { gql, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import { Interval } from '@vegaprotocol/types';
 import { AsyncRenderer, Dialog, Intent } from '@vegaprotocol/ui-toolkit';
 import { useState } from 'react';
+import { MARKET_LIST_QUERY } from '../markets-container/markets-data-provider';
+import type { MarketList } from '../markets-container/__generated__/MarketList';
 
-import type { MarketList } from '../__generated__/MarketList';
 import { SelectMarketList } from './select-market-list';
-
-const MARKET_LIST_QUERY = gql`
-  query MarketList($interval: Interval!, $since: String!) {
-    markets {
-      id
-      decimalPlaces
-      tradableInstrument {
-        instrument {
-          name
-          code
-        }
-      }
-      marketTimestamps {
-        open
-        close
-      }
-      candles(interval: $interval, since: $since) {
-        open
-        close
-      }
-    }
-  }
-`;
 
 export const LandingDialog = () => {
   const [open, setOpen] = useState(true);

--- a/libs/market-list/src/lib/components/landing/select-market-list.tsx
+++ b/libs/market-list/src/lib/components/landing/select-market-list.tsx
@@ -4,7 +4,7 @@ import {
 } from '@vegaprotocol/react-helpers';
 import { PriceCellChange, Sparkline } from '@vegaprotocol/ui-toolkit';
 import { mapDataToMarketList } from '../../utils';
-import type { MarketList } from '../__generated__/MarketList';
+import type { MarketList } from '../markets-container/__generated__/MarketList';
 
 export interface SelectMarketListProps {
   data: MarketList | undefined;

--- a/libs/market-list/src/lib/components/markets-container/__generated__/MarketDataFields.ts
+++ b/libs/market-list/src/lib/components/markets-container/__generated__/MarketDataFields.ts
@@ -1,0 +1,46 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { MarketState, MarketTradingMode } from "@vegaprotocol/types";
+
+// ====================================================
+// GraphQL fragment: MarketDataFields
+// ====================================================
+
+export interface MarketDataFields_market {
+  __typename: "Market";
+  /**
+   * Market ID
+   */
+  id: string;
+  /**
+   * Current state of the market
+   */
+  state: MarketState;
+  /**
+   * Current mode of execution of the market
+   */
+  tradingMode: MarketTradingMode;
+}
+
+export interface MarketDataFields {
+  __typename: "MarketData";
+  /**
+   * market id of the associated mark price
+   */
+  market: MarketDataFields_market;
+  /**
+   * the highest price level on an order book for buy orders.
+   */
+  bestBidPrice: string;
+  /**
+   * the lowest price level on an order book for offer orders.
+   */
+  bestOfferPrice: string;
+  /**
+   * the mark price (actually an unsigned int)
+   */
+  markPrice: string;
+}

--- a/libs/market-list/src/lib/components/markets-container/__generated__/MarketDataSub.ts
+++ b/libs/market-list/src/lib/components/markets-container/__generated__/MarketDataSub.ts
@@ -1,0 +1,53 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { MarketState, MarketTradingMode } from "@vegaprotocol/types";
+
+// ====================================================
+// GraphQL subscription operation: MarketDataSub
+// ====================================================
+
+export interface MarketDataSub_marketData_market {
+  __typename: "Market";
+  /**
+   * Market ID
+   */
+  id: string;
+  /**
+   * Current state of the market
+   */
+  state: MarketState;
+  /**
+   * Current mode of execution of the market
+   */
+  tradingMode: MarketTradingMode;
+}
+
+export interface MarketDataSub_marketData {
+  __typename: "MarketData";
+  /**
+   * market id of the associated mark price
+   */
+  market: MarketDataSub_marketData_market;
+  /**
+   * the highest price level on an order book for buy orders.
+   */
+  bestBidPrice: string;
+  /**
+   * the lowest price level on an order book for offer orders.
+   */
+  bestOfferPrice: string;
+  /**
+   * the mark price (actually an unsigned int)
+   */
+  markPrice: string;
+}
+
+export interface MarketDataSub {
+  /**
+   * Subscribe to the mark price changes
+   */
+  marketData: MarketDataSub_marketData;
+}

--- a/libs/market-list/src/lib/components/markets-container/__generated__/MarketList.ts
+++ b/libs/market-list/src/lib/components/markets-container/__generated__/MarketList.ts
@@ -3,11 +3,55 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { Interval } from "@vegaprotocol/types";
+import { Interval, MarketState, MarketTradingMode } from "@vegaprotocol/types";
 
 // ====================================================
 // GraphQL query operation: MarketList
 // ====================================================
+
+export interface MarketList_markets_data_market {
+  __typename: "Market";
+  /**
+   * Market ID
+   */
+  id: string;
+  /**
+   * Current state of the market
+   */
+  state: MarketState;
+  /**
+   * Current mode of execution of the market
+   */
+  tradingMode: MarketTradingMode;
+}
+
+export interface MarketList_markets_data {
+  __typename: "MarketData";
+  /**
+   * market id of the associated mark price
+   */
+  market: MarketList_markets_data_market;
+  /**
+   * the highest price level on an order book for buy orders.
+   */
+  bestBidPrice: string;
+  /**
+   * the lowest price level on an order book for offer orders.
+   */
+  bestOfferPrice: string;
+  /**
+   * the mark price (actually an unsigned int)
+   */
+  markPrice: string;
+}
+
+export interface MarketList_markets_tradableInstrument_instrument_metadata {
+  __typename: "InstrumentMetadata";
+  /**
+   * An arbitrary list of tags to associated to associate to the Instrument (string list)
+   */
+  tags: string[] | null;
+}
 
 export interface MarketList_markets_tradableInstrument_instrument {
   __typename: "Instrument";
@@ -19,6 +63,10 @@ export interface MarketList_markets_tradableInstrument_instrument {
    * A short non necessarily unique code used to easily describe the instrument (e.g: FX:BTCUSD/DEC18) (string)
    */
   code: string;
+  /**
+   * Metadata for this instrument
+   */
+  metadata?: MarketList_markets_tradableInstrument_instrument_metadata;
 }
 
 export interface MarketList_markets_tradableInstrument {
@@ -62,20 +110,24 @@ export interface MarketList_markets {
   /**
    * decimalPlaces indicates the number of decimal places that an integer must be shifted by in order to get a correct
    * number denominated in the currency of the Market. (uint64)
-   * 
+   *
    * Examples:
    * Currency     Balance  decimalPlaces  Real Balance
    * GBP              100              0       GBP 100
    * GBP              100              2       GBP   1.00
    * GBP              100              4       GBP   0.01
    * GBP                1              4       GBP   0.0001   (  0.01p  )
-   * 
+   *
    * GBX (pence)      100              0       GBP   1.00     (100p     )
    * GBX (pence)      100              2       GBP   0.01     (  1p     )
    * GBX (pence)      100              4       GBP   0.0001   (  0.01p  )
    * GBX (pence)        1              4       GBP   0.000001 (  0.0001p)
    */
   decimalPlaces: number;
+  /**
+   * marketData for the given market
+   */
+  data: MarketList_markets_data | null;
   /**
    * An instance of or reference to a tradable instrument.
    */

--- a/libs/market-list/src/lib/components/markets-container/__generated__/Markets.ts
+++ b/libs/market-list/src/lib/components/markets-container/__generated__/Markets.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { MarketState, MarketTradingMode } from "@vegaprotocol/types";
+
+// ====================================================
+// GraphQL query operation: Markets
+// ====================================================
+
+export interface Markets_markets_data_market {
+  __typename: "Market";
+  /**
+   * Market ID
+   */
+  id: string;
+  /**
+   * Current state of the market
+   */
+  state: MarketState;
+  /**
+   * Current mode of execution of the market
+   */
+  tradingMode: MarketTradingMode;
+}
+
+export interface Markets_markets_data {
+  __typename: "MarketData";
+  /**
+   * market id of the associated mark price
+   */
+  market: Markets_markets_data_market;
+  /**
+   * the highest price level on an order book for buy orders.
+   */
+  bestBidPrice: string;
+  /**
+   * the lowest price level on an order book for offer orders.
+   */
+  bestOfferPrice: string;
+  /**
+   * the mark price (actually an unsigned int)
+   */
+  markPrice: string;
+}
+
+export interface Markets_markets_tradableInstrument_instrument_product_settlementAsset {
+  __typename: "Asset";
+  /**
+   * The symbol of the asset (e.g: GBP)
+   */
+  symbol: string;
+}
+
+export interface Markets_markets_tradableInstrument_instrument_product {
+  __typename: "Future";
+  /**
+   * The name of the asset (string)
+   */
+  settlementAsset: Markets_markets_tradableInstrument_instrument_product_settlementAsset;
+}
+
+export interface Markets_markets_tradableInstrument_instrument {
+  __typename: "Instrument";
+  /**
+   * A short non necessarily unique code used to easily describe the instrument (e.g: FX:BTCUSD/DEC18) (string)
+   */
+  code: string;
+  /**
+   * A reference to or instance of a fully specified product, including all required product parameters for that product (Product union)
+   */
+  product: Markets_markets_tradableInstrument_instrument_product;
+}
+
+export interface Markets_markets_tradableInstrument {
+  __typename: "TradableInstrument";
+  /**
+   * An instance of or reference to a fully specified instrument.
+   */
+  instrument: Markets_markets_tradableInstrument_instrument;
+}
+
+export interface Markets_markets {
+  __typename: "Market";
+  /**
+   * Market ID
+   */
+  id: string;
+  /**
+   * Market full name
+   */
+  name: string;
+  /**
+   * decimalPlaces indicates the number of decimal places that an integer must be shifted by in order to get a correct
+   * number denominated in the currency of the Market. (uint64)
+   * 
+   * Examples:
+   * Currency     Balance  decimalPlaces  Real Balance
+   * GBP              100              0       GBP 100
+   * GBP              100              2       GBP   1.00
+   * GBP              100              4       GBP   0.01
+   * GBP                1              4       GBP   0.0001   (  0.01p  )
+   * 
+   * GBX (pence)      100              0       GBP   1.00     (100p     )
+   * GBX (pence)      100              2       GBP   0.01     (  1p     )
+   * GBX (pence)      100              4       GBP   0.0001   (  0.01p  )
+   * GBX (pence)        1              4       GBP   0.000001 (  0.0001p)
+   */
+  decimalPlaces: number;
+  /**
+   * marketData for the given market
+   */
+  data: Markets_markets_data | null;
+  /**
+   * An instance of or reference to a tradable instrument.
+   */
+  tradableInstrument: Markets_markets_tradableInstrument;
+}
+
+export interface Markets {
+  /**
+   * One or more instruments that are trading on the VEGA network
+   */
+  markets: Markets_markets[] | null;
+}

--- a/libs/market-list/src/lib/components/markets-container/markets-data-provider.ts
+++ b/libs/market-list/src/lib/components/markets-container/markets-data-provider.ts
@@ -49,6 +49,38 @@ const MARKETS_QUERY = gql`
   }
 `;
 
+export const MARKET_LIST_QUERY = gql`
+  query MarketList($interval: Interval!, $since: String!) {
+    markets {
+      id
+      decimalPlaces
+      data {
+        market {
+          id
+        }
+        markPrice
+      }
+      tradableInstrument {
+        instrument {
+          name
+          code
+          metadata {
+            tags
+          }
+        }
+      }
+      marketTimestamps {
+        open
+        close
+      }
+      candles(interval: $interval, since: $since) {
+        open
+        close
+      }
+    }
+  }
+`;
+
 const MARKET_DATA_SUB = gql`
   ${MARKET_DATA_FRAGMENT}
   subscription MarketDataSub {

--- a/libs/market-list/src/lib/utils/market-list.utils.spec.tsx
+++ b/libs/market-list/src/lib/utils/market-list.utils.spec.tsx
@@ -1,4 +1,4 @@
-import type { MarketList } from '../components/__generated__/MarketList';
+import type { MarketList } from '../components/markets-container/__generated__/MarketList';
 import { mapDataToMarketList } from './market-list.utils';
 
 describe('mapDataToMarketList', () => {

--- a/libs/market-list/src/lib/utils/market-list.utils.ts
+++ b/libs/market-list/src/lib/utils/market-list.utils.ts
@@ -2,7 +2,7 @@ import sortBy from 'lodash/sortBy';
 import type {
   MarketList,
   MarketList_markets,
-} from '../components/__generated__/MarketList';
+} from '../components/markets-container/__generated__/MarketList';
 
 export const lastPrice = ({ candles }: MarketList_markets) =>
   candles && candles.length > 0
@@ -16,7 +16,7 @@ export const mapDataToMarketList = ({ markets }: MarketList) =>
         id: m.id,
         decimalPlaces: m.decimalPlaces,
         marketName: m.tradableInstrument.instrument?.code,
-        lastPrice: lastPrice(m),
+        lastPrice: lastPrice(m) ?? m.data?.markPrice,
         candles: (m.candles || []).filter((c) => c),
         open: m.marketTimestamps.open
           ? new Date(m.marketTimestamps.open).getTime()


### PR DESCRIPTION
# Related issues 🔗

Closes #[448]

# Description ℹ️

When a user first visits the platform, the intention is to get them straight into the trading environment and allow them to see the app as soon as they land - but we also want them to select their preferred market before getting stuck in.


- [ ] want the route to use markPrice as the last price if last candle close is null

![image](https://user-images.githubusercontent.com/16125548/169851130-64f3b23e-f768-4f1a-8c96-7a240c56337e.png)
# Demo 📺
![image](https://user-images.githubusercontent.com/16125548/169851046-6fc1178c-6d46-4185-97d4-be7a47a1f879.png)

# Technical 👨‍🔧

- [ ] want the route to use markPrice as the last price if last candle close is null

