### PR TITLE
fix: rename tradesPaged to tradesConnection

### DIFF
--- a/apps/trading-e2e/src/integration/markets.cy.ts
+++ b/apps/trading-e2e/src/integration/markets.cy.ts
@@ -69,7 +69,6 @@ describe('markets table', () => {
     cy.get('[role="gridcell"][col-id=data]').contains('Active').click();
 
     cy.wait('@Market');
-    cy.get('.ag-root-wrapper').should('be.visible');
     cy.contains('ACTIVE MARKET');
     cy.url().should('include', '/markets/market-0');
 

--- a/apps/trading-e2e/src/integration/portfolio-fills.cy.ts
+++ b/apps/trading-e2e/src/integration/portfolio-fills.cy.ts
@@ -46,7 +46,7 @@ describe('fills', () => {
     ];
     const result = generateFills({
       party: {
-        tradesPaged: {
+        tradesConnection: {
           edges: fills.map((f, i) => {
             return {
               __typename: 'TradeEdge',

--- a/apps/trading-e2e/src/support/mocks/generate-fills.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-fills.ts
@@ -2,6 +2,7 @@ import type {
   Fills,
   Fills_party_tradesConnection_edges_node,
 } from '@vegaprotocol/fills';
+import { Side } from '@vegaprotocol/types';
 import merge from 'lodash/merge';
 import type { PartialDeep } from 'type-fest';
 

--- a/apps/trading-e2e/src/support/mocks/generate-fills.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-fills.ts
@@ -1,13 +1,12 @@
 import type {
   Fills,
-  Fills_party_tradesPaged_edges_node,
+  Fills_party_tradesConnection_edges_node,
 } from '@vegaprotocol/fills';
-import { Side } from '@vegaprotocol/types';
 import merge from 'lodash/merge';
 import type { PartialDeep } from 'type-fest';
 
 export const generateFills = (override?: PartialDeep<Fills>): Fills => {
-  const fills: Fills_party_tradesPaged_edges_node[] = [
+  const fills: Fills_party_tradesConnection_edges_node[] = [
     generateFill({
       buyer: {
         id: Cypress.env('VEGA_PUBLIC_KEY'),
@@ -49,7 +48,7 @@ export const generateFills = (override?: PartialDeep<Fills>): Fills => {
   const defaultResult: Fills = {
     party: {
       id: 'buyer-id',
-      tradesPaged: {
+      tradesConnection: {
         __typename: 'TradeConnection',
         totalCount: 1,
         edges: fills.map((f) => {
@@ -73,9 +72,9 @@ export const generateFills = (override?: PartialDeep<Fills>): Fills => {
 };
 
 export const generateFill = (
-  override?: PartialDeep<Fills_party_tradesPaged_edges_node>
+  override?: PartialDeep<Fills_party_tradesConnection_edges_node>
 ) => {
-  const defaultFill: Fills_party_tradesPaged_edges_node = {
+  const defaultFill: Fills_party_tradesConnection_edges_node = {
     __typename: 'Trade',
     id: '0',
     createdAt: new Date().toISOString(),

--- a/apps/trading/.env
+++ b/apps/trading/.env
@@ -1,6 +1,5 @@
 # App configuration variables
 NX_VEGA_ENV=TESTNET
-NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/testnet-network.json
 NX_VEGA_URL=https://lb.testnet.vega.xyz/query
 NX_ETHEREUM_PROVIDER_URL=https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
 NX_ETHERSCAN_URL=https://ropsten.etherscan.io

--- a/apps/trading/.env.testnet
+++ b/apps/trading/.env.testnet
@@ -1,6 +1,5 @@
 # App configuration variables
 NX_VEGA_ENV=TESTNET
-NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/testnet-network.json
 NX_VEGA_URL=https://lb.testnet.vega.xyz/query
 NX_VEGA_NETWORKS='{\"MAINNET\":\"https://alpha.console.vega.xyz\"}'
 NX_ETHEREUM_PROVIDER_URL=https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8

--- a/libs/fills/src/lib/__generated__/Fills.ts
+++ b/libs/fills/src/lib/__generated__/Fills.ts
@@ -9,7 +9,7 @@ import { Pagination, Side } from "@vegaprotocol/types";
 // GraphQL query operation: Fills
 // ====================================================
 
-export interface Fills_party_tradesPaged_edges_node_buyer {
+export interface Fills_party_tradesConnection_edges_node_buyer {
   __typename: "Party";
   /**
    * Party identifier
@@ -17,7 +17,7 @@ export interface Fills_party_tradesPaged_edges_node_buyer {
   id: string;
 }
 
-export interface Fills_party_tradesPaged_edges_node_seller {
+export interface Fills_party_tradesConnection_edges_node_seller {
   __typename: "Party";
   /**
    * Party identifier
@@ -25,7 +25,7 @@ export interface Fills_party_tradesPaged_edges_node_seller {
   id: string;
 }
 
-export interface Fills_party_tradesPaged_edges_node_buyerFee {
+export interface Fills_party_tradesConnection_edges_node_buyerFee {
   __typename: "TradeFee";
   /**
    * The maker fee, aggressive party to the other party (the one who had an order in the book)
@@ -41,7 +41,7 @@ export interface Fills_party_tradesPaged_edges_node_buyerFee {
   liquidityFee: string;
 }
 
-export interface Fills_party_tradesPaged_edges_node_sellerFee {
+export interface Fills_party_tradesConnection_edges_node_sellerFee {
   __typename: "TradeFee";
   /**
    * The maker fee, aggressive party to the other party (the one who had an order in the book)
@@ -57,7 +57,7 @@ export interface Fills_party_tradesPaged_edges_node_sellerFee {
   liquidityFee: string;
 }
 
-export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument_product_settlementAsset {
+export interface Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument_product_settlementAsset {
   __typename: "Asset";
   /**
    * The id of the asset
@@ -73,15 +73,15 @@ export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument_in
   decimals: number;
 }
 
-export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument_product {
+export interface Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument_product {
   __typename: "Future";
   /**
    * The name of the asset (string)
    */
-  settlementAsset: Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument_product_settlementAsset;
+  settlementAsset: Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument_product_settlementAsset;
 }
 
-export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument {
+export interface Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument {
   __typename: "Instrument";
   /**
    * Uniquely identify an instrument across all instruments available on Vega (string)
@@ -94,18 +94,18 @@ export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument_in
   /**
    * A reference to or instance of a fully specified product, including all required product parameters for that product (Product union)
    */
-  product: Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument_product;
+  product: Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument_product;
 }
 
-export interface Fills_party_tradesPaged_edges_node_market_tradableInstrument {
+export interface Fills_party_tradesConnection_edges_node_market_tradableInstrument {
   __typename: "TradableInstrument";
   /**
    * An instance of or reference to a fully specified instrument.
    */
-  instrument: Fills_party_tradesPaged_edges_node_market_tradableInstrument_instrument;
+  instrument: Fills_party_tradesConnection_edges_node_market_tradableInstrument_instrument;
 }
 
-export interface Fills_party_tradesPaged_edges_node_market {
+export interface Fills_party_tradesConnection_edges_node_market {
   __typename: "Market";
   /**
    * Market ID
@@ -141,10 +141,10 @@ export interface Fills_party_tradesPaged_edges_node_market {
   /**
    * An instance of or reference to a tradable instrument.
    */
-  tradableInstrument: Fills_party_tradesPaged_edges_node_market_tradableInstrument;
+  tradableInstrument: Fills_party_tradesConnection_edges_node_market_tradableInstrument;
 }
 
-export interface Fills_party_tradesPaged_edges_node {
+export interface Fills_party_tradesConnection_edges_node {
   __typename: "Trade";
   /**
    * The hash of the trade data
@@ -177,38 +177,38 @@ export interface Fills_party_tradesPaged_edges_node {
   /**
    * The party that bought
    */
-  buyer: Fills_party_tradesPaged_edges_node_buyer;
+  buyer: Fills_party_tradesConnection_edges_node_buyer;
   /**
    * The party that sold
    */
-  seller: Fills_party_tradesPaged_edges_node_seller;
+  seller: Fills_party_tradesConnection_edges_node_seller;
   /**
    * The fee paid by the buyer side of the trade
    */
-  buyerFee: Fills_party_tradesPaged_edges_node_buyerFee;
+  buyerFee: Fills_party_tradesConnection_edges_node_buyerFee;
   /**
    * The fee paid by the seller side of the trade
    */
-  sellerFee: Fills_party_tradesPaged_edges_node_sellerFee;
+  sellerFee: Fills_party_tradesConnection_edges_node_sellerFee;
   /**
    * The market the trade occurred on
    */
-  market: Fills_party_tradesPaged_edges_node_market;
+  market: Fills_party_tradesConnection_edges_node_market;
 }
 
-export interface Fills_party_tradesPaged_edges {
+export interface Fills_party_tradesConnection_edges {
   __typename: "TradeEdge";
-  node: Fills_party_tradesPaged_edges_node;
+  node: Fills_party_tradesConnection_edges_node;
   cursor: string;
 }
 
-export interface Fills_party_tradesPaged_pageInfo {
+export interface Fills_party_tradesConnection_pageInfo {
   __typename: "PageInfo";
   startCursor: string;
   endCursor: string;
 }
 
-export interface Fills_party_tradesPaged {
+export interface Fills_party_tradesConnection {
   __typename: "TradeConnection";
   /**
    * The total number of trades in this connection
@@ -217,11 +217,11 @@ export interface Fills_party_tradesPaged {
   /**
    * The trade in this connection
    */
-  edges: Fills_party_tradesPaged_edges[];
+  edges: Fills_party_tradesConnection_edges[];
   /**
    * The pagination information
    */
-  pageInfo: Fills_party_tradesPaged_pageInfo;
+  pageInfo: Fills_party_tradesConnection_pageInfo;
 }
 
 export interface Fills_party {
@@ -230,7 +230,7 @@ export interface Fills_party {
    * Party identifier
    */
   id: string;
-  tradesPaged: Fills_party_tradesPaged;
+  tradesConnection: Fills_party_tradesConnection;
 }
 
 export interface Fills {

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -6,7 +6,7 @@ import { FillsTable } from './fills-table';
 import type { IGetRowsParams } from 'ag-grid-community';
 
 import { fillsDataProvider as dataProvider } from './fills-data-provider';
-import type { Fills_party_tradesPaged_edges } from './__generated__/Fills';
+import type { Fills_party_tradesConnection_edges } from './__generated__/Fills';
 import type { FillsSub_trades } from './__generated__/FillsSub';
 
 interface FillsManagerProps {
@@ -15,11 +15,11 @@ interface FillsManagerProps {
 
 export const FillsManager = ({ partyId }: FillsManagerProps) => {
   const gridRef = useRef<AgGridReact | null>(null);
-  const dataRef = useRef<Fills_party_tradesPaged_edges[] | null>(null);
+  const dataRef = useRef<Fills_party_tradesConnection_edges[] | null>(null);
   const totalCountRef = useRef<number | undefined>(undefined);
 
   const update = useCallback(
-    ({ data }: { data: Fills_party_tradesPaged_edges[] }) => {
+    ({ data }: { data: Fills_party_tradesConnection_edges[] }) => {
       if (!gridRef.current?.api) {
         return false;
       }
@@ -35,7 +35,7 @@ export const FillsManager = ({ partyId }: FillsManagerProps) => {
       data,
       totalCount,
     }: {
-      data: Fills_party_tradesPaged_edges[];
+      data: Fills_party_tradesConnection_edges[];
       totalCount?: number;
     }) => {
       dataRef.current = data;
@@ -48,7 +48,7 @@ export const FillsManager = ({ partyId }: FillsManagerProps) => {
   const variables = useMemo(() => ({ partyId }), [partyId]);
 
   const { data, error, loading, load, totalCount } = useDataProvider<
-    Fills_party_tradesPaged_edges[],
+    Fills_party_tradesConnection_edges[],
     FillsSub_trades[]
   >({ dataProvider, update, insert, variables });
   totalCountRef.current = totalCount;

--- a/libs/fills/src/lib/fills-table.stories.tsx
+++ b/libs/fills/src/lib/fills-table.stories.tsx
@@ -16,7 +16,7 @@ Default.args = {
   partyId: 'party-id',
   datasource: {
     getRows: makeGetRows(
-      fills.party?.tradesPaged.edges.map((e) => e.node) || []
+      fills.party?.tradesConnection.edges.map((e) => e.node) || []
     ),
   },
 };

--- a/libs/fills/src/lib/test-helpers.ts
+++ b/libs/fills/src/lib/test-helpers.ts
@@ -1,14 +1,14 @@
-import { Side } from '@vegaprotocol/types';
 import merge from 'lodash/merge';
 import type { IGetRowsParams } from 'ag-grid-community';
 import type { PartialDeep } from 'type-fest';
 import type {
   Fills,
-  Fills_party_tradesPaged_edges_node,
+  Fills_party_tradesConnection_edges_node,
 } from './__generated__/Fills';
+import { Side } from '@vegaprotocol/types';
 
 export const generateFills = (override?: PartialDeep<Fills>): Fills => {
-  const fills: Fills_party_tradesPaged_edges_node[] = [
+  const fills: Fills_party_tradesConnection_edges_node[] = [
     generateFill({
       buyer: {
         id: 'party-id',
@@ -50,7 +50,7 @@ export const generateFills = (override?: PartialDeep<Fills>): Fills => {
   const defaultResult: Fills = {
     party: {
       id: 'buyer-id',
-      tradesPaged: {
+      tradesConnection: {
         __typename: 'TradeConnection',
         totalCount: 1,
         edges: fills.map((f) => {
@@ -74,9 +74,9 @@ export const generateFills = (override?: PartialDeep<Fills>): Fills => {
 };
 
 export const generateFill = (
-  override?: PartialDeep<Fills_party_tradesPaged_edges_node>
+  override?: PartialDeep<Fills_party_tradesConnection_edges_node>
 ) => {
-  const defaultFill: Fills_party_tradesPaged_edges_node = {
+  const defaultFill: Fills_party_tradesConnection_edges_node = {
     __typename: 'Trade',
     id: '0',
     createdAt: new Date().toISOString(),
@@ -135,7 +135,7 @@ export const generateFill = (
 };
 
 export const makeGetRows =
-  (data: Fills_party_tradesPaged_edges_node[]) =>
+  (data: Fills_party_tradesConnection_edges_node[]) =>
   ({ successCallback }: IGetRowsParams) => {
     successCallback(data, data.length);
   };

--- a/libs/types/src/__generated__/globalTypes.ts
+++ b/libs/types/src/__generated__/globalTypes.ts
@@ -110,6 +110,7 @@ export enum MarketTradingMode {
   BatchAuction = "BatchAuction",
   Continuous = "Continuous",
   MonitoringAuction = "MonitoringAuction",
+  NoTrading = "NoTrading",
   OpeningAuction = "OpeningAuction",
 }
 
@@ -211,6 +212,7 @@ export enum ProposalRejectionReason {
   EnactTimeTooLate = "EnactTimeTooLate",
   EnactTimeTooSoon = "EnactTimeTooSoon",
   IncompatibleTimestamps = "IncompatibleTimestamps",
+  InsufficientEquityLikeShare = "InsufficientEquityLikeShare",
   InsufficientTokens = "InsufficientTokens",
   InvalidAsset = "InvalidAsset",
   InvalidAssetDetails = "InvalidAssetDetails",
@@ -218,6 +220,7 @@ export enum ProposalRejectionReason {
   InvalidFutureMaturityTimestamp = "InvalidFutureMaturityTimestamp",
   InvalidFutureProduct = "InvalidFutureProduct",
   InvalidInstrumentSecurity = "InvalidInstrumentSecurity",
+  InvalidMarket = "InvalidMarket",
   InvalidRiskParameter = "InvalidRiskParameter",
   InvalidShape = "InvalidShape",
   MajorityThresholdNotReached = "MajorityThresholdNotReached",
@@ -236,6 +239,8 @@ export enum ProposalRejectionReason {
   OpeningAuctionDurationTooSmall = "OpeningAuctionDurationTooSmall",
   ParticipationThresholdNotReached = "ParticipationThresholdNotReached",
   ProductMaturityIsPassed = "ProductMaturityIsPassed",
+  TooManyMarketDecimalPlaces = "TooManyMarketDecimalPlaces",
+  TooManyPriceMonitoringTriggers = "TooManyPriceMonitoringTriggers",
   UnsupportedProduct = "UnsupportedProduct",
   UnsupportedTradingMode = "UnsupportedTradingMode",
 }


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

This fixes the fills table

# Demo 📺

N/A

# Technical 👨‍🔧

Query changed from `tradesPaged` to `tradesConnection`. But also some needed to re-add some fields which got removed but are required to calculate various fields in the table. Namely the fee fields/agressor and settlementAsset
