### PR TITLE
fix: revealed splash screen informing about loading and error (803)

### DIFF
--- a/apps/token/src/app.tsx
+++ b/apps/token/src/app.tsx
@@ -40,35 +40,37 @@ const AppContainer = () => {
   return (
     <Router>
       <AppStateProvider>
-        <AsyncRenderer loading={loading} data={config} error={error}>
-          {Connectors && (
-            <Web3Provider connectors={Connectors}>
-              <Web3Connector>
-                <VegaWalletProvider>
-                  <ContractsProvider>
-                    <AppLoader>
-                      <BalanceManager>
-                        <>
-                          <div className="app max-w-[1300px] mx-auto my-0 grid grid-rows-[min-content_1fr_min-content] min-h-full lg:border-l-1 lg:border-r-1 lg:border-white font-sans text-body lg:text-body-large text-white-80">
-                            <AppBanner />
-                            <TemplateSidebar sidebar={sideBar}>
-                              <AppRouter />
-                            </TemplateSidebar>
-                            <footer className="grid grid-rows-2 grid-cols-[1fr_auto] md:flex md:col-span-2 p-16 gap-12 border-t-1">
-                              <NetworkInfo />
-                            </footer>
-                          </div>
-                          <VegaWalletDialogs />
-                          <TransactionModal />
-                        </>
-                      </BalanceManager>
-                    </AppLoader>
-                  </ContractsProvider>
-                </VegaWalletProvider>
-              </Web3Connector>
-            </Web3Provider>
-          )}
-        </AsyncRenderer>
+        <div className="grid min-h-full text-white-80">
+          <AsyncRenderer loading={loading} data={config} error={error}>
+            {Connectors && (
+              <Web3Provider connectors={Connectors}>
+                <Web3Connector>
+                  <VegaWalletProvider>
+                    <ContractsProvider>
+                      <AppLoader>
+                        <BalanceManager>
+                          <>
+                            <div className="app max-w-[1300px] mx-auto my-0 grid grid-rows-[min-content_1fr_min-content] min-h-full lg:border-l-1 lg:border-r-1 lg:border-white font-sans text-body lg:text-body-large">
+                              <AppBanner />
+                              <TemplateSidebar sidebar={sideBar}>
+                                <AppRouter />
+                              </TemplateSidebar>
+                              <footer className="grid grid-rows-2 grid-cols-[1fr_auto] md:flex md:col-span-2 p-16 gap-12 border-t-1">
+                                <NetworkInfo />
+                              </footer>
+                            </div>
+                            <VegaWalletDialogs />
+                            <TransactionModal />
+                          </>
+                        </BalanceManager>
+                      </AppLoader>
+                    </ContractsProvider>
+                  </VegaWalletProvider>
+                </Web3Connector>
+              </Web3Provider>
+            )}
+          </AsyncRenderer>
+        </div>
       </AppStateProvider>
     </Router>
   );


### PR DESCRIPTION
# Related issues 🔗

Closes #803 

# Description ℹ️

Splash screen is now visible when network is loading or down (error).
Other error messages seem to be ok (see attached screenshots).

# Demo 📺

Initial splash screen:
![Screenshot 2022-08-19 at 14 17 47](https://user-images.githubusercontent.com/1980305/185618267-a7ada20a-40bf-46c8-a543-bf73c485ace6.png)

Other error messages:
![Screenshot 2022-08-19 at 14 25 06](https://user-images.githubusercontent.com/1980305/185618395-fe4f7dbd-7e43-4910-a474-1821f828eb6b.png)
![Screenshot 2022-08-19 at 14 26 17](https://user-images.githubusercontent.com/1980305/185618440-1fe774a8-1377-478e-9f52-9703da71e7f0.png)


# Technical 👨‍🔧

`color` wasn't defined becasue `AsyncRenderer` was outsite of anything definign styles.
