### PR TITLE
fix: correct timeouts for associate tests

### DIFF
--- a/apps/explorer-e2e/src/integration/node-switcher.cy.js
+++ b/apps/explorer-e2e/src/integration/node-switcher.cy.js
@@ -28,6 +28,7 @@ context('Node switcher', function () {
             .should('exist')
             .and('have.attr', 'aria-checked', 'true');
           cy.get('label').should('have.text', Cypress.env('networkQueryUrl'));
+          cy.contains('-').should('not.exist');
           cy.getByTestId('response-time-cell').should('contain.text', 'ms');
           cy.getByTestId('block-cell').should('not.be.empty');
           cy.getByTestId('ssl-cell').should('have.text', 'Yes');

--- a/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
+++ b/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
@@ -41,24 +41,16 @@ context(
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
-          .parent()
-          .should('contain', 2.0, txTimeout);
+          .parent(txTimeout)
+          .should('contain', 2.0);
 
         cy.get(ethWalletTotalAssociatedBalance, txTimeout)
           .contains('2.0', txTimeout)
           .should('be.visible');
 
-        cy.get(vegaWalletAssociatedBalance, txTimeout).should(
-          'contain',
-          2.0,
-          txTimeout
-        );
+        cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 2.0);
 
-        cy.get(vegaWalletUnstakedBalance, txTimeout).should(
-          'contain',
-          2.0,
-          txTimeout
-        );
+        cy.get(vegaWalletUnstakedBalance, txTimeout).should('contain', 2.0);
       });
 
       it('Able to disassociate tokens', function () {
@@ -66,8 +58,8 @@ context(
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
-          .parent()
-          .should('contain', 2.0, txTimeout);
+          .parent(txTimeout)
+          .should('contain', 2.0);
 
         cy.get(ethWalletTotalAssociatedBalance, txTimeout)
           .contains('2.0', txTimeout)
@@ -79,8 +71,8 @@ context(
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
-          .parent()
-          .should('contain', 1.0, txTimeout);
+          .parent(txTimeout)
+          .should('contain', 1.0);
 
         cy.get(ethWalletTotalAssociatedBalance, txTimeout)
           .contains('1.0', txTimeout)
@@ -101,19 +93,14 @@ context(
 
         cy.get(vegaWalletAssociatedBalance, txTimeout).should(
           'contain',
-          '1,001.000000000000000000',
-          txTimeout
+          '1,001.000000000000000000'
         );
       });
 
       it('Able to disassociate a partial amount of tokens currently associated', function () {
         cy.staking_page_associate_tokens('2');
 
-        cy.get(vegaWalletAssociatedBalance, txTimeout).should(
-          'contain',
-          2.0,
-          txTimeout
-        );
+        cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 2.0);
 
         cy.get('button').contains('Select a validator to nominate').click();
 
@@ -121,29 +108,21 @@ context(
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
-          .parent()
-          .should('contain', 1.0, txTimeout);
+          .parent(txTimeout)
+          .should('contain', 1.0);
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
-          .parent()
-          .should('contain', 1.0, txTimeout);
+          .parent(txTimeout)
+          .should('contain', 1.0);
 
-        cy.get(vegaWalletAssociatedBalance, txTimeout).should(
-          'contain',
-          1.0,
-          txTimeout
-        );
+        cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 1.0);
       });
 
       it('Able to disassociate all tokens', function () {
         cy.staking_page_associate_tokens('2');
 
-        cy.get(vegaWalletAssociatedBalance, txTimeout).should(
-          'contain',
-          2.0,
-          txTimeout
-        );
+        cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 2.0);
 
         cy.get('button').contains('Select a validator to nominate').click();
 
@@ -161,11 +140,7 @@ context(
           );
         });
 
-        cy.get(vegaWalletAssociatedBalance, txTimeout).should(
-          'contain',
-          0.0,
-          txTimeout
-        );
+        cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 0.0);
       });
     });
   }


### PR DESCRIPTION
- Corrected the timeouts in the associate flow tests so they should be retrying correctly now

- Added extra assertion to stop node switch test failing from race condition