### PR TITLE
[explorer] Direct link to a network parameter

### DIFF
--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.spec.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.spec.tsx
@@ -24,10 +24,10 @@ describe('NetworkParametersTable', () => {
     );
     const rows = screen.getAllByTestId('key-value-table-row');
     expect(rows[0].children[0]).toHaveTextContent(
-      'Market Fee Factors Infrastructure Fee'
+      'market.fee.factors.infrastructureFee'
     );
     expect(rows[1].children[0]).toHaveTextContent(
-      'Market Liquidity Provision Min Lp Stake Quantum Multiple'
+      'market.liquidityProvision.minLpStakeQuantumMultiple'
     );
     expect(rows[0].children[1]).toHaveTextContent('0.0005');
     expect(rows[1].children[1]).toHaveTextContent('1');
@@ -54,10 +54,10 @@ describe('NetworkParametersTable', () => {
     );
     const rows = screen.getAllByTestId('key-value-table-row');
     expect(rows[0].children[0]).toHaveTextContent(
-      'Market Fee Factors Infrastructure Fee'
+      'market.fee.factors.infrastructureFee'
     );
     expect(rows[1].children[0]).toHaveTextContent(
-      'Market Liquidity Provision Min Lp Stake Quantum Multiple'
+      'market.liquidityProvision.minLpStakeQuantumMultiple'
     );
     expect(rows[0].children[1]).toHaveTextContent('0.0005');
     expect(rows[1].children[1]).toHaveTextContent('1');

--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -16,7 +16,6 @@ import type {
   NetworkParametersQuery_networkParameters,
 } from './__generated__/NetworkParametersQuery';
 import orderBy from 'lodash/orderBy';
-import startCase from 'lodash/startCase';
 
 const BIG_NUMBER_PARAMS = [
   'spam.protection.delegation.min.tokens',
@@ -42,8 +41,13 @@ export const renderRow = ({
 }: NetworkParametersQuery_networkParameters) => {
   const isSyntaxRow = isJsonObject(value);
   return (
-    <KeyValueTableRow key={key} inline={!isSyntaxRow}>
-      {startCase(key)}
+    <KeyValueTableRow
+      key={key}
+      inline={!isSyntaxRow}
+      id={key}
+      className={'target:bg-vega-yellow target:text-black'}
+    >
+      {key}
       {isSyntaxRow ? (
         <SyntaxHighlighter data={JSON.parse(value)} />
       ) : isNaN(Number(value)) ? (

--- a/libs/ui-toolkit/src/components/key-value-table/key-value-table.spec.tsx
+++ b/libs/ui-toolkit/src/components/key-value-table/key-value-table.spec.tsx
@@ -90,3 +90,19 @@ it('Applies muted class if prop is passed', () => {
     'w-full border-collapse mb-8 [border-spacing:0] break-all'
   );
 });
+
+it('Applies id to row if passed', () => {
+  render(
+    <KeyValueTable>
+      <KeyValueTableRow inline={false} id="thisistheid">
+        <span>My value</span>
+        <span>My value</span>
+      </KeyValueTableRow>
+    </KeyValueTable>
+  );
+
+  expect(screen.getByTestId('key-value-table-row')).toHaveAttribute(
+    'id',
+    'thisistheid'
+  );
+});

--- a/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
+++ b/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
@@ -77,6 +77,7 @@ export const KeyValueTableRow = ({
   noBorder = false,
   dtClassName,
   ddClassName,
+  id,
 }: KeyValueTableRowProps) => {
   const dlClassName = classNames(
     'flex gap-1 flex-wrap justify-between ',
@@ -98,8 +99,17 @@ export const KeyValueTableRow = ({
     ddClassName
   );
 
+  const attributes = {} as Partial<React.HTMLProps<HTMLDListElement>>;
+  if (id) {
+    attributes.id = id;
+  }
+
   return (
-    <dl className={dlClassName} data-testid="key-value-table-row">
+    <dl
+      className={dlClassName}
+      data-testid="key-value-table-row"
+      {...attributes}
+    >
       <dt className={dtClassNames}>{children[0]}</dt>
       <dd className={ddClassNames}>{children[1]}</dd>
     </dl>


### PR DESCRIPTION
# Related issues 🔗

Closes #893

# Description ℹ️
**Note: WIP as taking a screenshot surfaced an error in dark mode** 

Over in [vegaprotocol/documentation](https://github.com/vegaprotocol/documentation) we're adding a component that pulls
in the value of a network parameter, and links to the explorer. For this feature, we want to be able to highlight the 
specific parameter the user is looking for. This PR implements the explorer side of this:

- Add optional `id` attribute to `KeyValueTableRow`
- Update NetworkParameter table to populate id with the network parameter key
- Update NetworkParameter table to style `active` row
- Update NetworkParameter table to not reformat network paramter name

# Demo 📺

<img width="1273" alt="Screenshot 2022-07-28 at 16 32 48" src="https://user-images.githubusercontent.com/6678/181578269-fe2e9b48-efcd-4cc5-813f-26ee3ae05fbb.png">
<img width="1264" alt="Screenshot 2022-07-28 at 16 33 30" src="https://user-images.githubusercontent.com/6678/181578344-e121b139-b9b2-43b4-9b3c-cf8d77810f0b.png">



