### PR TITLE
fix: border colour wrong for tranches overview

### DIFF
--- a/apps/token/src/routes/redemption/home/vesting-table.tsx
+++ b/apps/token/src/routes/redemption/home/vesting-table.tsx
@@ -63,7 +63,7 @@ export const VestingTable = ({
           {formatNumber(associated)}
         </KeyValueTableRow>
       </KeyValueTable>
-      <div className="flex">
+      <div className="flex border-white border">
         <div
           className="bg-vega-pink h-16"
           style={{ flex: lockedPercentage.toNumber() }}


### PR DESCRIPTION
# Related issues 🔗

Ad hoc little design issue

# Description ℹ️

The broder for the all tranches summary was not white but for individual tranches it was. This PR makes all the borders white.
