### PR TITLE
Fix/Trading grid layout fixes

### DIFF
--- a/apps/trading-e2e/src/integration/home.ts
+++ b/apps/trading-e2e/src/integration/home.ts
@@ -39,8 +39,6 @@ describe('home', () => {
     });
 
     it('redirects to a default market with the landing dialog open', () => {
-      cy.url().should('include', `/markets/${oldestMarket.id}`); // Should redirect to oldest market
-
       // Overlay should be shown
       cy.getByTestId(selectMarketOverlay).should('exist');
       cy.contains('Select a market to get started').should('be.visible');

--- a/apps/trading-e2e/src/integration/home.ts
+++ b/apps/trading-e2e/src/integration/home.ts
@@ -39,6 +39,8 @@ describe('home', () => {
     });
 
     it('redirects to a default market with the landing dialog open', () => {
+      cy.url().should('include', `/markets/${oldestMarket.id}`); // Should redirect to oldest market
+
       // Overlay should be shown
       cy.getByTestId(selectMarketOverlay).should('exist');
       cy.contains('Select a market to get started').should('be.visible');

--- a/apps/trading-e2e/src/integration/home.ts
+++ b/apps/trading-e2e/src/integration/home.ts
@@ -36,7 +36,6 @@ describe('home', () => {
 
       cy.get('main[data-testid="market"]').should('exist'); // Wait for page to be rendered to before checking url
       cy.url().should('include', `/markets/${oldestMarket.id}`); // Should redirect to oldest market
-      cy.wait('@MarketList');
     });
 
     it('redirects to a default market with the landing dialog open', () => {

--- a/apps/trading-e2e/src/integration/home.ts
+++ b/apps/trading-e2e/src/integration/home.ts
@@ -36,6 +36,7 @@ describe('home', () => {
 
       cy.get('main[data-testid="market"]').should('exist'); // Wait for page to be rendered to before checking url
       cy.url().should('include', `/markets/${oldestMarket.id}`); // Should redirect to oldest market
+      cy.wait('@MarketList');
     });
 
     it('redirects to a default market with the landing dialog open', () => {

--- a/apps/trading-e2e/src/support/mocks/generate-withdrawals.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-withdrawals.ts
@@ -15,8 +15,8 @@ export const generateWithdrawals = (
           status: WithdrawalStatus.Finalized,
           amount: '100',
           txHash: null,
-          createdTimestamp: new Date().toISOString(),
-          withdrawnTimestamp: new Date().toISOString(),
+          createdTimestamp: new Date('2022-02-02').toISOString(),
+          withdrawnTimestamp: new Date('2022-02-02').toISOString(),
           details: {
             __typename: 'Erc20WithdrawalDetails',
             receiverAddress: '0x72c22822A19D20DE7e426fB84aa047399Ddd8853',
@@ -35,8 +35,8 @@ export const generateWithdrawals = (
           amount: '100',
           txHash:
             '0x5d7b1a35ba6bd23be17bb7a159c13cdbb3121fceb94e9c6c510f5503dce48d03',
-          createdTimestamp: new Date().toISOString(),
-          withdrawnTimestamp: new Date().toISOString(),
+          createdTimestamp: new Date('2022-02-01').toISOString(),
+          withdrawnTimestamp: new Date('2022-02-01').toISOString(),
           details: {
             __typename: 'Erc20WithdrawalDetails',
             receiverAddress: '0x72c22822A19D20DE7e426fB84aa047399Ddd8853',

--- a/apps/trading/pages/markets/trade-grid.tsx
+++ b/apps/trading/pages/markets/trade-grid.tsx
@@ -34,11 +34,15 @@ const TradingViews = {
 
 type TradingView = keyof typeof TradingViews;
 
-interface TradeGridProps {
+interface TradeMarketHeaderProps {
   market: Market_market;
+  className?: string;
 }
 
-export const TradeMarketHeader = ({ market }: TradeGridProps) => {
+export const TradeMarketHeader = ({
+  market,
+  className,
+}: TradeMarketHeaderProps) => {
   const [open, setOpen] = useState(false);
   const candlesClose: string[] = (market?.candles || [])
     .map((candle) => candle?.close)
@@ -48,8 +52,12 @@ export const TradeMarketHeader = ({ market }: TradeGridProps) => {
     'font-sans font-normal mb-0 text-dark/80 dark:text-white/80 text-ui-small';
   const itemValueClassName =
     'capitalize font-sans tracking-tighter text-black dark:text-white text-ui';
+  const headerClassname = classNames(
+    'w-full p-8 bg-white dark:bg-black',
+    className
+  );
   return (
-    <header className="w-full p-8">
+    <header className={headerClassname}>
       <SelectMarketDialog dialogOpen={open} setDialogOpen={setOpen} />
       <div className="flex flex-col md:flex-row gap-20 md:gap-64 ml-auto mr-8">
         <button
@@ -90,19 +98,26 @@ export const TradeMarketHeader = ({ market }: TradeGridProps) => {
   );
 };
 
+interface TradeGridProps {
+  market: Market_market;
+}
+
 export const TradeGrid = ({ market }: TradeGridProps) => {
   const wrapperClasses = classNames(
     'h-full max-h-full',
-    'grid gap-[1px] grid-cols-[1fr_375px_460px] grid-rows-[min-content_1fr_200px]',
+    'grid gap-4 grid-cols-[1fr_375px_460px] grid-rows-[min-content_1fr_200px]',
     'bg-black-10 dark:bg-white-10',
     'text-ui'
   );
 
   return (
     <>
-      <TradeMarketHeader market={market} />
       <div className={wrapperClasses}>
-        <TradeGridChild className="row-start-1 row-end-3">
+        <TradeMarketHeader
+          market={market}
+          className="row-start-1 row-end-2 col-start-1 col-end-2"
+        />
+        <TradeGridChild className="row-start-2 row-end-3 col-start-1 col-end-2">
           <GridTabs>
             <GridTab id="candles" name={t('Candles')}>
               <TradingViews.Candles marketId={market.id} />

--- a/libs/ui-toolkit/src/components/grid-tabs/grid-tabs.tsx
+++ b/libs/ui-toolkit/src/components/grid-tabs/grid-tabs.tsx
@@ -18,31 +18,32 @@ export const GridTabs = ({ children }: GridTabsProps) => {
       className="h-full grid grid-rows-[min-content_1fr]"
       onValueChange={(value) => setActiveTab(value)}
     >
-      <Tabs.List
-        className="flex flex-nowrap gap-4 overflow-x-auto"
-        role="tablist"
-      >
-        {Children.map(children, (child) => {
-          if (!isValidElement(child)) return null;
-          const isActive = child.props.id === activeTab;
-          const triggerClass = classNames('py-4', 'px-12', 'capitalize', {
-            'text-black dark:text-vega-yellow': isActive,
-            'bg-white dark:bg-black': isActive,
-            'text-black dark:text-white': !isActive,
-            'bg-black-10 dark:bg-white-25': !isActive,
-          });
-          return (
-            <Tabs.Trigger
-              data-testid={child.props.name}
-              value={child.props.id}
-              className={triggerClass}
-            >
-              {child.props.name}
-            </Tabs.Trigger>
-          );
-        })}
-        <div className="bg-black-10 dark:bg-white-25 grow"></div>
-      </Tabs.List>
+      <div className="bg-black-10 dark:bg-white-10">
+        <Tabs.List
+          className="flex flex-nowrap gap-4 overflow-x-auto"
+          role="tablist"
+        >
+          {Children.map(children, (child) => {
+            if (!isValidElement(child)) return null;
+            const isActive = child.props.id === activeTab;
+            const triggerClass = classNames('py-4', 'px-12', 'capitalize', {
+              'text-black dark:text-vega-yellow': isActive,
+              'bg-white dark:bg-black': isActive,
+              'text-black-60 dark:text-white-60': !isActive,
+              'bg-black-10 dark:bg-white-10': !isActive,
+            });
+            return (
+              <Tabs.Trigger
+                data-testid={child.props.name}
+                value={child.props.id}
+                className={triggerClass}
+              >
+                {child.props.name}
+              </Tabs.Trigger>
+            );
+          })}
+        </Tabs.List>
+      </div>
       <div className="h-full overflow-auto">
         {Children.map(children, (child) => {
           if (!isValidElement(child)) return null;


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

This PR fixes the layout of the trade grid which was creating double scrollbars on the right hand side of the page. It also adjusts the colors and layout of the grid tabs slightly

# Demo 📺

Before:
Notice the scroll bars and the tabs not really looking like tabs:
<img width="1800" alt="Screen Shot 2022-06-16 at 3 41 01 PM" src="https://user-images.githubusercontent.com/6803987/174190196-bce10b94-d8dc-4798-9e05-98c43be1d668.png">

After:
<img width="1800" alt="Screen Shot 2022-06-16 at 3 36 38 PM" src="https://user-images.githubusercontent.com/6803987/174190231-66e23afb-2bac-4601-8059-1dca76f39d6b.png">

Dark mode:
<img width="1800" alt="Screen Shot 2022-06-16 at 3 36 48 PM" src="https://user-images.githubusercontent.com/6803987/174190240-66cf79e3-bb5a-49e8-a181-9c051f872e41.png">


# Technical 👨‍🔧

Nothing complicated here just some classes to adjust the positing of the header in the grid and some spacing and color changes.
