### PR TITLE
Fix/trading e2e

### DIFF
--- a/apps/simple-trading-app-e2e/src/integration/market-list.test.ts
+++ b/apps/simple-trading-app-e2e/src/integration/market-list.test.ts
@@ -60,7 +60,7 @@ describe('market list', () => {
       cy.intercept('POST', '/query').as('Filters');
       cy.visit('/markets');
       cy.wait('@Filters').then((filters) => {
-        if (filters?.response?.body.data.markets.length) {
+        if (filters?.response?.body?.data?.markets?.length) {
           const asset =
             filters.response.body.data.markets[0].tradableInstrument.instrument
               .product.settlementAsset.symbol;

--- a/apps/trading-e2e/.cypress-cucumber-preprocessorrc
+++ b/apps/trading-e2e/.cypress-cucumber-preprocessorrc
@@ -1,3 +1,0 @@
-{
-    "stepDefinitions": "src/support/step_definitions"
-}

--- a/libs/cypress/src/lib/graphql-test-utils.ts
+++ b/libs/cypress/src/lib/graphql-test-utils.ts
@@ -18,8 +18,9 @@ export const aliasQuery = (
   if (hasOperationName(req, operationName)) {
     req.alias = operationName;
     if (data !== undefined) {
-      req.reply((res) => {
-        res.body.data = data;
+      req.reply({
+        statusCode: 200,
+        body: { data },
       });
     }
   }


### PR DESCRIPTION
# Related issues 🔗
N/A

# Description ℹ️

Fixes trading tests

# Technical 👨‍🔧

Cypress v10 broke mocking. Tried to get cypress v10 to be able to import generate functions from their respective libs but no joy. I've moved helper functions to libs/cypress for better re-usability (now other e2e apps can import them) though you can't import into another lib due to circular deps if using types from said lib
