### PR TITLE
Chore/use vega 0.54.0

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: develop
+          ref: v0.54.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: develop
+          ref: v0.54.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: develop
+          ref: v0.54.0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 


### PR DESCRIPTION
# Related issues 🔗

Our pipeline is currently broken with any tests that use the Vegawallet failing. 

- Update workflow to pull from `0.54.0` instead of `develop`
