### PR TITLE
fix: update capsule to latest core

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -74,7 +74,7 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install Vega and Vega wallet binaries
+      - name: Install Vega binaries
         run: go install -v ./cmd/vega
         working-directory: vega
 

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -47,7 +47,7 @@ jobs:
       ## Checkout capsule
       #######
 
-     # Checkout capsule to build local network
+      # Checkout capsule to build local network
       - name: Checkout capsule
         uses: actions/checkout@v2
         with:
@@ -76,6 +76,10 @@ jobs:
 
       - name: Install Vega and Vega wallet binaries
         run: go install -v ./cmd/vega
+        working-directory: vega
+
+      - name: Install Vega wallet binaries
+        run: go install ./cmd/vegawallet
         working-directory: vega
 
       - name: Install date-node binaries

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -47,12 +47,12 @@ jobs:
       ## Checkout capsule
       #######
 
-      # Checkout capsule to build local network
+     # Checkout capsule to build local network
       - name: Checkout capsule
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.1
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 
@@ -66,22 +66,20 @@ jobs:
       - name: Set GOBIN
         run: echo GOBIN=$(go env GOPATH)/bin >> $GITHUB_ENV
 
-      - name: Install binaries
-        run: vegacapsule install-bins
-        env:
-          GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          GOBIN: ${{ env.GOBIN }}
-
       - name: Checkout Vega
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: tm35.9
+          ref: develop
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install binary from Vega repo
-        run: go install ./cmd/vega
+      - name: Install Vega and Vega wallet binaries
+        run: go install -v ./cmd/vega
+        working-directory: vega
+
+      - name: Install date-node binaries
+        run: go install ./cmd/data-node
         working-directory: vega
 
       ######

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install Vega and Vega wallet binaries
+      - name: Install Vega binaries
         run: go install -v ./cmd/vega
         working-directory: vega
 

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -31,7 +31,7 @@ jobs:
       ## Checkout capsule
       #######
 
-     # Checkout capsule to build local network
+      # Checkout capsule to build local network
       - name: Checkout capsule
         uses: actions/checkout@v2
         with:
@@ -60,6 +60,10 @@ jobs:
 
       - name: Install Vega and Vega wallet binaries
         run: go install -v ./cmd/vega
+        working-directory: vega
+
+      - name: Install Vega wallet binaries
+        run: go install ./cmd/vegawallet
         working-directory: vega
 
       - name: Install date-node binaries

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -31,12 +31,12 @@ jobs:
       ## Checkout capsule
       #######
 
-      # Checkout capsule to build local network
+     # Checkout capsule to build local network
       - name: Checkout capsule
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.1
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 
@@ -50,22 +50,20 @@ jobs:
       - name: Set GOBIN
         run: echo GOBIN=$(go env GOPATH)/bin >> $GITHUB_ENV
 
-      - name: Install binaries
-        run: vegacapsule install-bins
-        env:
-          GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          GOBIN: ${{ env.GOBIN }}
-
       - name: Checkout Vega
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: tm35.9
+          ref: develop
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install binary from Vega repo
-        run: go install ./cmd/vega
+      - name: Install Vega and Vega wallet binaries
+        run: go install -v ./cmd/vega
+        working-directory: vega
+
+      - name: Install date-node binaries
+        run: go install ./cmd/data-node
         working-directory: vega
 
       ######

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Set up Node 16
         uses: actions/setup-node@v2
         id: npm
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: v0.2.1
+          ref: main
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 
@@ -52,22 +52,20 @@ jobs:
       - name: Set GOBIN
         run: echo GOBIN=$(go env GOPATH)/bin >> $GITHUB_ENV
 
-      - name: Install binaries
-        run: vegacapsule install-bins
-        env:
-          GITHUB_TOKEN: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          GOBIN: ${{ env.GOBIN }}
-
       - name: Checkout Vega
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: tm35.9
+          ref: develop
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install binary from Vega repo
-        run: go install ./cmd/vega
+      - name: Install Vega and Vega wallet binaries
+        run: go install -v ./cmd/vega
+        working-directory: vega
+
+      - name: Install date-node binaries
+        run: go install ./cmd/data-node
         working-directory: vega
 
       ######

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -60,7 +60,7 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Install Vega and Vega wallet binaries
+      - name: Install Vega binaries
         run: go install -v ./cmd/vega
         working-directory: vega
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -64,6 +64,10 @@ jobs:
         run: go install -v ./cmd/vega
         working-directory: vega
 
+      - name: Install Vega wallet binaries
+        run: go install ./cmd/vegawallet
+        working-directory: vega
+
       - name: Install date-node binaries
         run: go install ./cmd/data-node
         working-directory: vega

--- a/apps/token-e2e/src/integration/view/staking.cy.js
+++ b/apps/token-e2e/src/integration/view/staking.cy.js
@@ -124,7 +124,7 @@ context('Staking Page - verify elements on page', function () {
   });
 
   // 1002-STKE-050
-  describe.skip('Should be able to see static information about a validator', function () {
+  describe('Should be able to see static information about a validator', function () {
     before('connect wallets and click on validator', function () {
       cy.vega_wallet_import();
       cy.vega_wallet_connect();


### PR DESCRIPTION
Update Capsule to use the latest Core 0.54

- Temporary pull latest from Capsule and Vega repo in order to get green builds
- Follow-up with changing to use release tags when they are created