### PR TITLE
fix: print env in netlify console

### DIFF
--- a/apps/token/project.json
+++ b/apps/token/project.json
@@ -70,6 +70,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
+          "printenv",
           "cp apps/token/netlify.toml netlify.toml",
           "nx build token"
         ]


### PR DESCRIPTION
Print the env vars when building the token app in netlify

Debugging #1270