### PR TITLE
Fix/829: Git info word length broke responsiveness

### DIFF
--- a/libs/network-info/src/network-info.tsx
+++ b/libs/network-info/src/network-info.tsx
@@ -31,7 +31,7 @@ export const NetworkInfo = () => {
         </Lozenge>
         . <Link onClick={() => setNodeSwitcherOpen()}>{t('Edit')}</Link>
       </p>
-      <p data-testid="git-eth-data" className="mb-16">
+      <p data-testid="git-eth-data" className="mb-16 break-all">
         {t('Reading Ethereum data from')}{' '}
         <Lozenge className="text-black dark:text-white bg-white-60 dark:bg-black-60">
           {ETHEREUM_PROVIDER_URL}


### PR DESCRIPTION
# Related issues 🔗

Closes #829

# Description ℹ️

The git info urls (i.e. 'https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8') were unable to word-break and so broke the mobile width in Explorer. I added the tailwind class of 'break-all' to allow that url to wrap at any point so the layout is preserved.

# Demo 📺

![Screenshot 2022-07-27 at 12 13 00](https://user-images.githubusercontent.com/2410498/181233619-22159453-7351-4c73-a194-06b557957d79.png)

