### PR TITLE
Add env vars as nx-cloud cache inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,5 @@
 {
-  "npmScope": "@vegaprotocol",
+  "npmScope": "vegaprotocol",
   "affected": {
     "defaultBase": "master"
   },
@@ -18,7 +18,16 @@
       "runner": "@nrwl/nx-cloud",
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
-        "accessToken": "OTY4ZjdlZTItNGIwNy00NDcyLTllZjctOWIzYTg1NWE0Yzg1fHJlYWQtd3JpdGU="
+        "accessToken": "OTY4ZjdlZTItNGIwNy00NDcyLTllZjctOWIzYTg1NWE0Yzg1fHJlYWQtd3JpdGU=",
+        "runtimeCacheInputs": [
+          "echo $NX_VEGA_NETWORKS",
+          "echo $NX_VEGA_ENV",
+          "echo $NX_VEGA_URL",
+          "echo $NX_TENDERMINT_URL",
+          "echo $NX_TENDERMINT_WEBSOCKET_URL",
+          "echo $NX_USE_ENV_OVERRIDES",
+          "echo $NX_ETHEREUM_PROVIDER_URL"
+        ]
       }
     }
   },


### PR DESCRIPTION
# Related issues 🔗

Closes #1174. Replaces #1022. Closes #1120 

# Description ℹ️

A previous issue with builds failing due to improper dependency mapping seemed to be fixed in #1022, but wasn't. This 
meant that builds could sometimes fail to build parts (css), or fail to take on environment variable updates. This PR
follows a suggestion over in the NX repo to add environment variables as cache inputs. It *seems* to work.

- Revert change to workspace name, back to 'vegaprotocol' from '@vegaprotocol'
- Add important NX_ environment variables as cache inputs
