### PR TITLE
feat(console-lite): add portfolio screen and accounts container

### DIFF
--- a/apps/simple-trading-app/src/app/components/portfolio/index.ts
+++ b/apps/simple-trading-app/src/app/components/portfolio/index.ts
@@ -1,0 +1,1 @@
+export * from './portfolio';

--- a/apps/simple-trading-app/src/app/components/portfolio/portfolio.tsx
+++ b/apps/simple-trading-app/src/app/components/portfolio/portfolio.tsx
@@ -1,0 +1,13 @@
+import { AccountsContainer } from '@vegaprotocol/accounts';
+import { t } from '@vegaprotocol/react-helpers';
+
+export const Portfolio = () => {
+  return (
+    <section>
+      <h2 className="text-lg mb-16">{t('Assets')}</h2>
+      <div className="h-screen">
+        <AccountsContainer />
+      </div>
+    </section>
+  );
+};

--- a/apps/simple-trading-app/src/app/routes/router-config.tsx
+++ b/apps/simple-trading-app/src/app/routes/router-config.tsx
@@ -1,6 +1,7 @@
 import { t } from '@vegaprotocol/react-helpers';
 import { DealTicketContainer } from '../components/deal-ticket';
 import { SimpleMarketList } from '../components/simple-market-list';
+import { Portfolio } from '../components/portfolio';
 
 export const ROUTES = {
   HOME: '/',
@@ -45,6 +46,6 @@ export const routerConfig = [
     path: ROUTES.PORTFOLIO,
     name: 'Portfolio',
     text: t('Portfolio'),
-    element: <div>Portfolio</div>,
+    element: <Portfolio />,
   },
 ];


### PR DESCRIPTION
# Related issues 🔗

Closes #340 

# Description ℹ️

Added a temporary component to the portfolio screen of console-lite to display a wallets assets

# Demo 📺
<img width="1728" alt="Screenshot 2022-05-26 at 01 42 20" src="https://user-images.githubusercontent.com/102954831/170507380-b1a760a4-2902-4069-8287-3c1f3531f057.png">

# Technical 👨‍🔧

N/A