### PR TITLE
Fix/652: Broken lozenge dark mode text class

### DIFF
--- a/libs/ui-toolkit/src/utils/intent.tsx
+++ b/libs/ui-toolkit/src/utils/intent.tsx
@@ -30,7 +30,7 @@ export const getIntentBorder = (intent = Intent.None) => {
 
 export const getIntentTextAndBackground = (intent = Intent.None) => {
   return {
-    'bg-black text-white dark:bg-white text-black': intent === Intent.None,
+    'bg-black text-white dark:bg-white dark:text-black': intent === Intent.None,
     'bg-vega-pink text-black dark:bg-vega-yellow dark:text-black-normal':
       intent === Intent.Primary,
     'bg-danger text-white': intent === Intent.Danger,


### PR DESCRIPTION
# Related issues 🔗

Closes #652

# Description ℹ️

The lozenge colours were broken through a merge conflict resolution. We needed dark text added onto the default intent for a lozenge (because it has a white background on dark mode)

# Demo 📺

![Screenshot 2022-06-27 at 16 38 41](https://user-images.githubusercontent.com/2410498/175979113-ee86df6a-e92b-449e-a356-631208fb6595.png)

