### PR TITLE
ci: dont run capsule tests if PR is draft

### DIFF
--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -11,7 +11,7 @@ jobs:
   pr:
     name: Run capsule tests - PR
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     env:
       GO111MODULE: 'on'
     steps:


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Checks to see if PR is not a draft PR before running capsule tests
