### PR TITLE
ci: check for draft pr for cypress test run

### DIFF
--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -11,7 +11,7 @@ jobs:
   pr:
     name: Run capsule tests - PR
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     env:
       GO111MODULE: 'on'
     steps:

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -6,6 +6,11 @@ on:
       - master
       - develop
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   pr:


### PR DESCRIPTION
# Description ℹ️

Adds a condition to check if a PR is in draft before triggering the capsule build and test run. Once its changed to ready for review the run will be triggered