### PR TITLE
frontend-monorepo-684: Txs list item dialog close button fixed

### DIFF
--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
@@ -56,14 +56,14 @@ export const TxsInfiniteListItem = ({
           data-testid="command-details"
         >
           <Icon name="search-template" />
-          <Dialog
-            open={open}
-            onChange={(isOpen) => setOpen(isOpen)}
-            intent={Intent.None}
-          >
-            <SyntaxHighlighter data={JSON.parse(Command)} />
-          </Dialog>
         </button>
+        <Dialog
+          open={open}
+          onChange={(isOpen) => setOpen(false)}
+          intent={Intent.None}
+        >
+          <SyntaxHighlighter data={JSON.parse(Command)} />
+        </Dialog>
       </div>
     </div>
   );


### PR DESCRIPTION
# Related issues 🔗

Closes #684

# Description ℹ️

Fixed an issue where a transaction details item dialog wouldn't close when you clicked the close button.
The other part of the ticket 684 described a colour problem in dark mode on the txs list, this appears to be a browser bug and couldn't be replicated on my machine or Dex's, but could on Joe and Rado's. Concerning, but not something I was able to fix so this ticket can be closed for now.
