### PR TITLE
fix: use position decimal places for volume and decimal places …

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -23,15 +23,20 @@ describe('market info is displayed', () => {
     validateMarketDataRow(2, 'Liquidity Fee', '1.00%');
   });
 
-  it('market data displated', () => {
-    cy.getByTestId(marketTitle).contains('Market data').click();
+  it('market volume displayed', () => {
+    cy.getByTestId(marketTitle).contains('Market volume').click();
 
-    validateMarketDataRow(0, 'Mark Price', '57.49');
     validateMarketDataRow(1, 'Indicative Volume', '0');
     validateMarketDataRow(2, 'Best Bid Volume', '5');
     validateMarketDataRow(3, 'Best Offer Volume', '1');
     validateMarketDataRow(4, 'Best Static Bid Volume', '5');
     validateMarketDataRow(5, 'Best Static Offer Volume', '1');
+  });
+
+  it('market price and interest displayed', () => {
+    cy.getByTestId(marketTitle).contains('Market price and interest').click();
+
+    validateMarketDataRow(0, 'Mark Price', '57.49');
     validateMarketDataRow(6, 'Open Interest', '0.00');
   });
 

--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -26,18 +26,18 @@ describe('market info is displayed', () => {
   it('market volume displayed', () => {
     cy.getByTestId(marketTitle).contains('Market volume').click();
 
-    validateMarketDataRow(1, 'Indicative Volume', '0');
-    validateMarketDataRow(2, 'Best Bid Volume', '5');
-    validateMarketDataRow(3, 'Best Offer Volume', '1');
-    validateMarketDataRow(4, 'Best Static Bid Volume', '5');
-    validateMarketDataRow(5, 'Best Static Offer Volume', '1');
+    validateMarketDataRow(0, 'Indicative Volume', '0');
+    validateMarketDataRow(1, 'Best Bid Volume', '5');
+    validateMarketDataRow(2, 'Best Offer Volume', '1');
+    validateMarketDataRow(3, 'Best Static Bid Volume', '5');
+    validateMarketDataRow(4, 'Best Static Offer Volume', '1');
   });
 
   it('market price and interest displayed', () => {
     cy.getByTestId(marketTitle).contains('Market price and interest').click();
 
     validateMarketDataRow(0, 'Mark Price', '57.49');
-    validateMarketDataRow(6, 'Open Interest', '0.00');
+    validateMarketDataRow(1, 'Open Interest', '0.00');
   });
 
   it('key details displayed', () => {

--- a/libs/deal-ticket/src/components/info-market.tsx
+++ b/libs/deal-ticket/src/components/info-market.tsx
@@ -193,11 +193,28 @@ export const Info = ({ market }: InfoProps) => {
       ),
     },
     {
-      title: t('Market data'),
+      title: t('Market price and interest'),
       content: (
         <MarketInfoTable
-          data={market.data}
+          data={pick(market.data, 'name', 'markPrice', 'openInterest')}
           decimalPlaces={market.decimalPlaces}
+        />
+      ),
+    },
+    {
+      title: t('Market volume'),
+      content: (
+        <MarketInfoTable
+          data={pick(
+            market.data,
+            'name',
+            'indicativeVolume',
+            'bestBidVolume',
+            'bestOfferVolume',
+            'bestStaticBidVolume',
+            'bestStaticOfferVolume'
+          )}
+          decimalPlaces={market.positionDecimalPlaces}
         />
       ),
     },


### PR DESCRIPTION
# Related issues 🔗

Closes #1025 

# Description ℹ️

Use position decimal places for volume and decimal places for price and interest.

# Demo 📺
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/16125548/184340653-2be00285-1526-48d6-9c6f-368a60677c49.png">

