### PR TITLE
chore: revert back to using previous ubuntu runners

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   manual:
     name: Run capsule tests -- manual trigger
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-latest
     env:
       GO111MODULE: 'on'
       GOPROXY: ${{ secrets.GO_PROXY }}

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   nightly:
     name: Run capsule tests -- nightly
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-latest
     env:
       GO111MODULE: 'on'
     steps:

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   pr:
     name: Run capsule tests - PR
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     env:
       GO111MODULE: 'on'


### PR DESCRIPTION
Runners are stuck on queue right now. Revert back to previous runners