### PR TITLE
chore: show full vega wallet key for large screen

### DIFF
--- a/libs/wallet/src/manage-dialog/manage-dialog.tsx
+++ b/libs/wallet/src/manage-dialog/manage-dialog.tsx
@@ -57,9 +57,10 @@ export const VegaManageDialog = ({
                     </Button>
                   )}
                   <div className="flex justify-between text-ui-small">
-                    <p className="font-mono">
+                    <p className="font-mono block sm:hidden">
                       {truncateByChars(kp.pub, 23, 23)}
                     </p>
+                    <p className="font-mono hidden sm:block">{kp.pub}</p>
                     <CopyWithTooltip text={kp.pub}>
                       <button className="underline">
                         <Icon name="duplicate" className="mr-4" />


### PR DESCRIPTION
# Related issues 🔗

Closes #853 

# Description ℹ️

Show full vega wallet key in Manage dialog when it fits on the screen, and truncate for smaller screens.

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
