### PR TITLE
Fix/678: Text colour for syntax highlighter light theme

### DIFF
--- a/libs/tailwindcss-config/src/vega-custom-classes.js
+++ b/libs/tailwindcss-config/src/vega-custom-classes.js
@@ -13,7 +13,7 @@ const vegaCustomClasses = plugin(function ({ addUtilities }) {
       overflowX: 'auto',
       padding: '1em',
       background: theme.colors.white.DEFAULT,
-      color: theme.colors.black[25],
+      color: theme.colors.black[70],
       border: `1px solid #${theme.colors.black[40]}`,
     },
     '.dark .syntax-highlighter-wrapper .hljs': {


### PR DESCRIPTION
# Related issues 🔗

Closes #678

This:

<img width="852" alt="Screenshot 2022-06-29 at 16 38 29" src="https://user-images.githubusercontent.com/2410498/176478076-84333fd9-2292-4749-8830-d88a9d400799.png">

becomes:

<img width="898" alt="Screenshot 2022-06-29 at 16 39 02" src="https://user-images.githubusercontent.com/2410498/176478106-7df254c9-8103-482e-a6f3-3271d86ee21e.png">


