### PR TITLE
feat(console-lite): enabling navigation from market to trade

### DIFF
--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
@@ -5,15 +5,19 @@ import {
 import { DealTicketSteps } from './deal-ticket-steps';
 import { useParams } from 'react-router-dom';
 
+const tempEmptyText = <p>Please select a market from the markets page</p>;
+
 export const DealTicketContainer = () => {
-  const { marketId } = useParams();
-  return (
-    <Container marketId={marketId as string}>
+  const { marketId } = useParams<{ marketId: string }>();
+  return marketId ? (
+    <Container marketId={marketId}>
       {(data) => (
         <DealTicketManager market={data.market}>
           <DealTicketSteps market={data.market} />
         </DealTicketManager>
       )}
     </Container>
+  ) : (
+    tempEmptyText
   );
 };

--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
@@ -1,9 +1,9 @@
+import { useParams } from 'react-router-dom';
 import {
   DealTicketManager,
   DealTicketContainer as Container,
 } from '@vegaprotocol/deal-ticket';
 import { DealTicketSteps } from './deal-ticket-steps';
-import { useParams } from 'react-router-dom';
 
 const tempEmptyText = <p>Please select a market from the markets page</p>;
 

--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
@@ -1,13 +1,14 @@
-import type { DealTicketContainerProps } from '@vegaprotocol/deal-ticket';
 import {
   DealTicketManager,
   DealTicketContainer as Container,
 } from '@vegaprotocol/deal-ticket';
 import { DealTicketSteps } from './deal-ticket-steps';
+import { useParams } from 'react-router-dom';
 
-export const DealTicketContainer = ({ marketId }: DealTicketContainerProps) => {
+export const DealTicketContainer = () => {
+  const { marketId } = useParams();
   return (
-    <Container marketId={marketId}>
+    <Container marketId={marketId as string}>
       {(data) => (
         <DealTicketManager market={data.market}>
           <DealTicketSteps market={data.market} />

--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-steps.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-steps.tsx
@@ -70,7 +70,7 @@ export const DealTicketSteps = ({ market }: DealTicketMarketProps) => {
     {
       label: 'Select Asset',
       description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
-      component: <div />,
+      component: <h1 className="font-bold mb-16">{market.name}</h1>,
     },
     {
       label: 'Select Order Type',

--- a/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.spec.tsx
+++ b/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.spec.tsx
@@ -5,6 +5,13 @@ import { MarketState } from '@vegaprotocol/types';
 import SimpleMarketList from './simple-market-list';
 import type { SimpleMarkets_markets } from './__generated__/SimpleMarkets';
 
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}));
+
 jest.mock('./data-provider', () => jest.fn());
 
 jest.mock('@vegaprotocol/react-helpers', () => ({

--- a/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
+++ b/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
@@ -23,9 +23,13 @@ const SimpleMarketList = () => {
     undefined, // @TODO - if we need a live update in the future
     variables
   );
-  const onClick = useCallback((marketId) => {
-    navigate(`/trading/${marketId}`);
-  }, []);
+  const onClick = useCallback(
+    (marketId) => {
+      navigate(`/trading/${marketId}`);
+    },
+    [navigate]
+  );
+
   return (
     <AsyncRenderer loading={loading} error={error} data={data}>
       {data && data.length > 0 ? (

--- a/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
+++ b/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useDataProvider } from '@vegaprotocol/react-helpers';
 import { t } from '@vegaprotocol/react-helpers';
 import { AsyncRenderer, Lozenge, Splash } from '@vegaprotocol/ui-toolkit';
@@ -7,7 +8,6 @@ import SimpleMarketPercentChange from './simple-market-percent-change';
 import SimpleMarketExpires from './simple-market-expires';
 import DataProvider from './data-provider';
 import { MARKET_STATUS } from './constants';
-import { useNavigate } from 'react-router-dom';
 
 const SimpleMarketList = () => {
   const navigate = useNavigate();

--- a/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
+++ b/apps/simple-trading-app/src/app/components/simple-market-list/simple-market-list.tsx
@@ -7,8 +7,10 @@ import SimpleMarketPercentChange from './simple-market-percent-change';
 import SimpleMarketExpires from './simple-market-expires';
 import DataProvider from './data-provider';
 import { MARKET_STATUS } from './constants';
+import { useNavigate } from 'react-router-dom';
 
 const SimpleMarketList = () => {
+  const navigate = useNavigate();
   const variables = useMemo(
     () => ({
       CandleInterval: 'I1H',
@@ -22,8 +24,7 @@ const SimpleMarketList = () => {
     variables
   );
   const onClick = useCallback((marketId) => {
-    // @TODO - let's try to have navigation first
-    console.log('trigger market', marketId);
+    navigate(`/trading/${marketId}`);
   }, []);
   return (
     <AsyncRenderer loading={loading} error={error} data={data}>

--- a/apps/simple-trading-app/src/app/routes/router-config.tsx
+++ b/apps/simple-trading-app/src/app/routes/router-config.tsx
@@ -6,7 +6,7 @@ import { Portfolio } from '../components/portfolio';
 export const ROUTES = {
   HOME: '/',
   MARKETS: 'markets',
-  TRADING: 'trading',
+  TRADING: 'trading/:marketId',
   LIQUIDITY: 'liquidity',
   PORTFOLIO: 'portfolio',
 };
@@ -28,13 +28,7 @@ export const routerConfig = [
     path: ROUTES.TRADING,
     name: 'Trading',
     text: t('Trading'),
-    element: (
-      <DealTicketContainer
-        marketId={
-          '41013c28d53a72225c07cf2660cdd415d9dd0e9317ec4574e77592332db35596'
-        }
-      />
-    ),
+    element: <DealTicketContainer />,
   },
   {
     path: ROUTES.LIQUIDITY,

--- a/apps/simple-trading-app/src/app/routes/router-config.tsx
+++ b/apps/simple-trading-app/src/app/routes/router-config.tsx
@@ -6,7 +6,7 @@ import { Portfolio } from '../components/portfolio';
 export const ROUTES = {
   HOME: '/',
   MARKETS: 'markets',
-  TRADING: 'trading/:marketId',
+  TRADING: 'trading',
   LIQUIDITY: 'liquidity',
   PORTFOLIO: 'portfolio',
 };
@@ -29,6 +29,12 @@ export const routerConfig = [
     name: 'Trading',
     text: t('Trading'),
     element: <DealTicketContainer />,
+    children: [
+      {
+        path: ':marketId',
+        element: <DealTicketContainer />,
+      },
+    ],
   },
   {
     path: ROUTES.LIQUIDITY,

--- a/apps/trading-e2e/src/support/mocks/generate-deal-ticket-query.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-deal-ticket-query.ts
@@ -9,6 +9,7 @@ export const generateDealTicketQuery = (
   const defaultResult: DealTicketQuery = {
     market: {
       id: 'market-id',
+      name: 'ETHBTC Quarterly (30 Jun 2022)',
       decimalPlaces: 2,
       positionDecimalPlaces: 1,
       state: MarketState.Active,

--- a/libs/deal-ticket/src/__generated__/DealTicketQuery.ts
+++ b/libs/deal-ticket/src/__generated__/DealTicketQuery.ts
@@ -56,6 +56,10 @@ export interface DealTicketQuery_market {
    */
   id: string;
   /**
+   * Market full name
+   */
+  name: string;
+  /**
    * decimalPlaces indicates the number of decimal places that an integer must be shifted by in order to get a correct
    * number denominated in the currency of the Market. (uint64)
    * 

--- a/libs/deal-ticket/src/components/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-container.tsx
@@ -1,5 +1,5 @@
-import { AsyncRenderer, Splash } from '@vegaprotocol/ui-toolkit';
 import { gql, useQuery } from '@apollo/client';
+import { AsyncRenderer, Splash } from '@vegaprotocol/ui-toolkit';
 import { DealTicketManager } from './deal-ticket-manager';
 import type {
   DealTicketQuery,

--- a/libs/deal-ticket/src/components/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-container.tsx
@@ -11,6 +11,7 @@ const DEAL_TICKET_QUERY = gql`
   query DealTicketQuery($marketId: ID!) {
     market(id: $marketId) {
       id
+      name
       decimalPlaces
       positionDecimalPlaces
       state


### PR DESCRIPTION
# Related issues 🔗

Closes #446 

# Description ℹ️

Allows the navigation from the market page to the making a trade page. Displays the name in the stepper component.

# Demo 📺
<img width="1728" alt="Screenshot 2022-05-31 at 13 55 49" src="https://user-images.githubusercontent.com/102954831/171178926-419c9eeb-ff68-44ae-800c-9b55015a18d4.png">

# Technical 👨‍🔧

- Added a new field to the DEAL_TICKET_QUERY in DealTicketContainer
- Ran `nx run types:generate`
