### PR TITLE
fix: tooltip appears behind trigger (1052)

### DIFF
--- a/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
+++ b/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
@@ -27,7 +27,7 @@ export const Tooltip = ({ children, description, open, align }: TooltipProps) =>
             <Content
               align={align}
               alignOffset={8}
-              className="tooltip-content dark:tooltip-content-dark"
+              className="tooltip-content dark:tooltip-content-dark z-20"
             >
               <div className="relative z-0 p-8 bg-black-50 border border-black-60 text-white rounded-sm max-w-sm text-ui">
                 {description}


### PR DESCRIPTION
# Related issues 🔗

Closes #1052 

# Description ℹ️

Bumped up `z-index` of tooltip's content to `z-20` which is the same as for the dialogs.

# Demo 📺

<img width="947" alt="Screenshot 2022-08-19 at 18 03 58" src="https://user-images.githubusercontent.com/1980305/185660351-4d5dd385-65ea-413e-8721-89c8c4ee5116.png">

doesn't break this:
<img width="947" alt="Screenshot 2022-08-19 at 18 04 37" src="https://user-images.githubusercontent.com/1980305/185660452-0ef182ce-cc1e-4299-8e74-37719952c429.png">


