### PR TITLE
feat: show correct reward type (#930)

### DIFF
--- a/apps/token/src/routes/rewards/home/__generated__/Rewards.ts
+++ b/apps/token/src/routes/rewards/home/__generated__/Rewards.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { AccountType } from "@vegaprotocol/types";
+
 // ====================================================
 // GraphQL query operation: Rewards
 // ====================================================
@@ -45,6 +47,10 @@ export interface Rewards_party_rewardDetails_rewards_epoch {
 
 export interface Rewards_party_rewardDetails_rewards {
   __typename: "Reward";
+  /**
+   * The type of reward
+   */
+  rewardType: AccountType;
   /**
    * The asset this reward is paid in
    */

--- a/apps/token/src/routes/rewards/home/index.tsx
+++ b/apps/token/src/routes/rewards/home/index.tsx
@@ -30,6 +30,7 @@ export const REWARDS_QUERY = gql`
           symbol
         }
         rewards {
+          rewardType
           asset {
             id
           }

--- a/apps/token/src/routes/rewards/home/reward-info.tsx
+++ b/apps/token/src/routes/rewards/home/reward-info.tsx
@@ -19,10 +19,6 @@ interface RewardInfoProps {
   rewardAssetId: string;
 }
 
-// Note: For now the only reward type is Staking. We'll need this from the API
-// at a later date
-const DEFAULT_REWARD_TYPE = 'Staking';
-
 export const RewardInfo = ({
   data,
   currVegaKey,
@@ -119,7 +115,7 @@ export const RewardTable = ({ reward, delegations }: RewardTableProps) => {
       <KeyValueTable>
         <KeyValueTableRow>
           {t('rewardType')}
-          <span>{DEFAULT_REWARD_TYPE}</span>
+          <span>{reward.rewardType}</span>
         </KeyValueTableRow>
         <KeyValueTableRow>
           {t('yourStake')}


### PR DESCRIPTION
# Related issues 🔗

Closes #956

Related to #930

# Description ℹ️

Put back the reward types that were removed to facilitate the release of token from monorepo
