### PR TITLE
Feat/1147 input setter

### DIFF
--- a/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
+++ b/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
@@ -92,6 +92,14 @@ export const DealTicketSize = ({
     [onValueChange, positionDecimalPlaces]
   );
 
+  const onSliderValueChange = useCallback(
+    (value: number[]) => {
+      setInputValue(value[0]);
+      onValueChange(value);
+    },
+    [onValueChange]
+  );
+
   return max === 0 ? (
     <p>Not enough balance to trade</p>
   ) : (
@@ -103,7 +111,7 @@ export const DealTicketSize = ({
       <SliderRoot
         className="mb-2"
         value={[value]}
-        onValueChange={onValueChange}
+        onValueChange={onSliderValueChange}
         step={step}
         min={min}
         max={max}

--- a/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
+++ b/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
@@ -13,7 +13,7 @@ import {
 } from '@vegaprotocol/ui-toolkit';
 import { BigNumber } from 'bignumber.js';
 import { DealTicketEstimates } from './deal-ticket-estimates';
-import { InputSetter } from '../input-setter/';
+import { InputSetter } from '../input-setter';
 import * as constants from './constants';
 
 interface DealTicketSizeProps {

--- a/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
+++ b/apps/console-lite/src/app/components/deal-ticket/deal-ticket-size.tsx
@@ -7,13 +7,13 @@ import {
   SliderThumb,
   SliderTrack,
   SliderRange,
-  Input,
   FormGroup,
   Icon,
   Tooltip,
 } from '@vegaprotocol/ui-toolkit';
 import { BigNumber } from 'bignumber.js';
 import { DealTicketEstimates } from './deal-ticket-estimates';
+import { InputSetter } from '../input-setter/';
 import * as constants from './constants';
 
 interface DealTicketSizeProps {
@@ -61,7 +61,6 @@ export const DealTicketSize = ({
 }: DealTicketSizeProps) => {
   const sizeRatios = [0, 25, 50, 75, 100];
   const [inputValue, setInputValue] = useState(value);
-  const [isInputVisible, setIsInputVisible] = useState(false);
 
   const onInputValueChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -84,30 +83,13 @@ export const DealTicketSize = ({
 
   const onButtonValueChange = useCallback(
     (size: number) => {
-      if (isInputVisible) {
-        setIsInputVisible(false);
-      }
       const newVal = new BigNumber(size)
         .decimalPlaces(positionDecimalPlaces)
         .toNumber();
       onValueChange([newVal]);
       setInputValue(newVal);
     },
-    [isInputVisible, onValueChange, positionDecimalPlaces]
-  );
-
-  const toggleInput = useCallback(() => {
-    setIsInputVisible(!isInputVisible);
-  }, [isInputVisible]);
-
-  const onInputEnter = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter') {
-        event.stopPropagation();
-        toggleInput();
-      }
-    },
-    [toggleInput]
+    [onValueChange, positionDecimalPlaces]
   );
 
   return max === 0 ? (
@@ -160,36 +142,16 @@ export const DealTicketSize = ({
               label="Enter Size"
               labelFor="trade-size-input"
             >
-              {isInputVisible ? (
-                <div className="flex items-center">
-                  <Input
-                    id="input-order-size-market"
-                    type="number"
-                    step={step}
-                    min={min}
-                    max={max}
-                    className="w-full"
-                    value={inputValue}
-                    onKeyDown={onInputEnter}
-                    onChange={onInputValueChange}
-                  />
-                  <button
-                    className="no-underline hover:underline text-blue ml-2"
-                    type="button"
-                    onClick={toggleInput}
-                  >
-                    {t('set')}
-                  </button>
-                </div>
-              ) : (
-                <button
-                  className="no-underline hover:underline text-blue"
-                  onClick={toggleInput}
-                  type="button"
-                >
-                  {value}
-                </button>
-              )}
+              <InputSetter
+                id="input-order-size-market"
+                type="number"
+                step={step}
+                min={min}
+                max={max}
+                className="w-full"
+                value={inputValue}
+                onChange={onInputValueChange}
+              />
             </FormGroup>
           </dd>
         </div>

--- a/apps/console-lite/src/app/components/input-setter/index.ts
+++ b/apps/console-lite/src/app/components/input-setter/index.ts
@@ -1,0 +1,1 @@
+export * from './input-setter';

--- a/apps/console-lite/src/app/components/input-setter/input-setter.spec.tsx
+++ b/apps/console-lite/src/app/components/input-setter/input-setter.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { InputSetter } from './index';
+
+describe('InputSetter Component', () => {
+  it('should show the correct value and visibility based on props', async () => {
+    const value = 'Hello';
+    const isInputToggled = true;
+    const { getByRole } = await render(
+      <InputSetter
+        id="input-order-size-market"
+        type="number"
+        className="w-full"
+        value={value}
+        isInputToggled={isInputToggled}
+        onChange={() => false}
+      />
+    );
+    const input = getByRole('spinbutton');
+    const btn = getByRole('button');
+    expect(input).toHaveAttribute('value', value);
+    expect(btn).toBeTruthy();
+  });
+
+  it('should get toggled when button is clicked', async () => {
+    const value = 'Hello';
+    const isInputToggled = true;
+    const { getByRole } = await render(
+      <InputSetter
+        id="input-order-size-market"
+        type="number"
+        className="w-full"
+        value={value}
+        isInputToggled={isInputToggled}
+        onChange={() => false}
+      />
+    );
+    const btn = getByRole('button');
+    fireEvent.click(btn);
+    await waitFor(() => getByRole('button'));
+    expect(getByRole('button')).toHaveTextContent(value);
+  });
+
+  it('should get toggled when enter button is pressed', async () => {
+    const value = 'Hello';
+    const isInputToggled = true;
+    const { getByRole } = await render(
+      <InputSetter
+        id="input-order-size-market"
+        name="input-order-size-market"
+        type="number"
+        className="w-full"
+        value={value}
+        isInputToggled={isInputToggled}
+        onChange={() => false}
+      />
+    );
+    fireEvent.keyDown(getByRole('spinbutton'), {
+      key: 'Enter',
+    });
+    await waitFor(() => getByRole('button'));
+    expect(getByRole('button')).toHaveTextContent(value);
+  });
+});

--- a/apps/console-lite/src/app/components/input-setter/input-setter.spec.tsx
+++ b/apps/console-lite/src/app/components/input-setter/input-setter.spec.tsx
@@ -5,14 +5,14 @@ import { InputSetter } from './index';
 describe('InputSetter Component', () => {
   it('should show the correct value and visibility based on props', async () => {
     const value = 'Hello';
-    const isInputToggled = true;
+    const isInputVisible = true;
     const { getByRole } = await render(
       <InputSetter
         id="input-order-size-market"
         type="number"
         className="w-full"
         value={value}
-        isInputToggled={isInputToggled}
+        isInputVisible={isInputVisible}
         onChange={() => false}
       />
     );
@@ -22,16 +22,16 @@ describe('InputSetter Component', () => {
     expect(btn).toBeTruthy();
   });
 
-  it('should get toggled when button is clicked', async () => {
+  it('should toggle the visibility of the input when the button is clicked', async () => {
     const value = 'Hello';
-    const isInputToggled = true;
+    const isInputVisible = true;
     const { getByRole } = await render(
       <InputSetter
         id="input-order-size-market"
         type="number"
         className="w-full"
         value={value}
-        isInputToggled={isInputToggled}
+        isInputVisible={isInputVisible}
         onChange={() => false}
       />
     );
@@ -41,9 +41,9 @@ describe('InputSetter Component', () => {
     expect(getByRole('button')).toHaveTextContent(value);
   });
 
-  it('should get toggled when enter button is pressed', async () => {
+  it('should toggle the visibility of the input when the enter key is pressed', async () => {
     const value = 'Hello';
-    const isInputToggled = true;
+    const isInputVisible = true;
     const { getByRole } = await render(
       <InputSetter
         id="input-order-size-market"
@@ -51,7 +51,7 @@ describe('InputSetter Component', () => {
         type="number"
         className="w-full"
         value={value}
-        isInputToggled={isInputToggled}
+        isInputVisible={isInputVisible}
         onChange={() => false}
       />
     );

--- a/apps/console-lite/src/app/components/input-setter/input-setter.tsx
+++ b/apps/console-lite/src/app/components/input-setter/input-setter.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useState } from 'react';
+import { t } from '@vegaprotocol/react-helpers';
+import { Input } from '@vegaprotocol/ui-toolkit';
+import type { InputProps } from '@vegaprotocol/ui-toolkit';
+
+interface InputSetterProps {
+  buttonLabel?: string;
+  value: string | number;
+  isInputToggled?: boolean;
+  onValueChange?: () => string;
+}
+
+export const InputSetter = ({
+  buttonLabel = t('set'),
+  value = '',
+  isInputToggled = false,
+  onValueChange,
+  ...props
+}: InputSetterProps & InputProps) => {
+  const [isInputVisible, setIsInputVisible] = useState(isInputToggled);
+
+  const toggleInput = useCallback(() => {
+    setIsInputVisible(!isInputVisible);
+  }, [isInputVisible]);
+
+  const onInputEnter = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        event.stopPropagation();
+        toggleInput();
+      }
+    },
+    [toggleInput]
+  );
+
+  return isInputVisible ? (
+    <div className="flex items-center">
+      <Input {...props} value={value} onKeyDown={onInputEnter} />
+      <button
+        type="button"
+        className="no-underline hover:underline text-blue ml-2"
+        onClick={toggleInput}
+      >
+        {buttonLabel}
+      </button>
+    </div>
+  ) : (
+    <button
+      type="button"
+      className="no-underline hover:underline text-blue"
+      onClick={toggleInput}
+    >
+      {value}
+    </button>
+  );
+};

--- a/apps/console-lite/src/app/components/input-setter/input-setter.tsx
+++ b/apps/console-lite/src/app/components/input-setter/input-setter.tsx
@@ -17,11 +17,11 @@ export const InputSetter = ({
   onValueChange,
   ...props
 }: InputSetterProps & InputProps) => {
-  const [isVisible, setIsVisible] = useState(isInputVisible);
+  const [isInputToggled, setIsInputToggled] = useState(isInputVisible);
 
   const toggleInput = useCallback(() => {
-    setIsVisible(!isInputVisible);
-  }, [isInputVisible]);
+    setIsInputToggled(!isInputToggled);
+  }, [isInputToggled]);
 
   const onInputEnter = useCallback(
     (event: React.KeyboardEvent) => {
@@ -33,7 +33,7 @@ export const InputSetter = ({
     [toggleInput]
   );
 
-  return isVisible ? (
+  return isInputToggled ? (
     <div className="flex items-center">
       <Input {...props} value={value} onKeyDown={onInputEnter} />
       <button

--- a/apps/console-lite/src/app/components/input-setter/input-setter.tsx
+++ b/apps/console-lite/src/app/components/input-setter/input-setter.tsx
@@ -6,21 +6,21 @@ import type { InputProps } from '@vegaprotocol/ui-toolkit';
 interface InputSetterProps {
   buttonLabel?: string;
   value: string | number;
-  isInputToggled?: boolean;
+  isInputVisible?: boolean;
   onValueChange?: () => string;
 }
 
 export const InputSetter = ({
   buttonLabel = t('set'),
   value = '',
-  isInputToggled = false,
+  isInputVisible = false,
   onValueChange,
   ...props
 }: InputSetterProps & InputProps) => {
-  const [isInputVisible, setIsInputVisible] = useState(isInputToggled);
+  const [isVisible, setIsVisible] = useState(isInputVisible);
 
   const toggleInput = useCallback(() => {
-    setIsInputVisible(!isInputVisible);
+    setIsVisible(!isInputVisible);
   }, [isInputVisible]);
 
   const onInputEnter = useCallback(
@@ -33,7 +33,7 @@ export const InputSetter = ({
     [toggleInput]
   );
 
-  return isInputVisible ? (
+  return isVisible ? (
     <div className="flex items-center">
       <Input {...props} value={value} onKeyDown={onInputEnter} />
       <button

--- a/apps/console-lite/src/app/components/portfolio/portfolio.tsx
+++ b/apps/console-lite/src/app/components/portfolio/portfolio.tsx
@@ -11,7 +11,11 @@ import ConnectWallet from '../wallet-connector';
 export const Portfolio = () => {
   const { keypair } = useVegaWallet();
   if (!keypair) {
-    return <ConnectWallet />;
+    return (
+      <section className="xl:w-1/2">
+        <ConnectWallet />
+      </section>
+    );
   }
   return (
     <Tabs>

--- a/libs/ui-toolkit/src/components/input/input.tsx
+++ b/libs/ui-toolkit/src/components/input/input.tsx
@@ -55,7 +55,7 @@ type InputAppend = NoPrepend &
 
 type AffixProps = InputPrepend | InputAppend;
 
-type InputProps = InputRootProps & AffixProps;
+export type InputProps = InputRootProps & AffixProps;
 
 export const inputStyle = ({
   style,


### PR DESCRIPTION
# Related issues 🔗

Closes #1147 

# Description ℹ️

Created a separate reusable component from the input setter with button that was previously used in deal ticket size, so we can reuse for setting slippage.

# Demo 📺
<img width="665" alt="Screenshot 2022-08-25 at 12 12 53" src="https://user-images.githubusercontent.com/102954831/186650188-49dc19e5-47c2-47a9-9eef-e1238ca0f729.png">
<img width="661" alt="Screenshot 2022-08-25 at 12 12 46" src="https://user-images.githubusercontent.com/102954831/186650195-a7f902aa-ead4-45cf-bc09-a0d010604631.png">
<img width="661" alt="Screenshot 2022-08-25 at 12 12 34" src="https://user-images.githubusercontent.com/102954831/186650199-aa856a28-a2c9-4af9-b726-c53835671ea1.png">

# Technical 👨‍🔧

- Added unit tests
- Created new component
- Exported InputProps from ui-toolkit