### PR TITLE
feat(#297): use 40% opacity colors in white themed orderbook

### DIFF
--- a/libs/react-helpers/src/lib/grid/cumulative-vol-cell.tsx
+++ b/libs/react-helpers/src/lib/grid/cumulative-vol-cell.tsx
@@ -30,7 +30,7 @@ export const CumulativeVol = React.memo(
     const askBar = relativeAsk ? (
       <div
         data-testid="ask-bar"
-        className="absolute left-0 top-0"
+        className="absolute left-0 top-0 opacity-40 dark:opacity-100"
         style={{
           height: relativeBid && relativeAsk ? '50%' : '100%',
           width: `${relativeAsk}%`,
@@ -41,7 +41,7 @@ export const CumulativeVol = React.memo(
     const bidBar = relativeBid ? (
       <div
         data-testid="bid-bar"
-        className="absolute top-0 left-0"
+        className="absolute top-0 left-0 opacity-40 dark:opacity-100"
         style={{
           height: relativeBid && relativeAsk ? '50%' : '100%',
           top: relativeBid && relativeAsk ? '50%' : '0',

--- a/libs/react-helpers/src/lib/grid/vol-cell.tsx
+++ b/libs/react-helpers/src/lib/grid/vol-cell.tsx
@@ -30,10 +30,13 @@ export const Vol = React.memo(
     return (
       <div className="relative" data-testid={testId || 'vol'}>
         <div
-          className={classNames('h-full absolute top-0', {
-            'left-0': type === VolumeType.bid,
-            'right-0': type === VolumeType.ask,
-          })}
+          className={classNames(
+            'h-full absolute top-0 opacity-40 dark:opacity-100',
+            {
+              'left-0': type === VolumeType.bid,
+              'right-0': type === VolumeType.ask,
+            }
+          )}
           style={{
             width: relativeValue ? `${relativeValue}%` : '0%',
             backgroundColor: type === VolumeType.bid ? BID_COLOR : ASK_COLOR,


### PR DESCRIPTION
# Related issues 🔗

Closes #297

# Description ℹ️

Improve orderbook colours in light theme - make bars 40% opacity

