### PR TITLE
Chore/checkout capsule using tags

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -72,6 +72,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           GOBIN: ${{ env.GOBIN }}
 
+      - name: Checkout Vega
+        uses: actions/checkout@v2
+        with:
+          repository: vegaprotocol/vega
+          ref: develop
+          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+          path: './vega'
+
+      - name: Install binary from Vega repo
+        run: go install ./cmd/vega
+        working-directory: vega
+
       ######
       ## Start capsule
       ######

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress-nightly.yml
+++ b/.github/workflows/capsule-cypress-nightly.yml
@@ -56,6 +56,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           GOBIN: ${{ env.GOBIN }}
 
+      - name: Checkout Vega
+        uses: actions/checkout@v2
+        with:
+          repository: vegaprotocol/vega
+          ref: develop
+          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+          path: './vega'
+
+      - name: Install binary from Vega repo
+        run: go install ./cmd/vega
+        working-directory: vega
+
       ######
       ## Start capsule
       ######

--- a/.github/workflows/capsule-cypress-nightly.yml
+++ b/.github/workflows/capsule-cypress-nightly.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -58,6 +58,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           GOBIN: ${{ env.GOBIN }}
 
+      - name: Checkout Vega
+        uses: actions/checkout@v2
+        with:
+          repository: vegaprotocol/vega
+          ref: develop
+          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+          path: './vega'
+
+      - name: Install binary from Vega repo
+        run: go install ./cmd/vega
+        working-directory: vega
+
       ######
       ## Start capsule
       ######


### PR DESCRIPTION
# Description ℹ️

This fixes the pipeline to allow tests to run on Capsule again. 

Right now we need to install binaries from develop branch of Vega. When the fix is merged in main and binaries are updated in Capsule we can revert this change. 

Also added change so we are now using release tag versions of Capsule rather than main