### PR TITLE
frontend-monorepo-607: Added correct text colours to intent backgrounds

### DIFF
--- a/libs/ui-toolkit/src/utils/intent.tsx
+++ b/libs/ui-toolkit/src/utils/intent.tsx
@@ -19,7 +19,8 @@ export const getIntentShadow = (intent?: Intent) => {
 
 export const getVariantBackground = (variant?: Intent) => {
   return {
-    'bg-black dark:bg-white': variant === Intent.None,
+    'bg-black text-white dark:bg-white dark:text-black':
+      variant === Intent.None,
     'bg-vega-pink text-black dark:bg-vega-yellow dark:text-black-normal':
       variant === Intent.Primary,
     'bg-danger text-white': variant === Intent.Danger,


### PR DESCRIPTION
# Related issues 🔗

Closes #607 

# Description ℹ️

A change to the way intents were set up created an oversight with text colours on different backgrounds. This PR simply adds the correct text colours to be visible on white and black backgrounds respectively

# Demo 📺

![Screenshot 2022-06-22 at 12 04 38](https://user-images.githubusercontent.com/2410498/175014156-04ed7c47-bb5c-4cab-aa87-94d0160245f7.png)
![Screenshot 2022-06-22 at 12 04 30](https://user-images.githubusercontent.com/2410498/175014164-0c6f375e-3494-40aa-af13-82d118707fb3.png)

