### PR TITLE
Fix/836: Theme switcher - light toggle had wrong text colour

### DIFF
--- a/libs/ui-toolkit/src/components/theme-switcher/theme-switcher.tsx
+++ b/libs/ui-toolkit/src/components/theme-switcher/theme-switcher.tsx
@@ -13,7 +13,7 @@ export const ThemeSwitcher = ({
   sunClassName?: string;
   moonClassName?: string;
 }) => {
-  const sunClasses = classNames('dark:hidden text-white', sunClassName);
+  const sunClasses = classNames('dark:hidden text-black', sunClassName);
   const moonClasses = classNames(
     'hidden dark:inline text-white',
     moonClassName


### PR DESCRIPTION
# Related issues 🔗

Closes #836

# Description ℹ️

Theme switcher light toggle had white text showing on white background, needed to be black text.

# Demo 📺

![Screenshot 2022-07-27 at 11 41 27](https://user-images.githubusercontent.com/2410498/181228130-863a11f2-d2b1-4992-b5fd-45e18f0d7e54.png)

