### PR TITLE
fix: etherscan links not opening in new tabs sometimes

### DIFF
--- a/apps/token/src/routes/contracts/index.tsx
+++ b/apps/token/src/routes/contracts/index.tsx
@@ -42,6 +42,7 @@ const Contracts = () => {
             <Link
               title={t('View address on Etherscan')}
               href={`${ETHERSCAN_URL}/address/${contract.address}`}
+              target="_blank"
             >
               {contract.address}
             </Link>
@@ -57,6 +58,7 @@ const Contracts = () => {
           <Link
             title={t('View address on Etherscan')}
             href={`${ETHERSCAN_URL}/address/${value}`}
+            target="_blank"
           >
             {value}
           </Link>

--- a/apps/token/src/routes/home/token-details/token-details.tsx
+++ b/apps/token/src/routes/home/token-details/token-details.tsx
@@ -50,6 +50,7 @@ export const TokenDetails = ({
           title={t('View on Etherscan (opens in a new tab)')}
           className="font-mono text-white text-right"
           href={`${ETHERSCAN_URL}/address/${token.address}`}
+          target="_blank"
         >
           {token.address}
         </Link>
@@ -61,6 +62,7 @@ export const TokenDetails = ({
           title={t('View on Etherscan (opens in a new tab)')}
           className="font-mono text-white text-right"
           href={`${ETHERSCAN_URL}/address/${config.token_vesting_contract.address}`}
+          target="_blank"
         >
           {config.token_vesting_contract.address}
         </Link>

--- a/libs/web3/src/lib/transaction-dialog/dialog-rows.tsx
+++ b/libs/web3/src/lib/transaction-dialog/dialog-rows.tsx
@@ -46,6 +46,7 @@ export const TxRow = ({
           href={`${ETHERSCAN_URL}/tx/${txHash}`}
           title={t('View transaction on Etherscan')}
           className="text-vega-pink dark:text-vega-yellow"
+          target="_blank"
         >
           {t('View on Etherscan')}
         </Link>
@@ -65,6 +66,7 @@ export const TxRow = ({
           href={`${ETHERSCAN_URL}/tx/${txHash}`}
           title={t('View on Etherscan')}
           className="text-vega-pink dark:text-vega-yellow"
+          target="_blank"
         >
           {t('View transaction on Etherscan')}
         </Link>


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Noticed Etherscan links were opening in same tab and not new tabs. Fix this.