### PR TITLE
chore: workaround for #641 - ignoreErrors on governance page

### DIFF
--- a/apps/token/src/routes/governance/proposals/proposals-container.tsx
+++ b/apps/token/src/routes/governance/proposals/proposals-container.tsx
@@ -24,7 +24,7 @@ export const ProposalsContainer = () => {
   const { t } = useTranslation();
   const { data, loading, error } = useQuery<Proposals, never>(PROPOSALS_QUERY, {
     pollInterval: 5000,
-    errorPolicy: 'ignore',
+    errorPolicy: 'ignore', // this is to get around some backend issues and should be removed in future
   });
 
   const proposals = React.useMemo(() => {

--- a/apps/token/src/routes/governance/proposals/proposals-container.tsx
+++ b/apps/token/src/routes/governance/proposals/proposals-container.tsx
@@ -24,6 +24,7 @@ export const ProposalsContainer = () => {
   const { t } = useTranslation();
   const { data, loading, error } = useQuery<Proposals, never>(PROPOSALS_QUERY, {
     pollInterval: 5000,
+    errorPolicy: 'ignore',
   });
 
   const proposals = React.useMemo(() => {


### PR DESCRIPTION
# Related issues 🔗

Workaround for #641, ignores request errors, which allows us to render the page again

# Description ℹ️

Due to an API issue in the GraphQL API, the proposals request contains an error if a market update proposal is rejected
because the proposer had insufficient stake. This errorPolicy change allows the page to render again, which is more
useful.

This should be reverted when https://github.com/vegaprotocol/data-node/issues/740 is fixed
