### PR TITLE
fix(790): gap between orderbook headers and tabs

### DIFF
--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -282,13 +282,13 @@ export const Orderbook = ({
   const hasData = renderedRows.data && renderedRows.data.length !== 0;
   return (
     <div
-      className={`h-full overflow-auto relative ${styles['scroll']} pl-4 pt-4`}
+      className={`h-full overflow-auto relative ${styles['scroll']} pl-4`}
       onScroll={onScroll}
       ref={scrollElement}
       data-testid="scroll"
     >
       <div
-        className="sticky top-0 grid grid-cols-4 gap-5 text-right border-b-1 text-ui-small mb-2 pb-2 bg-white dark:bg-black z-10"
+        className="sticky top-0 grid grid-cols-4 gap-5 text-right border-b-1 text-ui-small mb-2 pt-4 pb-2 bg-white dark:bg-black z-10"
         style={{ gridAutoRows: '17px' }}
       >
         <div>{t('Bid Vol')}</div>


### PR DESCRIPTION
# Related issues 🔗

Closes #790

# Description ℹ️

Moves "pt-4" classname from main orderbook container to the labels'

# Demo 📺

![Screenshot 2022-08-01 at 15 50 11](https://user-images.githubusercontent.com/1980305/182163190-7aa2f48b-8101-4a14-b615-5228a1552f94.png)

