### PR TITLE
chore: remove GOPROXY

### DIFF
--- a/.github/workflows/capsule-cypress-nightly.yml
+++ b/.github/workflows/capsule-cypress-nightly.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO111MODULE: 'on'
-      GOPROXY: ${{ secrets.GO_PROXY }}
     steps:
       #######
       ## Setup langs

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -14,7 +14,6 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     env:
       GO111MODULE: 'on'
-      GOPROXY: ${{ secrets.GO_PROXY }}
     steps:
       #######
       ## Setup langs


### PR DESCRIPTION
# Related issues 🔗

Part of https://github.com/vegaprotocol/devops-infra/issues/1426

# Description ℹ️

GOPROXY is no longer needed after we made repositories publicly available.

# Demo 📺

Checks in this PR

# Technical 👨‍🔧

Nothing extra
