### PR TITLE
fix: dodgey poposals should not crash the governance page on exlporer

### DIFF
--- a/apps/explorer/src/app/routes/governance/index.tsx
+++ b/apps/explorer/src/app/routes/governance/index.tsx
@@ -101,7 +101,9 @@ const PROPOSAL_QUERY = gql`
 `;
 
 const Governance = () => {
-  const { data } = useQuery<ProposalsQuery>(PROPOSAL_QUERY);
+  const { data } = useQuery<ProposalsQuery>(PROPOSAL_QUERY, {
+    errorPolicy: 'ignore',
+  });
 
   if (!data) return null;
   return (


### PR DESCRIPTION
# Related issues 🔗

N/A noticed in UX x function and fixing it quickly

# Description ℹ️

Data node has something sideways and protobuf deserialisation does not appear to be working correctly. This should not bomb out the whole page when a single proposal is borked.