### PR TITLE
Feat/863 Explorer: "Proposals" should say "Governance proposals"

### DIFF
--- a/apps/explorer/src/app/routes/governance/index.tsx
+++ b/apps/explorer/src/app/routes/governance/index.tsx
@@ -108,7 +108,9 @@ const Governance = () => {
   if (!data) return null;
   return (
     <section>
-      <RouteTitle data-testid="governance-header">{t('Governance')}</RouteTitle>
+      <RouteTitle data-testid="governance-header">
+        {t('Governance Proposals')}
+      </RouteTitle>
       {data.proposals?.map((p) => (
         <React.Fragment key={p.id}>
           <SubHeading>{getProposalName(p.terms.change)}</SubHeading>

--- a/apps/explorer/src/app/routes/router-config.tsx
+++ b/apps/explorer/src/app/routes/router-config.tsx
@@ -66,8 +66,8 @@ const governanceRoutes = flags.governance
   ? [
       {
         path: Routes.GOVERNANCE,
-        name: 'Governance',
-        text: t('Proposals'),
+        name: 'Governance proposals',
+        text: t('Governance Proposals'),
         element: <Governance />,
       },
     ]


### PR DESCRIPTION
# Related issues 🔗

Closes #863

# Description ℹ️

Aligns menu and page title with desired 'governance proposals' title

# Demo 📺

![Screenshot 2022-07-27 at 11 30 18](https://user-images.githubusercontent.com/2410498/181226135-a7411c6e-5ccf-4919-96f5-6c339424bdda.png)

