### PR TITLE
fix: make check link unclickable while loading

### DIFF
--- a/libs/environment/src/components/node-switcher/node-switcher.tsx
+++ b/libs/environment/src/components/node-switcher/node-switcher.tsx
@@ -169,7 +169,7 @@ export const NodeSwitcher = ({
                         onChange={(e) => setCustomNodeText(e.target.value)}
                       />
                       <Link
-                        aria-disabled={!customNodeText}
+                        aria-disabled={!customNodeText || getIsNodeLoading(state[CUSTOM_NODE_KEY])}
                         onClick={() => {
                           setNetworkError(null);
                           updateNodeUrl(CUSTOM_NODE_KEY, customNodeText);

--- a/libs/environment/src/components/node-switcher/node-switcher.tsx
+++ b/libs/environment/src/components/node-switcher/node-switcher.tsx
@@ -169,7 +169,10 @@ export const NodeSwitcher = ({
                         onChange={(e) => setCustomNodeText(e.target.value)}
                       />
                       <Link
-                        aria-disabled={!customNodeText || getIsNodeLoading(state[CUSTOM_NODE_KEY])}
+                        aria-disabled={
+                          !customNodeText ||
+                          getIsNodeLoading(state[CUSTOM_NODE_KEY])
+                        }
                         onClick={() => {
                           setNetworkError(null);
                           updateNodeUrl(CUSTOM_NODE_KEY, customNodeText);

--- a/libs/environment/src/utils/validate-node.tsx
+++ b/libs/environment/src/utils/validate-node.tsx
@@ -2,17 +2,13 @@ import { t } from '@vegaprotocol/react-helpers';
 import { CUSTOM_NODE_KEY, ErrorType } from '../types';
 import type { Networks, NodeData } from '../types';
 
-export const getIsNodeLoading = ({
-  chain,
-  responseTime,
-  block,
-  ssl,
-}: NodeData) => {
+export const getIsNodeLoading = (node?: NodeData):boolean => {
+  if (!node) return false;
   return (
-    chain.isLoading ||
-    responseTime.isLoading ||
-    block.isLoading ||
-    ssl.isLoading
+    node.chain.isLoading ||
+    node.responseTime.isLoading ||
+    node.block.isLoading ||
+    node.ssl.isLoading
   );
 };
 

--- a/libs/environment/src/utils/validate-node.tsx
+++ b/libs/environment/src/utils/validate-node.tsx
@@ -2,7 +2,7 @@ import { t } from '@vegaprotocol/react-helpers';
 import { CUSTOM_NODE_KEY, ErrorType } from '../types';
 import type { Networks, NodeData } from '../types';
 
-export const getIsNodeLoading = (node?: NodeData):boolean => {
+export const getIsNodeLoading = (node?: NodeData): boolean => {
   if (!node) return false;
   return (
     node.chain.isLoading ||


### PR DESCRIPTION
# Related issues 🔗

Fix for #856 (the rest of the points raised on the issue require clarification)

# Description ℹ️

Fixes no 3 from the original issue: "Input fake url and click check twice freezes the modal with the user unable to do anything else"

# Demo 📺

<img width="925" alt="Screenshot 2022-08-01 at 12 07 52" src="https://user-images.githubusercontent.com/105208209/182135351-d2b5fc33-7acc-4e7f-a8eb-67c99db98ec5.png">

# Technical

Disables the clicking the check link while the checks are running for the custom node