### PR TITLE
frontend-monorepo-567: Ensure menu sits above other content when open on mobile

### DIFF
--- a/apps/explorer/src/app/components/nav/index.tsx
+++ b/apps/explorer/src/app/components/nav/index.tsx
@@ -11,7 +11,7 @@ export const Nav = ({ menuOpen }: NavProps) => {
       <div
         className={`${
           menuOpen ? 'right-0 h-[100vh]' : 'right-[200vw] h-full'
-        } transition-[right] absolute top-0 w-full md:static md:border-r-1 bg-white dark:bg-black p-20`}
+        } transition-[right] absolute top-0 w-full md:static md:border-r-1 bg-white dark:bg-black p-20 z-50`}
       >
         {routerConfig.map((r) => (
           <NavLink


### PR DESCRIPTION
# Related issues 🔗

Closes #567 

# Description ℹ️

Ensure the open mobile menu on explorer is always visible on top of any other content.

# Technical 👨‍🔧
Until now, the mobile menu was absolutely positioned, without a z-index. This was fine until other positioned elements were used. To ensure the menu is above other components I've given it a higher z-index than other components in the explorer app or from the ui-toolkit.
