### PR TITLE
Feat/893 anchor per network param

### DIFF
--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.spec.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.spec.tsx
@@ -24,10 +24,10 @@ describe('NetworkParametersTable', () => {
     );
     const rows = screen.getAllByTestId('key-value-table-row');
     expect(rows[0].children[0]).toHaveTextContent(
-      'Market Fee Factors Infrastructure Fee'
+      'market.fee.factors.infrastructureFee'
     );
     expect(rows[1].children[0]).toHaveTextContent(
-      'Market Liquidity Provision Min Lp Stake Quantum Multiple'
+      'market.liquidityProvision.minLpStakeQuantumMultiple'
     );
     expect(rows[0].children[1]).toHaveTextContent('0.0005');
     expect(rows[1].children[1]).toHaveTextContent('1');
@@ -54,10 +54,10 @@ describe('NetworkParametersTable', () => {
     );
     const rows = screen.getAllByTestId('key-value-table-row');
     expect(rows[0].children[0]).toHaveTextContent(
-      'Market Fee Factors Infrastructure Fee'
+      'market.fee.factors.infrastructureFee'
     );
     expect(rows[1].children[0]).toHaveTextContent(
-      'Market Liquidity Provision Min Lp Stake Quantum Multiple'
+      'market.liquidityProvision.minLpStakeQuantumMultiple'
     );
     expect(rows[0].children[1]).toHaveTextContent('0.0005');
     expect(rows[1].children[1]).toHaveTextContent('1');

--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -45,7 +45,9 @@ export const renderRow = ({
       key={key}
       inline={!isSyntaxRow}
       id={key}
-      className={'target:bg-vega-yellow target:text-black'}
+      className={
+        'group target:bg-vega-pink target:!text-white dark:target:bg-vega-yellow dark:target:!text-black'
+      }
     >
       {key}
       {isSyntaxRow ? (

--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -16,7 +16,6 @@ import type {
   NetworkParametersQuery_networkParameters,
 } from './__generated__/NetworkParametersQuery';
 import orderBy from 'lodash/orderBy';
-import startCase from 'lodash/startCase';
 
 const BIG_NUMBER_PARAMS = [
   'spam.protection.delegation.min.tokens',
@@ -42,8 +41,13 @@ export const renderRow = ({
 }: NetworkParametersQuery_networkParameters) => {
   const isSyntaxRow = isJsonObject(value);
   return (
-    <KeyValueTableRow key={key} inline={!isSyntaxRow}>
-      {startCase(key)}
+    <KeyValueTableRow
+      key={key}
+      inline={!isSyntaxRow}
+      id={key}
+      className={'target:bg-vega-yellow target:text-black'}
+    >
+      {key}
       {isSyntaxRow ? (
         <SyntaxHighlighter data={JSON.parse(value)} />
       ) : isNaN(Number(value)) ? (

--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -46,7 +46,7 @@ export const renderRow = ({
       inline={!isSyntaxRow}
       id={key}
       className={
-        'group target:bg-vega-pink target:!text-white dark:target:bg-vega-yellow dark:target:!text-black'
+        'group target:bg-vega-pink target:text-white dark:target:bg-vega-yellow dark:target:text-black'
       }
     >
       {key}

--- a/libs/ui-toolkit/src/components/key-value-table/key-value-table.spec.tsx
+++ b/libs/ui-toolkit/src/components/key-value-table/key-value-table.spec.tsx
@@ -90,3 +90,19 @@ it('Applies muted class if prop is passed', () => {
     'w-full border-collapse mb-8 [border-spacing:0] break-all'
   );
 });
+
+it('Applies id to row if passed', () => {
+  render(
+    <KeyValueTable>
+      <KeyValueTableRow inline={false} id="thisistheid">
+        <span>My value</span>
+        <span>My value</span>
+      </KeyValueTableRow>
+    </KeyValueTable>
+  );
+
+  expect(screen.getByTestId('key-value-table-row')).toHaveAttribute(
+    'id',
+    'thisistheid'
+  );
+});

--- a/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
+++ b/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
@@ -77,6 +77,7 @@ export const KeyValueTableRow = ({
   noBorder = false,
   dtClassName,
   ddClassName,
+  id,
 }: KeyValueTableRowProps) => {
   const dlClassName = classNames(
     'flex gap-1 flex-wrap justify-between ',
@@ -98,8 +99,17 @@ export const KeyValueTableRow = ({
     ddClassName
   );
 
+  const attributes = {} as Partial<React.HTMLProps<HTMLDListElement>>;
+  if (id) {
+    attributes.id = id;
+  }
+
   return (
-    <dl className={dlClassName} data-testid="key-value-table-row">
+    <dl
+      className={dlClassName}
+      data-testid="key-value-table-row"
+      {...attributes}
+    >
       <dt className={dtClassNames}>{children[0]}</dt>
       <dd className={ddClassNames}>{children[1]}</dd>
     </dl>

--- a/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
+++ b/libs/ui-toolkit/src/components/key-value-table/key-value-table.tsx
@@ -93,6 +93,7 @@ export const KeyValueTableRow = ({
   const dtClassNames = `break-words font-medium uppercase align-top p-4 capitalize ${dtClassName}`;
   const ddClassNames = classNames(
     'align-top p-4 text-black/60 dark:text-white/60 break-words',
+    'group-target:text-white dark:group-target:text-black',
     {
       'font-mono': numerical,
     },


### PR DESCRIPTION
# Related issues 🔗

Closes #893

# Description ℹ️

Over in [vegaprotocol/documentation](https://github.com/vegaprotocol/documentation) we're adding a component that pulls
in the value of a network parameter, and links to the explorer. For this feature, we want to be able to highlight the 
specific parameter the user is looking for. This PR implements the explorer side of this:

- Add optional `id` attribute to `KeyValueTableRow`
- Update NetworkParameter table to populate id with the network parameter key
- Update NetworkParameter table to style `active` row
- Update NetworkParameter table to not reformat network paramter name

# Demo 📺

<img width="1269" alt="Screenshot 2022-07-28 at 17 25 41" src="https://user-images.githubusercontent.com/6678/181589443-722ad0df-0f62-4fb3-b42d-bea02fa29d06.png">
<img width="1275" alt="Screenshot 2022-07-28 at 17 25 50" src="https://user-images.githubusercontent.com/6678/181589456-e52a9415-bbb8-4424-97a3-c632a10d9448.png">



