### PR TITLE
fix: remove redundant env settings from explorer

### DIFF
--- a/apps/explorer/webpack.config.js
+++ b/apps/explorer/webpack.config.js
@@ -1,12 +1,4 @@
-const { execSync } = require('child_process');
-const webpack = require('webpack');
 const SentryPlugin = require('@sentry/webpack-plugin');
-
-const gitCommitHash = execSync('git rev-parse HEAD').toString();
-const gitOriginUrl = execSync('git remote get-url origin')
-  .toString()
-  .replace('ssh://git@github.com', 'https://github.com')
-  .replace('.git', '');
 
 module.exports = (config, context) => {
   const additionalPlugins = process.env.SENTRY_AUTH_TOKEN
@@ -23,10 +15,6 @@ module.exports = (config, context) => {
     plugins: [
       ...additionalPlugins,
       ...config.plugins,
-      new webpack.DefinePlugin({
-        'process.env.GIT_COMMIT_HASH': JSON.stringify(gitCommitHash),
-        'process.env.GIT_ORIGIN_URL': JSON.stringify(gitOriginUrl),
-      }),
     ],
   };
 };


### PR DESCRIPTION
Removing some redundant code which is breaking the netlify builds.