### PR TITLE
chore: update test asserting SSL

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Set up Node 16
         uses: actions/setup-node@v2
         id: npm

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Set up Node 16
         uses: actions/setup-node@v2
         id: npm

--- a/apps/explorer-e2e/src/integration/node-switcher.cy.js
+++ b/apps/explorer-e2e/src/integration/node-switcher.cy.js
@@ -31,7 +31,7 @@ context('Node switcher', function () {
           cy.contains('-').should('not.exist');
           cy.getByTestId('response-time-cell').should('contain.text', 'ms');
           cy.getByTestId('block-cell').should('not.be.empty');
-          cy.getByTestId('ssl-cell').should('have.text', 'Yes');
+          cy.getByTestId('ssl-cell').should('not.be.empty');
         });
     });
 
@@ -55,9 +55,12 @@ context('Node switcher', function () {
       cy.getByTestId('node-url-custom').click();
 
       cy.getByTestId(customNodeBtn).within(() => {
-        cy.get('input').clear().type('https://api.token.vega.xyz/query');
+        cy.get('input')
+          .clear()
+          .type('https://api.n10.testnet.vega.xyz/graphql');
         cy.getByTestId('link').click();
       });
+      cy.getByTestId('ssl-cell').should('contain.text', 'Yes');
       validateNodeError(errorTypeTxt, nodeErrorTxt);
     });
 


### PR DESCRIPTION
Alter node switcher test as connecting to SSL is returning NO. 

There's a schema change that is not rolled out to Testnet yet which also requires a fix on FE. Once that's done the test change can be reverted.

- Updated Go version in CI which was missed in last PR
