### PR TITLE
Chore: Split settlement asset into separate market info section

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -43,7 +43,7 @@ describe('market info is displayed', () => {
     validateMarketDataRow(2, 'Position Decimal Places', '0');
     validateMarketDataRow(3, 'Trading Mode', 'Continuous');
     validateMarketDataRow(4, 'State', 'Active');
-    validateMarketDataRow(5, 'Market Id', 'market-0');
+    validateMarketDataRow(5, 'Market ID', 'market-0');
   });
 
   it('instrument displayed', () => {
@@ -58,13 +58,13 @@ describe('market info is displayed', () => {
   it('settlement asset displayed', () => {
     cy.getByTestId(marketTitle).contains('Settlement asset').click();
 
+    validateMarketDataRow(0, 'Name', 'tBTC TEST');
+    validateMarketDataRow(1, 'Symbol', 'tBTC');
     validateMarketDataRow(
-      4,
+      2,
       'ID',
       '5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c'
     );
-    validateMarketDataRow(5, 'Symbol', 'tBTC');
-    validateMarketDataRow(6, 'Name', 'tBTC TEST');
   });
 
   it('metadata displayed', () => {

--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -53,9 +53,14 @@ describe('market info is displayed', () => {
     validateMarketDataRow(1, 'Code', 'BTCUSD.MF21');
     validateMarketDataRow(2, 'Product Type', 'Future');
     validateMarketDataRow(3, 'Quote Name', 'BTC');
+  });
+
+  it('settlement asset displayed', () => {
+    cy.getByTestId(marketTitle).contains('Settlement asset').click();
+
     validateMarketDataRow(
       4,
-      'Id',
+      'ID',
       '5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c'
     );
     validateMarketDataRow(5, 'Symbol', 'tBTC');

--- a/libs/deal-ticket/src/components/info-market.tsx
+++ b/libs/deal-ticket/src/components/info-market.tsx
@@ -219,7 +219,7 @@ export const Info = ({ market }: InfoProps) => {
         <MarketInfoTable
           data={{
             ...keyDetails,
-            marketId: keyDetails.id,
+            marketID: keyDetails.id,
             id: undefined,
             tradingMode:
               keyDetails.tradingMode && formatLabel(keyDetails.tradingMode),
@@ -237,8 +237,22 @@ export const Info = ({ market }: InfoProps) => {
             productType:
               market.tradableInstrument.instrument.product.__typename,
             ...market.tradableInstrument.instrument.product,
-            ...(market.tradableInstrument.instrument.product?.settlementAsset ??
-              {}),
+          }}
+        />
+      ),
+    },
+    {
+      title: t('Settlement asset'),
+      content: (
+        <MarketInfoTable
+          data={{
+            name: market.tradableInstrument.instrument.product?.settlementAsset
+              .name,
+            symbol:
+              market.tradableInstrument.instrument.product?.settlementAsset
+                .symbol,
+            ID: market.tradableInstrument.instrument.product?.settlementAsset
+              .id,
           }}
         />
       ),


### PR DESCRIPTION
# Description ℹ️

Split settlement asset info out of Instrument section of Market Specification panel

# Demo 📺

Before:
![image](https://user-images.githubusercontent.com/1325606/184368368-02004f4a-b7ba-46ce-bdd3-068b0b6a60b8.png)

After:
![image](https://user-images.githubusercontent.com/1325606/184368575-0105efba-13fc-4f13-8ce7-4818d124bcea.png)
