### PR TITLE
Fix/687: Jump to block input should not allow negative block numbers or 0

### DIFF
--- a/apps/explorer/src/app/components/jump-to-block/index.tsx
+++ b/apps/explorer/src/app/components/jump-to-block/index.tsx
@@ -29,7 +29,7 @@ export const JumpToBlock = () => {
       inputType="number"
       inputName="blockNumber"
       submitHandler={handleSubmit}
-      inputMin={0}
+      inputMin={1}
     />
   );
 };

--- a/apps/explorer/src/app/components/jump-to-block/index.tsx
+++ b/apps/explorer/src/app/components/jump-to-block/index.tsx
@@ -29,6 +29,7 @@ export const JumpToBlock = () => {
       inputType="number"
       inputName="blockNumber"
       submitHandler={handleSubmit}
+      inputMin={0}
     />
   );
 };

--- a/apps/explorer/src/app/components/jump-to/index.tsx
+++ b/apps/explorer/src/app/components/jump-to/index.tsx
@@ -9,6 +9,8 @@ interface JumpToProps {
   inputType: HTMLInputTypeAttribute;
   inputName: string;
   submitHandler: (arg0: SyntheticEvent) => void;
+  inputMin?: string | number;
+  inputMax?: string | number;
 }
 
 export const JumpTo = ({
@@ -18,6 +20,8 @@ export const JumpTo = ({
   inputType,
   inputName,
   submitHandler,
+  inputMin,
+  inputMax,
 }: JumpToProps) => {
   return (
     <form onSubmit={submitHandler}>
@@ -35,6 +39,8 @@ export const JumpTo = ({
           name={inputName}
           placeholder={placeholder}
           className="max-w-[200px]"
+          min={inputMin}
+          max={inputMax}
         />
         <Button
           data-testid="go-submit"


### PR DESCRIPTION
# Related issues 🔗

Closes #687

# Description ℹ️

The Explorer 'jump to block' component was previously accepting negative numbers or 0, which never correlate to a block number. This fix sets the minimum range of the input to 1. 

# Demo 📺

![Screenshot 2022-07-29 at 12 28 26](https://user-images.githubusercontent.com/2410498/181749794-05759a03-aa4e-4b1b-8d43-8c04215c77f3.png)

# Technical 👨‍🔧

Provided a way to set both min and max attributes for the 'JumpTo' component
