### PR TITLE
Chore/switch capsule version to use main

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.0
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.1
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress-nightly.yml
+++ b/.github/workflows/capsule-cypress-nightly.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.1
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress-nightly.yml
+++ b/.github/workflows/capsule-cypress-nightly.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.0
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.1
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.0
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 


### PR DESCRIPTION
Capsule tests are failing due to breaking change which requires update to v0.2.1
