### PR TITLE
chore(deps): update pennant to v0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",
     "next": "^12.0.7",
-    "pennant": "0.4.10",
+    "pennant": "0.4.11",
     "postcss": "^8.4.6",
     "react": "17.0.2",
     "react-copy-to-clipboard": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17569,10 +17569,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-pennant@0.4.10:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.10.tgz#a2c90d27b4f3772c9ba5e23a5503abc0243863ae"
-  integrity sha512-5uTrZZsqTW8d8McFH8A1DtFJR+fukr4XozKjrj0m/02PdQRvZQnrs04HjUWf5asUYwMNjR81KRBiSQLBC2YD5g==
+pennant@0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.11.tgz#d246ae140acd88da82ceca74f606afa0731f367b"
+  integrity sha512-H6851PEuURt4kWQFPyuT7MyVjX+mG8rDVK6x9kssOU8L/57rFS64Yu9ZQi2xcu1+q8optfEqe8WB77dd+/qjPA==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@d3fc/d3fc-technical-indicator" "^8.0.1"


### PR DESCRIPTION
# Related issues 🔗

Closes #260

# Description ℹ️

We were seeing a blue area on the candlestick chart (where the y-axis is rendered). This was due to a bug in pennant which would only support 6 character hex color codes and not the 3 character shorthand codes.

# Technical 👨‍🔧

The bug only appears when running the built version of the trading app. As part of the build css color codes are optimised to their shortest representation. In particular, #ffffff -> #fff which pennant was interpreting as #000fff.

The relevant pennant commit is: https://github.com/vegaprotocol/pennant/commit/2342be2c89a6b1a59b30fc66cb9188b28e7879b3