### PR TITLE
Feat/980: New Asset proposals should require validationTimestamp

### DIFF
--- a/libs/wallet/src/wallet-types.ts
+++ b/libs/wallet/src/wallet-types.ts
@@ -174,6 +174,7 @@ interface ProposalNewAssetTerms {
   };
   closingTimestamp: number;
   enactmentTimestamp: number;
+  validationTimestamp: number;
 }
 
 interface OracleSpecBinding {


### PR DESCRIPTION
# Related issues 🔗

Closes #980

# Description ℹ️

Adds validationTimestamp as a required field for new asset proposals
