### PR TITLE
test: changing config to prevent successful test videos from compress…

### DIFF
--- a/apps/explorer-e2e/cypress.config.js
+++ b/apps/explorer-e2e/cypress.config.js
@@ -14,6 +14,7 @@ module.exports = defineConfig({
     modifyObstructiveCode: false,
     supportFile: './src/support/index.ts',
     video: true,
+    videoUploadOnPasses: false,
     videosFolder: '../../dist/cypress/apps/explorer-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/explorer-e2e/screenshots',
     chromeWebSecurity: false,

--- a/apps/simple-trading-app-e2e/cypress.config.js
+++ b/apps/simple-trading-app-e2e/cypress.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
     modifyObstructiveCode: false,
     supportFile: './src/support/index.ts',
     video: true,
+    videoUploadOnPasses: false,
     videosFolder: '../../dist/cypress/apps/explorer-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/explorer-e2e/screenshots',
     chromeWebSecurity: false,

--- a/apps/stats-e2e/cypress.config.js
+++ b/apps/stats-e2e/cypress.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
     modifyObstructiveCode: false,
     supportFile: './src/support/index.ts',
     video: true,
+    videoUploadOnPasses: false,
     videosFolder: '../../dist/cypress/apps/explorer-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/explorer-e2e/screenshots',
     chromeWebSecurity: false,

--- a/apps/token-e2e/cypress.config.js
+++ b/apps/token-e2e/cypress.config.js
@@ -10,6 +10,7 @@ module.exports = defineConfig({
     modifyObstructiveCode: false,
     supportFile: './src/support/index.ts',
     video: true,
+    videoUploadOnPasses: false,
     videosFolder: '../../dist/cypress/apps/explorer-e2e/videos',
     screenshotsFolder: '../../dist/cypress/apps/explorer-e2e/screenshots',
     chromeWebSecurity: false,

--- a/apps/trading-e2e/cypress.config.js
+++ b/apps/trading-e2e/cypress.config.js
@@ -22,6 +22,7 @@ module.exports = defineConfig({
     supportFile: './src/support/index.ts',
     video: true,
     videosFolder: '../../dist/cypress/apps/trading-e2e/videos',
+    videoUploadOnPasses: false,
     screenshotsFolder: '../../dist/cypress/apps/trading-e2e/screenshots',
     chromeWebSecurity: false,
     projectId: 'et4snf',


### PR DESCRIPTION
… and uploading

# Related issues 🔗

Closes #[Issue number here]

# Description ℹ️

Just a simple cypress config change to prevent videos from compressing and uploading if the tests have passed.
e2e tests can take some time and those big vids are slowing down the test cycle

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
