### PR TITLE
Fix/898: Avatar images now only displaying if avatarUrl is valid

### DIFF
--- a/apps/token/src/routes/staking/node-list.tsx
+++ b/apps/token/src/routes/staking/node-list.tsx
@@ -66,6 +66,7 @@ const ValidatorRenderer = ({ data }: ValidatorRendererProps) => {
           className="h-24 w-24 rounded-full mr-8"
           src={avatarUrl}
           alt={`Avatar icon for ${name}`}
+          onError={(e) => (e.currentTarget.style.display = 'none')}
         />
       )}
       {name}


### PR DESCRIPTION
# Related issues 🔗

Closes #898

# Description ℹ️

If a validator avatarUrl was broken, browsers would handle the broken image tag poorly (and inconsistently between browsers). This fix hides the image in that state.

# Demo 📺

![Screenshot 2022-07-28 at 14 19 32](https://user-images.githubusercontent.com/2410498/181515399-50e67c0a-850c-4fa2-a0ec-707861bb9f7d.png)

# Technical 👨‍🔧

Simply an onError prop on the image tag, which sets the display property to 'none'.
