### PR TITLE
Fix/872: Remove useThemeSwitcher from Token

### DIFF
--- a/apps/token/src/app.tsx
+++ b/apps/token/src/app.tsx
@@ -49,7 +49,7 @@ const AppContainer = () => {
                     <AppLoader>
                       <BalanceManager>
                         <>
-                          <div className="app dark max-w-[1300px] mx-auto my-0 grid grid-rows-[min-content_1fr_min-content] min-h-full lg:border-l-1 lg:border-r-1 lg:border-white font-sans text-body lg:text-body-large text-white-80">
+                          <div className="app max-w-[1300px] mx-auto my-0 grid grid-rows-[min-content_1fr_min-content] min-h-full lg:border-l-1 lg:border-r-1 lg:border-white font-sans text-body lg:text-body-large text-white-80">
                             <AppBanner />
                             <TemplateSidebar sidebar={sideBar}>
                               <AppRouter />

--- a/apps/token/src/hooks/use-animate-value.ts
+++ b/apps/token/src/hooks/use-animate-value.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import { usePrevious } from './use-previous';
 import type { BigNumber } from '../lib/bignumber';
 import { theme as tailwindcss } from '@vegaprotocol/tailwindcss-config';
-import { useThemeSwitcher } from '@vegaprotocol/react-helpers';
 const Colors = tailwindcss.colors;
 
 const FLASH_DURATION = 1200; // Duration of flash animation in milliseconds
@@ -13,7 +12,6 @@ export function useAnimateValue(
 ) {
   const shouldAnimate = React.useRef(false);
   const previous = usePrevious(value);
-  const [theme] = useThemeSwitcher();
 
   React.useEffect(() => {
     const timeout = setTimeout(() => {
@@ -38,8 +36,7 @@ export function useAnimateValue(
           offset: 0.8,
         },
         {
-          backgroundColor:
-            theme === 'dark' ? Colors.white[60] : Colors.black[60],
+          backgroundColor: Colors.white[60],
           color: Colors.white.DEFAULT,
         },
       ],
@@ -64,8 +61,7 @@ export function useAnimateValue(
           offset: 0.8,
         },
         {
-          backgroundColor:
-            theme === 'dark' ? Colors.white[60] : Colors.black[60],
+          backgroundColor: Colors.white[60],
           color: Colors.white.DEFAULT,
         },
       ],


### PR DESCRIPTION
# Related issues 🔗

Closes #872

# Description ℹ️

If a user has their system set to light mode, it was possible to end up seeing white backgrounds in the manage wallet dialog on Token when they should be black.

# Demo 📺

![Screenshot 2022-07-27 at 15 19 08](https://user-images.githubusercontent.com/2410498/181270949-cd54b1ba-e4d6-49af-9ff1-86dee9187741.png)

# Technical 👨‍🔧

Removal of unnecessary useThemeSwitcher meant the theme switcher was no longer checking for a user's theme preferences and stripping the 'dark' class out from the HTML tag. Once we implement a light class for Token this will of course be needed, but for now this allows us to maintain the desired dark theme.
