### PR TITLE
Chore/Improves trading app mock queries

### DIFF
--- a/apps/trading-e2e/src/integration/deposit.ts
+++ b/apps/trading-e2e/src/integration/deposit.ts
@@ -1,15 +1,11 @@
-import { hasOperationName } from '../support';
+import { aliasQuery } from '@vegaprotocol/cypress';
 import { generateDepositPage } from '../support/mocks/generate-deposit-page';
 
 describe('deposit form validation', () => {
   beforeEach(() => {
     cy.mockWeb3Provider();
-    cy.mockGQL('DepositPage', (req) => {
-      if (hasOperationName(req, 'DepositPage')) {
-        req.reply({
-          body: { data: generateDepositPage() },
-        });
-      }
+    cy.mockGQL((req) => {
+      aliasQuery(req, 'DepositPage', generateDepositPage());
     });
     cy.visit('/portfolio/deposit');
 

--- a/apps/trading-e2e/src/integration/home.ts
+++ b/apps/trading-e2e/src/integration/home.ts
@@ -1,6 +1,6 @@
+import { aliasQuery } from '@vegaprotocol/cypress';
 import type { MarketList, MarketList_markets } from '@vegaprotocol/market-list';
 import { MarketState } from '@vegaprotocol/types';
-import { hasOperationName } from '../support';
 import { generateMarketList } from '../support/mocks/generate-market-list';
 import { generateMarkets } from '../support/mocks/generate-markets';
 import type { MarketsLanding } from '../support/mocks/generate-markets-landing';
@@ -23,25 +23,13 @@ describe('home', () => {
       );
 
       // Mock markets query that is triggered by home page to find default market
-      cy.mockGQL('MarketsLanding', (req) => {
-        if (hasOperationName(req, 'MarketsLanding')) {
-          req.reply({
-            body: { data: marketsLanding },
-          });
-        }
-      });
+      cy.mockGQL((req) => {
+        aliasQuery(req, 'MarketsLanding', marketsLanding);
+        aliasQuery(req, 'MarketList', marketList);
 
-      // Market market list for the dialog that opens on a trading page
-      cy.mockGQL('MarketList', (req) => {
-        if (hasOperationName(req, 'MarketList')) {
-          req.reply({
-            body: { data: marketList },
-          });
-        }
+        // Mock all market page queries
+        mockTradingPage(req, MarketState.Active);
       });
-
-      // Mock market page
-      mockTradingPage(MarketState.Active);
 
       cy.visit('/');
       cy.wait('@MarketsLanding');
@@ -115,40 +103,31 @@ describe('home', () => {
   describe('no default found', () => {
     it('redirects to a the market list page if no sensible default is found', () => {
       // Mock markets query that is triggered by home page to find default market
-      cy.mockGQL('MarketsLanding', (req) => {
-        if (hasOperationName(req, 'MarketsLanding')) {
-          req.reply({
-            body: {
-              // Remove open timestamps so we can't calculate a sensible default market
-              data: generateMarketsLanding({
-                markets: [
-                  {
-                    marketTimestamps: {
-                      __typename: 'MarketTimestamps',
-                      open: '',
-                    },
-                  },
-                  {
-                    marketTimestamps: {
-                      __typename: 'MarketTimestamps',
-                      open: '',
-                    },
-                  },
-                ],
-              }),
-            },
-          });
-        }
-      });
+      cy.mockGQL((req) => {
+        aliasQuery(
+          req,
+          'MarketsLanding',
+          generateMarketsLanding({
+            markets: [
+              {
+                marketTimestamps: {
+                  __typename: 'MarketTimestamps',
+                  open: '',
+                },
+              },
+              {
+                marketTimestamps: {
+                  __typename: 'MarketTimestamps',
+                  open: '',
+                },
+              },
+            ],
+          })
+        );
+        aliasQuery(req, 'Markets', generateMarkets());
 
-      cy.mockGQL('Markets', (req) => {
-        if (hasOperationName(req, 'Markets')) {
-          req.reply({
-            body: {
-              data: generateMarkets(),
-            },
-          });
-        }
+        // Mock all market page queries
+        mockTradingPage(req, MarketState.Active);
       });
 
       cy.visit('/');

--- a/apps/trading-e2e/src/integration/markets.ts
+++ b/apps/trading-e2e/src/integration/markets.ts
@@ -1,16 +1,12 @@
+import { aliasQuery } from '@vegaprotocol/cypress';
 import { MarketState } from '@vegaprotocol/types';
-import { hasOperationName } from '../support';
 import { generateMarkets } from '../support/mocks/generate-markets';
 import { mockTradingPage } from '../support/trading';
 
 describe('markets table', () => {
   beforeEach(() => {
-    cy.mockGQL('Markets', (req) => {
-      if (hasOperationName(req, 'Markets')) {
-        req.reply({
-          body: { data: generateMarkets() },
-        });
-      }
+    cy.mockGQL((req) => {
+      aliasQuery(req, 'Markets', generateMarkets());
     });
     cy.visit('/markets');
   });
@@ -64,7 +60,9 @@ describe('markets table', () => {
     cy.wait('@Markets');
     cy.get('.ag-root-wrapper').should('be.visible');
 
-    mockTradingPage(MarketState.Active);
+    cy.mockGQL((req) => {
+      mockTradingPage(req, MarketState.Active);
+    });
 
     // click on active market
     cy.get('[role="gridcell"][col-id=data]').should('be.visible');
@@ -79,7 +77,9 @@ describe('markets table', () => {
     cy.wait('@Markets');
     cy.get('.ag-root-wrapper').should('be.visible');
 
-    mockTradingPage(MarketState.Suspended);
+    cy.mockGQL((req) => {
+      mockTradingPage(req, MarketState.Suspended);
+    });
 
     // click on active market
     cy.get('[role="gridcell"][col-id=data]').should('be.visible');

--- a/apps/trading-e2e/src/integration/trading-accounts.ts
+++ b/apps/trading-e2e/src/integration/trading-accounts.ts
@@ -3,7 +3,9 @@ import { mockTradingPage } from '../support/trading';
 import { connectVegaWallet } from '../support/vega-wallet';
 
 beforeEach(() => {
-  mockTradingPage(MarketState.Active);
+  cy.mockGQL((req) => {
+    mockTradingPage(req, MarketState.Active);
+  });
   cy.visit('/markets/market-0');
 });
 

--- a/apps/trading-e2e/src/integration/trading-deal-ticket.ts
+++ b/apps/trading-e2e/src/integration/trading-deal-ticket.ts
@@ -26,7 +26,9 @@ describe('deal ticket orders', () => {
   const orderTransactionHash = 'tx-hash';
 
   before(() => {
-    mockTradingPage(MarketState.Active);
+    cy.mockGQL((req) => {
+      mockTradingPage(req, MarketState.Active);
+    });
     cy.visit('/markets/market-0');
     connectVegaWallet();
   });
@@ -152,7 +154,9 @@ describe('deal ticket orders', () => {
 
 describe('deal ticket validation', () => {
   before(() => {
-    mockTradingPage(MarketState.Active);
+    cy.mockGQL((req) => {
+      mockTradingPage(req, MarketState.Active);
+    });
     cy.visit('/markets/market-0');
   });
 

--- a/apps/trading-e2e/src/integration/trading-orders.ts
+++ b/apps/trading-e2e/src/integration/trading-orders.ts
@@ -3,7 +3,9 @@ import { mockTradingPage } from '../support/trading';
 import { connectVegaWallet } from '../support/vega-wallet';
 
 beforeEach(() => {
-  mockTradingPage(MarketState.Active);
+  cy.mockGQL((req) => {
+    mockTradingPage(req, MarketState.Active);
+  });
   cy.visit('/markets/market-0');
 });
 

--- a/apps/trading-e2e/src/integration/trading-positions.ts
+++ b/apps/trading-e2e/src/integration/trading-positions.ts
@@ -3,7 +3,9 @@ import { mockTradingPage } from '../support/trading';
 import { connectVegaWallet } from '../support/vega-wallet';
 
 beforeEach(() => {
-  mockTradingPage(MarketState.Active);
+  cy.mockGQL((req) => {
+    mockTradingPage(req, MarketState.Active);
+  });
   cy.visit('/markets/market-0');
 });
 

--- a/apps/trading-e2e/src/integration/trading-trades.ts
+++ b/apps/trading-e2e/src/integration/trading-trades.ts
@@ -2,7 +2,9 @@ import { MarketState } from '@vegaprotocol/types';
 import { mockTradingPage } from '../support/trading';
 
 beforeEach(() => {
-  mockTradingPage(MarketState.Active);
+  cy.mockGQL((req) => {
+    mockTradingPage(req, MarketState.Active);
+  });
   cy.visit('/markets/market-0');
 });
 

--- a/apps/trading-e2e/src/integration/withdraw.ts
+++ b/apps/trading-e2e/src/integration/withdraw.ts
@@ -1,4 +1,4 @@
-import { hasOperationName } from '../support';
+import { aliasQuery } from '@vegaprotocol/cypress';
 import { connectEthereumWallet } from '../support/ethereum-wallet';
 import { generateWithdrawPageQuery } from '../support/mocks/generate-withdraw-page-query';
 import { connectVegaWallet } from '../support/vega-wallet';
@@ -13,12 +13,8 @@ describe('withdraw', () => {
 
   beforeEach(() => {
     cy.mockWeb3Provider();
-    cy.mockGQL('WithdrawPageQuery', (req) => {
-      if (hasOperationName(req, 'WithdrawPageQuery')) {
-        req.reply({
-          body: { data: generateWithdrawPageQuery() },
-        });
-      }
+    cy.mockGQL((req) => {
+      aliasQuery(req, 'WithdrawPageQuery', generateWithdrawPageQuery());
     });
     cy.visit('/portfolio/withdraw');
 

--- a/apps/trading-e2e/src/integration/withdrawals.ts
+++ b/apps/trading-e2e/src/integration/withdrawals.ts
@@ -1,4 +1,4 @@
-import { hasOperationName } from '../support';
+import { aliasQuery } from '@vegaprotocol/cypress';
 import { connectEthereumWallet } from '../support/ethereum-wallet';
 import { generateWithdrawals } from '../support/mocks/generate-withdrawals';
 import { connectVegaWallet } from '../support/vega-wallet';
@@ -6,12 +6,8 @@ import { connectVegaWallet } from '../support/vega-wallet';
 describe('withdrawals', () => {
   beforeEach(() => {
     cy.mockWeb3Provider();
-    cy.mockGQL('Withdrawals', (req) => {
-      if (hasOperationName(req, 'Withdrawals')) {
-        req.reply({
-          body: { data: generateWithdrawals() },
-        });
-      }
+    cy.mockGQL((req) => {
+      aliasQuery(req, 'Withdrawals', generateWithdrawals());
     });
     cy.visit('/portfolio/withdrawals');
 

--- a/apps/trading-e2e/src/support/index.ts
+++ b/apps/trading-e2e/src/support/index.ts
@@ -1,11 +1,1 @@
 import '@vegaprotocol/cypress';
-import type { CyHttpMessages } from 'cypress/types/net-stubbing';
-
-// Utility to match GraphQL mutation based on the operation name
-export const hasOperationName = (
-  req: CyHttpMessages.IncomingHttpRequest,
-  operationName: string
-) => {
-  const { body } = req;
-  return 'operationName' in body && body.operationName === operationName;
-};

--- a/apps/trading-e2e/src/support/trading.ts
+++ b/apps/trading-e2e/src/support/trading.ts
@@ -1,5 +1,6 @@
+import { aliasQuery } from '@vegaprotocol/cypress';
 import type { MarketState } from '@vegaprotocol/types';
-import { hasOperationName } from '.';
+import type { CyHttpMessages } from 'cypress/types/net-stubbing';
 import { generateAccounts } from './mocks/generate-accounts';
 import { generateCandles } from './mocks/generate-candles';
 import { generateChart } from './mocks/generate-chart';
@@ -9,62 +10,28 @@ import { generateOrders } from './mocks/generate-orders';
 import { generatePositions } from './mocks/generate-positions';
 import { generateTrades } from './mocks/generate-trades';
 
-export const mockTradingPage = (state: MarketState) => {
-  cy.mockGQL('Market', (req) => {
-    if (hasOperationName(req, 'Market')) {
-      req.reply({
-        body: {
-          data: generateMarket({
-            market: {
-              name: `${state.toUpperCase()} MARKET`,
-            },
-          }),
-        },
-      });
-    }
-
-    if (hasOperationName(req, 'Orders')) {
-      req.reply({
-        body: { data: generateOrders() },
-      });
-    }
-
-    if (hasOperationName(req, 'Accounts')) {
-      req.reply({
-        body: {
-          data: generateAccounts(),
-        },
-      });
-    }
-
-    if (hasOperationName(req, 'Positions')) {
-      req.reply({
-        body: { data: generatePositions() },
-      });
-    }
-
-    if (hasOperationName(req, 'DealTicketQuery')) {
-      req.reply({
-        body: { data: generateDealTicketQuery({ market: { state } }) },
-      });
-    }
-
-    if (hasOperationName(req, 'Trades')) {
-      req.reply({
-        body: { data: generateTrades() },
-      });
-    }
-
-    if (hasOperationName(req, 'Chart')) {
-      req.reply({
-        body: { data: generateChart() },
-      });
-    }
-
-    if (hasOperationName(req, 'Candles')) {
-      req.reply({
-        body: { data: generateCandles() },
-      });
-    }
-  });
+export const mockTradingPage = (
+  req: CyHttpMessages.IncomingHttpRequest,
+  state: MarketState
+) => {
+  aliasQuery(
+    req,
+    'Market',
+    generateMarket({
+      market: {
+        name: `${state.toUpperCase()} MARKET`,
+      },
+    })
+  );
+  aliasQuery(req, 'Orders', generateOrders());
+  aliasQuery(req, 'Accounts', generateAccounts());
+  aliasQuery(req, 'Positions', generatePositions());
+  aliasQuery(
+    req,
+    'DealTicketQuery',
+    generateDealTicketQuery({ market: { state } })
+  );
+  aliasQuery(req, 'Trades', generateTrades());
+  aliasQuery(req, 'Chart', generateChart());
+  aliasQuery(req, 'Candles', generateCandles());
 };

--- a/libs/cypress/src/index.ts
+++ b/libs/cypress/src/index.ts
@@ -9,3 +9,5 @@ addSlackCommand();
 addMockGQLCommand();
 addMockVegaWalletCommands();
 addMockWeb3ProviderCommand();
+
+export * from './lib/graphql-test-utils';

--- a/libs/cypress/src/lib/commands/mock-gql.ts
+++ b/libs/cypress/src/lib/commands/mock-gql.ts
@@ -5,15 +5,15 @@ declare global {
   namespace Cypress {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Chainable<Subject> {
-      mockGQL(alias: string, handler: RouteHandler): void;
+      mockGQL(handler: RouteHandler): void;
     }
   }
 }
 
 export function addMockGQLCommand() {
-  Cypress.Commands.add('mockGQL', (alias: string, handler: RouteHandler) => {
+  Cypress.Commands.add('mockGQL', (handler: RouteHandler) => {
     cy.intercept('POST', 'https://lb.testnet.vega.xyz/query', handler).as(
-      alias
+      'GQL'
     );
   });
 }

--- a/libs/cypress/src/lib/graphql-test-utils.ts
+++ b/libs/cypress/src/lib/graphql-test-utils.ts
@@ -1,0 +1,26 @@
+import type { CyHttpMessages } from 'cypress/types/net-stubbing';
+
+export const hasOperationName = (
+  req: CyHttpMessages.IncomingHttpRequest,
+  operationName: string
+) => {
+  const { body } = req;
+  return 'operationName' in body && body.operationName === operationName;
+};
+
+// Alias query if operationName matches
+export const aliasQuery = (
+  req: CyHttpMessages.IncomingHttpRequest,
+  operationName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any
+) => {
+  if (hasOperationName(req, operationName)) {
+    req.alias = operationName;
+    if (data !== undefined) {
+      req.reply((res) => {
+        res.body.data = data;
+      });
+    }
+  }
+};


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

This PR improves gql mocks for the trading app and should also fix a flakey test on the home page.

# Technical 👨‍🔧

I believe the flakeyness is due to multiple overlapping cy.intercept calls with the same alias. This PR gives each specific query its own alias and converts the tests to use only a single intercept call for all queries. This also tidies up Cypress's output.
