### PR TITLE
Fix/900: Validator list - pending stake formatted as per current stake

### DIFF
--- a/apps/token/src/routes/staking/node-list.tsx
+++ b/apps/token/src/routes/staking/node-list.tsx
@@ -142,7 +142,7 @@ export const NodeList = ({ epoch }: NodeListProps) => {
           [TOTAL_STAKE_THIS_EPOCH]: formatNumber(stakedTotal, 2),
           [SHARE]: stakedTotalPercentage,
           [VALIDATOR_STAKE]: formatNumber(stakedOnNode, 2),
-          [PENDING_STAKE]: pendingStake,
+          [PENDING_STAKE]: formatNumber(pendingStake, 2),
           [RANKING_SCORE]: formatNumber(new BigNumber(rankingScore), 5),
           [STAKE_SCORE]: formatNumber(new BigNumber(stakeScore), 5),
           [PERFORMANCE_SCORE]: formatNumber(new BigNumber(performanceScore), 5),


### PR DESCRIPTION
# Related issues 🔗

Closes #900

# Description ℹ️

Validator list pending stake was previously unformatted. This formatting now brings it inline with current stake.
