### PR TITLE
Fix/1128: Individual proposal pages failing to load

### DIFF
--- a/apps/token/src/routes/governance/components/proposal-terms-json/proposal-terms-json.tsx
+++ b/apps/token/src/routes/governance/components/proposal-terms-json/proposal-terms-json.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next';
 import { SyntaxHighlighter } from '@vegaprotocol/ui-toolkit';
-import type { RestProposalResponse } from '../../proposal/proposal-container';
+import type { Proposal_proposal_terms } from '../../proposal/__generated__/Proposal';
 
 export const ProposalTermsJson = ({
   terms,
 }: {
-  terms: RestProposalResponse;
+  terms: Proposal_proposal_terms;
 }) => {
   const { t } = useTranslation();
   return (

--- a/apps/token/src/routes/governance/components/proposal/proposal.tsx
+++ b/apps/token/src/routes/governance/components/proposal/proposal.tsx
@@ -1,6 +1,8 @@
 import { ProposalHeader } from '../proposal-detail-header/proposal-header';
-import type { Proposal_proposal } from '../../proposal/__generated__/Proposal';
-import type { RestProposalResponse } from '../../proposal/proposal-container';
+import type {
+  Proposal_proposal,
+  Proposal_proposal_terms,
+} from '../../proposal/__generated__/Proposal';
 import { ProposalChangeTable } from '../proposal-change-table';
 import { ProposalTermsJson } from '../proposal-terms-json';
 import { ProposalVotesTable } from '../proposal-votes-table';
@@ -8,7 +10,7 @@ import { VoteDetails } from '../vote-details';
 
 interface ProposalProps {
   proposal: Proposal_proposal;
-  terms: RestProposalResponse;
+  terms: Proposal_proposal_terms;
 }
 
 export const Proposal = ({ proposal, terms }: ProposalProps) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #1128

# Description ℹ️

Ensures individual proposal pages are loading, based on the same data as the other proposal pages.

# Technical 👨‍🔧

Individual proposal pages were built early on and relied on the REST endpoint to get the 'terms' data. Fairground was broken for individual proposals because it didn't have an `NX_VEGA_REST` env var, and was (possibly?) using a cached version which pointed at a borked node. The cleanest solution IMO was to remove the unnecessary REST reliance, instead using GQL fully, bringing everything in line. 
