### PR TITLE
fix: [#445] shallow routing from index

### DIFF
--- a/apps/trading/pages/index.page.tsx
+++ b/apps/trading/pages/index.page.tsx
@@ -32,6 +32,14 @@ export function Index() {
   // The default market selected in the platform behind the overlay
   // should be the oldest market that is currently trading in continuous mode(i.e. not in auction).
   const { data, error, loading } = useQuery<MarketsLanding>(MARKETS_QUERY);
+  if (data && !error && !loading) {
+    const marketId = marketList(data)[0]?.id;
+    window.history.replaceState(
+      data,
+      '',
+      marketId ? `/markets/${marketId}` : '/markets'
+    );
+  }
   return (
     <>
       <LandingDialog />

--- a/libs/market-list/src/lib/components/landing/landing-dialog.tsx
+++ b/libs/market-list/src/lib/components/landing/landing-dialog.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { t } from '@vegaprotocol/react-helpers';
 import { Interval } from '@vegaprotocol/types';
 import { AsyncRenderer, Dialog, Intent } from '@vegaprotocol/ui-toolkit';
 import { useState } from 'react';
@@ -22,7 +23,7 @@ export const LandingDialog = () => {
     <AsyncRenderer loading={loading} error={error} data={data}>
       {
         <Dialog
-          title="Select a market to get started"
+          title={t('Select a market to get started')}
           intent={Intent.Prompt}
           open={open}
           onChange={setClose}

--- a/libs/market-list/src/lib/components/landing/select-market-list.tsx
+++ b/libs/market-list/src/lib/components/landing/select-market-list.tsx
@@ -1,8 +1,10 @@
 import {
   addDecimalsFormatNumber,
   PriceCell,
+  t,
 } from '@vegaprotocol/react-helpers';
 import { PriceCellChange, Sparkline } from '@vegaprotocol/ui-toolkit';
+import Link from 'next/link';
 import { mapDataToMarketList } from '../../utils';
 import type { MarketList } from '../markets-container/__generated__/MarketList';
 
@@ -46,9 +48,9 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
                     className={`hover:bg-black/20 dark:hover:bg-white/20 cursor-pointer relative`}
                   >
                     <td className={`${boldUnderlineClassNames} relative`}>
-                      <a href={`/markets/${id}`} className={stretchedLink}>
+                      <Link href={`/markets/${id}`} passHref={true}>
                         {marketName}
-                      </a>
+                      </Link>
                     </td>
                     <td className={tdClassNames}>
                       {lastPrice && (
@@ -84,8 +86,11 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
         </tbody>
       </table>
 
-      <a className={`${boldUnderlineClassNames} text-ui-small`} href="/markets">
-        {'Or view full market list'}
+      <a
+        href="/markets"
+        className={`${boldUnderlineClassNames} text-ui-small ${stretchedLink}`}
+      >
+        {t('Or view full market list')}
       </a>
     </div>
   );

--- a/libs/market-list/src/lib/components/landing/select-market-list.tsx
+++ b/libs/market-list/src/lib/components/landing/select-market-list.tsx
@@ -22,7 +22,6 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
 
   const boldUnderlineClassNames =
     'px-8 underline font-sans text-base leading-9 font-bold tracking-tight decoration-solid text-ui light:hover:text-black/80 dark:hover:text-white/80';
-  const stretchedLink = `after:content-[''] after:inset-0 after:z-[1] after:absolute after:box-border`;
   return (
     <div className="max-h-[40rem] overflow-x-auto">
       <table className="relative h-full min-w-full whitespace-nowrap">

--- a/libs/market-list/src/lib/components/landing/select-market-list.tsx
+++ b/libs/market-list/src/lib/components/landing/select-market-list.tsx
@@ -46,10 +46,7 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
                     className={`hover:bg-black/20 dark:hover:bg-white/20 cursor-pointer relative`}
                   >
                     <td className={`${boldUnderlineClassNames} relative`}>
-                      <a
-                        href={`/markets/${id}?portfolio=orders&trade=orderbook&chart=candles`}
-                        className={stretchedLink}
-                      >
+                      <a href={`/markets/${id}`} className={stretchedLink}>
                         {marketName}
                       </a>
                     </td>

--- a/libs/market-list/src/lib/components/landing/select-market-list.tsx
+++ b/libs/market-list/src/lib/components/landing/select-market-list.tsx
@@ -48,7 +48,9 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
                     className={`hover:bg-black/20 dark:hover:bg-white/20 cursor-pointer relative`}
                   >
                     <td className={`${boldUnderlineClassNames} relative`}>
-                      <Link href={`/markets/${id}`} passHref={true}>
+                      <Link
+                        href={`/markets/${id}?portfolio=orders&trade=orderbook&chart=candles`}
+                      >
                         {marketName}
                       </Link>
                     </td>
@@ -86,10 +88,7 @@ export const SelectMarketList = ({ data }: SelectMarketListProps) => {
         </tbody>
       </table>
 
-      <a
-        href="/markets"
-        className={`${boldUnderlineClassNames} text-ui-small ${stretchedLink}`}
-      >
+      <a className={`${boldUnderlineClassNames} text-ui-small`} href="/markets">
         {t('Or view full market list')}
       </a>
     </div>


### PR DESCRIPTION
# Related issues 🔗

Closes [#445]

# Description ℹ️

When a user first visits the platform, the intention is to get them straight into the trading environment and allow them to see the app as soon as they land - but we also want them to select their preferred market before getting stuck in.
The default market in the overlay is the oldest market traded in continuous mode.
We want the route to reflect that.

# Demo 📺

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/16125548/170498235-d1422fa9-6b30-435e-bdbf-41fce67b9064.png">

# Technical 👨‍🔧

- [x] direct to the market URL - make it sharable 
