### PR TITLE
fix: walletconnect does not work

### DIFF
--- a/apps/token/src/assets/env-config.js
+++ b/apps/token/src/assets/env-config.js
@@ -1,3 +1,1 @@
 window._env_ = {};
-// eslint-disable-next-line no-undef, no-global-assign, no-native-reassign
-global = globalThis;

--- a/apps/token/src/assets/env-config.js
+++ b/apps/token/src/assets/env-config.js
@@ -1,1 +1,3 @@
 window._env_ = {};
+// eslint-disable-next-line no-undef, no-global-assign, no-native-reassign
+global = globalThis;

--- a/apps/token/src/polyfills.ts
+++ b/apps/token/src/polyfills.ts
@@ -5,3 +5,6 @@
  */
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+window.Buffer = require('buffer/').Buffer;

--- a/apps/token/src/polyfills.ts
+++ b/apps/token/src/polyfills.ts
@@ -8,3 +8,5 @@ import 'regenerator-runtime/runtime';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 window.Buffer = require('buffer/').Buffer;
+// eslint-disable-next-line no-undef, no-global-assign, no-native-reassign
+window.global = globalThis;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "apollo": "^2.33.9",
     "autoprefixer": "^10.4.2",
     "bignumber.js": "^9.0.2",
+    "buffer": "^6.0.3",
     "classnames": "^2.3.1",
     "core-js": "^3.6.5",
     "date-fns": "^2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8954,6 +8954,14 @@ buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 buffer@~5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
@@ -13774,7 +13782,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
# Related issues 🔗

Closes #919

# Technical 👨‍🔧

Bug was caused by a `global` and not `globalThis` reference in `@walletconnect/socket-transport/dist/esm/index.js`. That's why there's a dirty `global = globalThis` added to the `polyfills.js`

Fixing `global` issue revealed another with missing `Buffer` - *webpack@5+* doesn't include node's polyfills anymore hence I needed to add it manually to the `polyfills.ts`.

# Demo 📺

![image](https://user-images.githubusercontent.com/1980305/182407208-cf1508c1-a2ec-4a1c-b8e2-2416d4139de3.png)

