### PR TITLE
feat(console-lite): add trade balance component and hook

### DIFF
--- a/apps/simple-trading-app/src/app/components/deal-ticket/__generated__/PartyBalanceQuery.ts
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/__generated__/PartyBalanceQuery.ts
@@ -1,0 +1,59 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: PartyBalanceQuery
+// ====================================================
+
+export interface PartyBalanceQuery_party_accounts_asset {
+  __typename: "Asset";
+  /**
+   * The id of the asset
+   */
+  id: string;
+  /**
+   * The symbol of the asset (e.g: GBP)
+   */
+  symbol: string;
+  /**
+   * The full name of the asset (e.g: Great British Pound)
+   */
+  name: string;
+  /**
+   * The precision of the asset
+   */
+  decimals: number;
+}
+
+export interface PartyBalanceQuery_party_accounts {
+  __typename: "Account";
+  /**
+   * Balance as string - current account balance (approx. as balances can be updated several times per second)
+   */
+  balance: string;
+  /**
+   * Asset, the 'currency'
+   */
+  asset: PartyBalanceQuery_party_accounts_asset;
+}
+
+export interface PartyBalanceQuery_party {
+  __typename: "Party";
+  /**
+   * Collateral accounts relating to a party
+   */
+  accounts: PartyBalanceQuery_party_accounts[] | null;
+}
+
+export interface PartyBalanceQuery {
+  /**
+   * An entity that is trading on the VEGA network
+   */
+  party: PartyBalanceQuery_party | null;
+}
+
+export interface PartyBalanceQueryVariables {
+  partyId: string;
+}

--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-balance.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-balance.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import type { DealTicketQuery_market_tradableInstrument_instrument_product_settlementAsset } from '@vegaprotocol/deal-ticket';
+import type { PartyBalanceQuery_party_accounts } from './__generated__/PartyBalanceQuery';
+import { useSettlementAccount } from '../../hooks/use-settlement-account';
+import { addDecimalsFormatNumber, t } from '@vegaprotocol/react-helpers';
+
+interface DealTicketBalanceProps {
+  settlementAsset: DealTicketQuery_market_tradableInstrument_instrument_product_settlementAsset;
+  accounts: PartyBalanceQuery_party_accounts[];
+  isWalletConnected: boolean;
+}
+
+export const DealTicketBalance = ({
+  settlementAsset,
+  accounts,
+  isWalletConnected,
+}: DealTicketBalanceProps) => {
+  const settlementAssetId = settlementAsset?.id;
+  const settlementAssetSymbol = settlementAsset?.symbol;
+  const settlementAccount = useSettlementAccount(settlementAssetId, accounts);
+  const formatedNumber =
+    settlementAccount?.balance &&
+    settlementAccount.asset.decimals &&
+    addDecimalsFormatNumber(
+      settlementAccount.balance,
+      settlementAccount.asset.decimals
+    );
+
+  const balance = settlementAccount ? (
+    <p>
+      {t(
+        `${formatedNumber} ${settlementAccount.asset.symbol} available to trade`
+      )}
+    </p>
+  ) : (
+    <p>{t(`You have no ${settlementAssetSymbol} available to trade`)}</p>
+  );
+
+  const connectWallet = (
+    <p>
+      {t(
+        "Please connect your Vega wallet to see your balance for this market's settlement asset"
+      )}
+    </p>
+  );
+
+  return (
+    <div className="text-right">
+      <div className="border border-current p-16 inline-block">
+        <small className="text-text">{t('Balance')}</small>
+        {isWalletConnected ? balance : connectWallet}
+      </div>
+    </div>
+  );
+};

--- a/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
+++ b/apps/simple-trading-app/src/app/components/deal-ticket/deal-ticket-container.tsx
@@ -8,6 +8,7 @@ import { useVegaWallet } from '@vegaprotocol/wallet';
 import { gql, useQuery } from '@apollo/client';
 import { DealTicketBalance } from './deal-ticket-balance';
 import * as React from 'react';
+import type { PartyBalanceQuery } from './__generated__/PartyBalanceQuery';
 
 const tempEmptyText = <p>Please select a market from the markets page</p>;
 
@@ -31,22 +32,27 @@ export const DealTicketContainer = () => {
   const { marketId } = useParams<{ marketId: string }>();
   const { keypair } = useVegaWallet();
 
-  const { data: partyData, loading } = useQuery(PARTY_BALANCE_QUERY, {
-    variables: { partyId: keypair?.pub },
-    skip: !keypair?.pub,
-  });
+  const { data: partyData, loading } = useQuery<PartyBalanceQuery>(
+    PARTY_BALANCE_QUERY,
+    {
+      variables: { partyId: keypair?.pub },
+      skip: !keypair?.pub,
+    }
+  );
 
   return marketId ? (
     <Container marketId={marketId}>
       {(data) => (
         <DealTicketManager market={data.market}>
-          {loading ? null : (
+          {loading ? (
+            'Loading...'
+          ) : (
             <DealTicketBalance
               settlementAsset={
                 data.market.tradableInstrument.instrument.product
                   ?.settlementAsset
               }
-              accounts={partyData?.party.accounts}
+              accounts={partyData?.party?.accounts || []}
               isWalletConnected={!!keypair?.pub}
             />
           )}

--- a/apps/simple-trading-app/src/app/hooks/use-settlement-account.spec.tsx
+++ b/apps/simple-trading-app/src/app/hooks/use-settlement-account.spec.tsx
@@ -1,17 +1,6 @@
-import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import { useSettlementAccount } from './use-settlement-account';
 import type { PartyBalanceQuery_party_accounts } from '../components/deal-ticket/__generated__/PartyBalanceQuery';
-import { render, screen } from '@testing-library/react';
-
-interface Props {
-  settlementAssetId: string;
-  accounts: PartyBalanceQuery_party_accounts[];
-}
-
-const MockComponent = ({ settlementAssetId, accounts }: Props) => {
-  const settlementAccount = useSettlementAccount(settlementAssetId, accounts);
-  return <div>{settlementAccount?.asset.name || 'Not Found'}</div>;
-};
 
 describe('useSettlementAccount Hook', () => {
   it('should filter accounts by settlementAssetId', () => {
@@ -53,26 +42,20 @@ describe('useSettlementAccount Hook', () => {
     const settlementAssetId =
       '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61';
 
-    render(
-      <MockComponent
-        settlementAssetId={settlementAssetId}
-        accounts={accounts}
-      />
+    const { result } = renderHook(() =>
+      useSettlementAccount(settlementAssetId, accounts)
     );
-    expect(screen.getByText('tDAI TEST')).toBeInTheDocument();
+    expect(result.current?.balance).toBe(accounts[1].balance);
+    expect(result.current?.asset).toEqual(accounts[1].asset);
   });
 
   it('should return null if no accounts', () => {
     const accounts: PartyBalanceQuery_party_accounts[] = [];
     const settlementAssetId =
       '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61';
-
-    render(
-      <MockComponent
-        settlementAssetId={settlementAssetId}
-        accounts={accounts}
-      />
+    const { result } = renderHook(() =>
+      useSettlementAccount(settlementAssetId, accounts)
     );
-    expect(screen.getByText('Not Found')).toBeInTheDocument();
+    expect(result.current).toBe(undefined);
   });
 });

--- a/apps/simple-trading-app/src/app/hooks/use-settlement-account.spec.tsx
+++ b/apps/simple-trading-app/src/app/hooks/use-settlement-account.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useSettlementAccount } from './use-settlement-account';
+import type { PartyBalanceQuery_party_accounts } from '../components/deal-ticket/__generated__/PartyBalanceQuery';
+import { render, screen } from '@testing-library/react';
+
+interface Props {
+  settlementAssetId: string;
+  accounts: PartyBalanceQuery_party_accounts[];
+}
+
+const MockComponent = ({ settlementAssetId, accounts }: Props) => {
+  const settlementAccount = useSettlementAccount(settlementAssetId, accounts);
+  return <div>{settlementAccount?.asset.name || 'Not Found'}</div>;
+};
+
+describe('useSettlementAccount Hook', () => {
+  it('should filter accounts by settlementAssetId', () => {
+    const accounts: PartyBalanceQuery_party_accounts[] = [
+      {
+        __typename: 'Account',
+        balance: '2000000000000000000000',
+        asset: {
+          __typename: 'Asset',
+          id: '5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c',
+          symbol: 'tBTC',
+          name: 'tBTC TEST',
+          decimals: 5,
+        },
+      },
+      {
+        __typename: 'Account',
+        balance: '1000000000',
+        asset: {
+          __typename: 'Asset',
+          id: '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61',
+          symbol: 'tDAI',
+          name: 'tDAI TEST',
+          decimals: 5,
+        },
+      },
+      {
+        __typename: 'Account',
+        balance: '5000000000000000000',
+        asset: {
+          __typename: 'Asset',
+          id: 'fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55',
+          symbol: 'VEGA',
+          name: 'Vega (testnet)',
+          decimals: 18,
+        },
+      },
+    ];
+    const settlementAssetId =
+      '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61';
+
+    render(
+      <MockComponent
+        settlementAssetId={settlementAssetId}
+        accounts={accounts}
+      />
+    );
+    expect(screen.getByText('tDAI TEST')).toBeInTheDocument();
+  });
+
+  it('should return null if no accounts', () => {
+    const accounts: PartyBalanceQuery_party_accounts[] = [];
+    const settlementAssetId =
+      '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61';
+
+    render(
+      <MockComponent
+        settlementAssetId={settlementAssetId}
+        accounts={accounts}
+      />
+    );
+    expect(screen.getByText('Not Found')).toBeInTheDocument();
+  });
+});

--- a/apps/simple-trading-app/src/app/hooks/use-settlement-account.ts
+++ b/apps/simple-trading-app/src/app/hooks/use-settlement-account.ts
@@ -3,14 +3,10 @@ import { useMemo } from 'react';
 
 export const useSettlementAccount = (
   settlementAssetId: string,
-  accounts: PartyBalanceQuery_party_accounts[] | null
+  accounts: PartyBalanceQuery_party_accounts[]
 ): PartyBalanceQuery_party_accounts | null => {
   const callback = () =>
-    accounts?.length
-      ? accounts.find((account) => {
-          return account.asset.id === settlementAssetId;
-        })
-      : null;
+    accounts.find((account) => account.asset.id === settlementAssetId);
   const account = useMemo(callback, [accounts, settlementAssetId]);
   return account as PartyBalanceQuery_party_accounts;
 };

--- a/apps/simple-trading-app/src/app/hooks/use-settlement-account.ts
+++ b/apps/simple-trading-app/src/app/hooks/use-settlement-account.ts
@@ -1,0 +1,16 @@
+import type { PartyBalanceQuery_party_accounts } from '../components/deal-ticket/__generated__/PartyBalanceQuery';
+import { useMemo } from 'react';
+
+export const useSettlementAccount = (
+  settlementAssetId: string,
+  accounts: PartyBalanceQuery_party_accounts[] | null
+): PartyBalanceQuery_party_accounts | null => {
+  const callback = () =>
+    accounts?.length
+      ? accounts.find((account) => {
+          return account.asset.id === settlementAssetId;
+        })
+      : null;
+  const account = useMemo(callback, [accounts, settlementAssetId]);
+  return account as PartyBalanceQuery_party_accounts;
+};

--- a/apps/trading-e2e/src/support/mocks/generate-deal-ticket-query.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-deal-ticket-query.ts
@@ -18,6 +18,12 @@ export const generateDealTicketQuery = (
         instrument: {
           product: {
             quoteName: 'BTC',
+            settlementAsset: {
+              __typename: 'Asset',
+              id: '5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c',
+              symbol: 'tBTC',
+              name: 'tBTC TEST',
+            },
             __typename: 'Future',
           },
           __typename: 'Instrument',

--- a/libs/deal-ticket/src/__generated__/DealTicketQuery.ts
+++ b/libs/deal-ticket/src/__generated__/DealTicketQuery.ts
@@ -9,12 +9,32 @@ import { MarketState, MarketTradingMode } from "@vegaprotocol/types";
 // GraphQL query operation: DealTicketQuery
 // ====================================================
 
+export interface DealTicketQuery_market_tradableInstrument_instrument_product_settlementAsset {
+  __typename: "Asset";
+  /**
+   * The id of the asset
+   */
+  id: string;
+  /**
+   * The symbol of the asset (e.g: GBP)
+   */
+  symbol: string;
+  /**
+   * The full name of the asset (e.g: Great British Pound)
+   */
+  name: string;
+}
+
 export interface DealTicketQuery_market_tradableInstrument_instrument_product {
   __typename: "Future";
   /**
    * String representing the quote (e.g. BTCUSD -> USD is quote)
    */
   quoteName: string;
+  /**
+   * The name of the asset (string)
+   */
+  settlementAsset: DealTicketQuery_market_tradableInstrument_instrument_product_settlementAsset;
 }
 
 export interface DealTicketQuery_market_tradableInstrument_instrument {

--- a/libs/deal-ticket/src/components/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-container.tsx
@@ -21,6 +21,11 @@ const DEAL_TICKET_QUERY = gql`
           product {
             ... on Future {
               quoteName
+              settlementAsset {
+                id
+                symbol
+                name
+              }
             }
           }
         }

--- a/libs/market-depth/src/lib/__generated__/MarketDepthSubscription.ts
+++ b/libs/market-depth/src/lib/__generated__/MarketDepthSubscription.ts
@@ -86,7 +86,7 @@ export interface MarketDepthSubscription_marketDepthUpdate {
    */
   buy: MarketDepthSubscription_marketDepthUpdate_buy[] | null;
   /**
-   * Sequence number for the current snapshot of the market depth
+   * Sequence number for the current snapshot of the market depth. It is always increasing but not monotonic.
    */
   sequenceNumber: string;
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #343 

# Description ℹ️

Displays balance of settlement asset for the selected key and trade

# Demo 📺
<img width="385" alt="Screenshot 2022-06-07 at 16 42 09" src="https://user-images.githubusercontent.com/102954831/172423707-6fd3ef0f-3f61-46b4-a698-7e06cbf7c524.png">

# Technical 👨‍🔧

- Added useSettlementBalance Hook and Spec
- Added new fields to query for DealTicketQuery
- Created local DealTicketBalance component
- Regenerated types
- Added PartyBalanceQuery to local DealTicketContainer