### PR TITLE
Fix/1152: Rejected proposal details pages have wrong url

### DIFF
--- a/apps/token/src/routes/governance/components/proposals-list-item/proposals-list-item-details.tsx
+++ b/apps/token/src/routes/governance/components/proposals-list-item/proposals-list-item-details.tsx
@@ -16,6 +16,7 @@ import {
   ProposalRejectionReasonMapping,
   ProposalState,
 } from '@vegaprotocol/types';
+import Routes from '../../../routes';
 
 const MajorityNotReached = () => {
   const { t } = useTranslation();
@@ -199,7 +200,7 @@ export const ProposalsListItemDetails = ({
       )}
       {proposal.id && (
         <div className="col-start-2 row-start-2 justify-self-end">
-          <Link to={proposal.id}>
+          <Link to={`${Routes.GOVERNANCE}/${proposal.id}`}>
             <Button variant="secondary" data-testid="view-proposal-btn">
               {t('View')}
             </Button>


### PR DESCRIPTION
# Related issues 🔗

Closes #1152

# Description ℹ️

Rejected proposal details pages incorrectly had '/rejected' in the url, this fix removes it.
