### PR TITLE
Feat/680: Bring explorer nav colours in line with light theme

### DIFF
--- a/apps/explorer/src/app/components/nav/index.tsx
+++ b/apps/explorer/src/app/components/nav/index.tsx
@@ -28,9 +28,10 @@ export const Nav = ({ menuOpen }: NavProps) => {
             className={({ isActive }) =>
               classnames(
                 'block mb-8 px-8',
-                'text-h5 hover:bg-vega-yellow hover:text-black',
+                'text-h5 hover:bg-vega-pink dark:hover:bg-vega-yellow hover:text-white dark:hover:text-black',
                 {
-                  'bg-vega-yellow text-black': isActive,
+                  'bg-vega-pink text-white dark:bg-vega-yellow dark:text-black':
+                    isActive,
                 }
               )
             }


### PR DESCRIPTION
# Related issues 🔗

Closes #680

This:
![Screenshot 2022-06-29 at 16 25 10](https://user-images.githubusercontent.com/2410498/176481163-df6ed09c-0a69-4515-99bf-4d39e6554ab2.png)

becomes:
<img width="988" alt="Screenshot 2022-06-29 at 16 54 04" src="https://user-images.githubusercontent.com/2410498/176481305-5688675d-9df1-4e50-a165-4c62fa03a4a3.png">

