### PR TITLE
fix: unbreak nx dependency mapping

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,5 @@
 {
-  "npmScope": "vegaprotocol",
+  "npmScope": "@vegaprotocol",
   "affected": {
     "defaultBase": "master"
   },


### PR DESCRIPTION
# Description ℹ️

Fix NX dependency mapping with this one simple trick (the nx npmScope did not match the path we used to declare deps). This seemed to cause subtle build failures when building from a clean source.

# Demo
## Before
![graph (1)](https://user-images.githubusercontent.com/6678/184221312-cb26e9dc-5fe8-46c7-9334-bcf046b65932.png)

## After
![graph(1)](https://user-images.githubusercontent.com/6678/184221352-15ce84a8-cda3-4ba3-a968-747a80affed0.png)

# To verify
Run the following on `master`:
```bash
rm -rf node_modules && nvm install 16.14.0 && yarn && SKIP_NX_CACHE=true ./node_modules/.bin/nx run token:build:production --source-map=false --skip-nx-cache && cd dist/apps/token && python3 -m http.server 8001
```

and you'll see that it's nearly right, but all the buttons render incorrectly. It seems like `react-helpers` wasn't being built in time, always. Apply the fix, re-run, and it will all work.

Unblocks #596, #597 

