### PR TITLE
Ignore epoch 0 error in node data

### DIFF
--- a/apps/token/src/routes/staking/node-list.tsx
+++ b/apps/token/src/routes/staking/node-list.tsx
@@ -87,7 +87,10 @@ const nodeListGridStyles = `
 
 export const NodeList = ({ epoch }: NodeListProps) => {
   const { t } = useTranslation();
-  const { data, error, loading, refetch } = useQuery<Nodes>(NODES_QUERY);
+  // errorPolicy due to vegaprotocol/vega issue 5898
+  const { data, error, loading, refetch } = useQuery<Nodes>(NODES_QUERY, {
+    errorPolicy: 'ignore',
+  });
   const navigate = useNavigate();
 
   useEffect(() => {


### PR DESCRIPTION
Workaround for https://github.com/vegaprotocol/vega/pull/5898 - 

- Ignore error in GraphQL query during epoch 0