### PR TITLE
Feat/1048: Remove asset.totalSupply

### DIFF
--- a/apps/explorer/src/app/routes/assets/__generated__/AssetsQuery.ts
+++ b/apps/explorer/src/app/routes/assets/__generated__/AssetsQuery.ts
@@ -66,10 +66,6 @@ export interface AssetsQuery_assets {
    */
   symbol: string;
   /**
-   * The total supply of the market
-   */
-  totalSupply: string;
-  /**
    * The precision of the asset
    */
   decimals: number;

--- a/apps/explorer/src/app/routes/assets/index.tsx
+++ b/apps/explorer/src/app/routes/assets/index.tsx
@@ -12,7 +12,6 @@ export const ASSETS_QUERY = gql`
       id
       name
       symbol
-      totalSupply
       decimals
       source {
         ... on ERC20 {

--- a/apps/explorer/src/app/routes/markets/__generated__/MarketsQuery.ts
+++ b/apps/explorer/src/app/routes/markets/__generated__/MarketsQuery.ts
@@ -64,10 +64,6 @@ export interface MarketsQuery_markets_tradableInstrument_instrument_product_sett
    */
   decimals: number;
   /**
-   * The total supply of the market
-   */
-  totalSupply: string;
-  /**
    * The global reward pool account for this asset
    */
   globalRewardPoolAccount: MarketsQuery_markets_tradableInstrument_instrument_product_settlementAsset_globalRewardPoolAccount | null;

--- a/apps/explorer/src/app/routes/markets/index.tsx
+++ b/apps/explorer/src/app/routes/markets/index.tsx
@@ -33,7 +33,6 @@ const MARKETS_QUERY = gql`
                 id
                 name
                 decimals
-                totalSupply
                 globalRewardPoolAccount {
                   balance
                 }


### PR DESCRIPTION
# Related issues 🔗

Closes #1048

# Description ℹ️

asset.totalSupply was removed from the API in https://github.com/vegaprotocol/vega/pull/5892, this removes it from use in Explorer
