### PR TITLE
fix: token app useSearchParams

### DIFF
--- a/apps/token/src/hooks/use-search-params.ts
+++ b/apps/token/src/hooks/use-search-params.ts
@@ -5,7 +5,8 @@ export function useSearchParams() {
   const location = useLocation();
 
   return React.useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new URLSearchParams(location.search) as any;
+    const searchParams = new URLSearchParams(location.search);
+    // @ts-ignore searchParams doesnt have symbol.iterator
+    return Object.fromEntries(searchParams);
   }, [location]);
 }

--- a/apps/token/src/routes/staking/associate/associate-page.tsx
+++ b/apps/token/src/routes/staking/associate/associate-page.tsx
@@ -30,7 +30,9 @@ export const AssociatePage = ({
   const [amount, setAmount] = React.useState<string>('');
 
   const [selectedStakingMethod, setSelectedStakingMethod] =
-    React.useState<StakingMethod | null>(params.method || null);
+    React.useState<StakingMethod | null>(
+      (params.method as StakingMethod) || null
+    );
 
   // Clear the amount when the staking method changes
   React.useEffect(() => {
@@ -71,7 +73,7 @@ export const AssociatePage = ({
     } else if (!zeroVega && zeroVesting) {
       setSelectedStakingMethod(StakingMethod.Wallet);
     } else {
-      setSelectedStakingMethod(params.method);
+      setSelectedStakingMethod(params.method as StakingMethod);
     }
   }, [params.method, zeroVega, zeroVesting]);
 

--- a/apps/token/src/routes/staking/disassociate/disassociate-page-no-vega.tsx
+++ b/apps/token/src/routes/staking/disassociate/disassociate-page-no-vega.tsx
@@ -14,7 +14,9 @@ export const DisassociatePageNoVega = () => {
   const params = useSearchParams();
   const [amount, setAmount] = React.useState<string>('');
   const [selectedStakingMethod, setSelectedStakingMethod] =
-    React.useState<StakingMethod | null>(params.method || null);
+    React.useState<StakingMethod | null>(
+      (params.method as StakingMethod) || null
+    );
 
   return (
     <section className="disassociate-page" data-testid="disassociate-page">

--- a/apps/token/src/routes/staking/disassociate/disassociate-page.tsx
+++ b/apps/token/src/routes/staking/disassociate/disassociate-page.tsx
@@ -26,7 +26,9 @@ export const DisassociatePage = ({
   const params = useSearchParams();
   const [amount, setAmount] = React.useState<string>('');
   const [selectedStakingMethod, setSelectedStakingMethod] =
-    React.useState<StakingMethod | null>(params.method || null);
+    React.useState<StakingMethod | null>(
+      (params.method as StakingMethod) || null
+    );
   const refreshBalances = useRefreshAssociatedBalances();
 
   // Clear the amount when the staking method changes

--- a/apps/token/src/routes/staking/staking-form.tsx
+++ b/apps/token/src/routes/staking/staking-form.tsx
@@ -91,7 +91,9 @@ export const StakingForm = ({
   const { sendTx } = useVegaWallet();
   const [formState, setFormState] = React.useState(FormState.Default);
   const { t } = useTranslation();
-  const [action, setAction] = React.useState<StakeAction>(params.action);
+  const [action, setAction] = React.useState<StakeAction>(
+    params.action as StakeAction
+  );
   const [amount, setAmount] = React.useState('');
   const [removeType, setRemoveType] = React.useState<RemoveType>(
     RemoveType.EndOfEpoch


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Claim page was broken due to useSearchParams hook bug resulting from stray :any type.

# Demo 📺

N/A

# Technical 👨‍🔧

useSearchParams hook had an any type which resulted in incorrect usage. Hook has been adjusted to return a basic object of url search param keys and values.

Note, we should be using useParams from react-router but this was returning an empty object. This is a quick fix but we should come back and use the react-router provided hook if possible.
