### PR TITLE
Fix/945: Orderbook memory leak

### DIFF
--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -96,7 +96,7 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
     setOrderbookData(dataRef.current);
     return () => {
       updateOrderbookData.current.cancel();
-    }
+    };
   }, [data, resolution]);
 
   useEffect(() => {

--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -94,6 +94,9 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
       ...mapMarketData(data.data, resolution),
     };
     setOrderbookData(dataRef.current);
+    return () => {
+      updateOrderbookData.current.cancel();
+    }
   }, [data, resolution]);
 
   useEffect(() => {

--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -83,6 +83,7 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
   });
 
   useEffect(() => {
+    const throttleRunnner = updateOrderbookData.current;
     if (!data) {
       dataRef.current = { rows: null };
       setOrderbookData(dataRef.current);
@@ -94,8 +95,9 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
       ...mapMarketData(data.data, resolution),
     };
     setOrderbookData(dataRef.current);
+
     return () => {
-      updateOrderbookData.current.cancel();
+      throttleRunnner.cancel();
     };
   }, [data, resolution]);
 


### PR DESCRIPTION
# Related issues 🔗

Closes #945 

# Description ℹ️

Solves the first error regarding the orderbook memory leak.
The second leak (ag-grid) is apparently solved by just [updating to react 18](https://github.com/vegaprotocol/frontend-monorepo/pull/952/files), tried it out on that branch, and couldn't reproduce it anymore)

 # Technical
 
 After cancelling the throttle on unmount, wasn't able to reproduce the orderbook leak anymore.
 
 Had a look, and the
