### PR TITLE
Fix positions table handling of market name

### DIFF
--- a/libs/positions/src/lib/positions-table.spec.tsx
+++ b/libs/positions/src/lib/positions-table.spec.tsx
@@ -66,6 +66,18 @@ it('Splits market name', async () => {
   expect(screen.getByText('31 july 2022')).toBeTruthy();
 });
 
+it('Does not fail if the market name does not match the split pattern', async () => {
+  const breakingMarketName = 'OP/USD AUG-SEP22 - Incentive';
+  const row = [
+    Object.assign({}, singleRow, { marketName: breakingMarketName }),
+  ];
+  await act(async () => {
+    render(<PositionsTable rowData={row} />);
+  });
+
+  expect(screen.getByText(breakingMarketName)).toBeTruthy();
+});
+
 it('add color and sign to amount, displays positive notional value', async () => {
   let result: RenderResult;
   await act(async () => {

--- a/libs/positions/src/lib/positions-table.tsx
+++ b/libs/positions/src/lib/positions-table.tsx
@@ -172,7 +172,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
             }
             // split market name into two parts, 'Part1 (Part2)' or 'Part1 - Part2'
             const matches = value.match(/^(.*)(\((.*)\)| - (.*))\s*$/);
-            if (matches) {
+            if (matches && matches[1] && matches[3]) {
               return [matches[1].trim(), matches[3].trim()];
             }
             return [value];


### PR DESCRIPTION
# Related issues 🔗

Closes #1261

# Description ℹ️

See ticket for a great description. If the market name did not fit what the regex expected,
it was possible to break the whole console for anyone with a position in a 'poorly' named
market.

- Improve market name split


# Technical 👨‍🔧

The code naively assumed the market name would split as expected
