### PR TITLE
test: add test for filtering assets not enabled

### DIFF
--- a/apps/trading-e2e/src/integration/deposit.cy.ts
+++ b/apps/trading-e2e/src/integration/deposit.cy.ts
@@ -59,9 +59,9 @@ describe('deposit form validation', () => {
   it('unable to select assets not enabled', () => {
     cy.getByTestId('deposit-submit').click();
     // Assets not enabled in mocks
-    cy.get(assetSelectField + ' option:contains(Asset 2)').should('not.exist')
-    cy.get(assetSelectField + ' option:contains(Asset 3)').should('not.exist')
-    cy.get(assetSelectField + ' option:contains(Asset 4)').should('not.exist')
+    cy.get(assetSelectField + ' option:contains(Asset 2)').should('not.exist');
+    cy.get(assetSelectField + ' option:contains(Asset 3)').should('not.exist');
+    cy.get(assetSelectField + ' option:contains(Asset 4)').should('not.exist');
   });
 
   it('able to disconnect eth wallet', () => {

--- a/apps/trading-e2e/src/integration/deposit.cy.ts
+++ b/apps/trading-e2e/src/integration/deposit.cy.ts
@@ -3,6 +3,10 @@ import { generateDepositPage } from '../support/mocks/generate-deposit-page';
 import { generateNetworkParameters } from '../support/mocks/generate-network-parameters';
 
 const connectEthWalletBtn = 'connect-eth-wallet-btn';
+const assetSelectField = 'select[name="asset"]';
+const toAddressField = 'input[name="to"]';
+const amountField = 'input[name="amount"]';
+const formFieldError = 'input-error-text';
 
 describe('deposit form validation', () => {
   beforeEach(() => {
@@ -21,11 +25,6 @@ describe('deposit form validation', () => {
   });
 
   it('handles empty fields', () => {
-    const assetSelectField = 'select[name="asset"]';
-    const toAddressField = 'input[name="to"]';
-    const amountField = 'input[name="amount"]';
-    const formFieldError = 'input-error-text';
-
     // Submit form to trigger any empty validaion messages
     cy.getByTestId('deposit-submit').click();
 
@@ -55,6 +54,14 @@ describe('deposit form validation', () => {
       .type('100')
       .next(`[data-testid="${formFieldError}"]`)
       .should('have.text', 'Insufficient amount in Ethereum wallet');
+  });
+
+  it('unable to select assets not enabled', () => {
+    cy.getByTestId('deposit-submit').click();
+    // Assets not enabled in mocks
+    cy.get(assetSelectField + ' option:contains(Asset 2)').should('not.exist')
+    cy.get(assetSelectField + ' option:contains(Asset 3)').should('not.exist')
+    cy.get(assetSelectField + ' option:contains(Asset 4)').should('not.exist')
   });
 
   it('able to disconnect eth wallet', () => {

--- a/apps/trading-e2e/src/integration/home.cy.ts
+++ b/apps/trading-e2e/src/integration/home.cy.ts
@@ -5,6 +5,10 @@ import { mockTradingPage } from '../support/trading';
 describe('home', () => {
   const selectMarketOverlay = 'select-market-list';
 
+  beforeEach('load homepage', () => {
+    cy.visit('/');
+  });
+
   describe('default market found', () => {
     it('redirects to a default market with the landing dialog open', () => {
       cy.mockGQL((req) => {

--- a/apps/trading-e2e/src/support/mocks/generate-deposit-page.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-deposit-page.ts
@@ -39,6 +39,51 @@ export const generateDepositPage = (
           },
           __typename: 'AssetEdge',
         },
+        {
+          node: {
+            id: 'asset-2',
+            symbol: 'AST2',
+            name: 'Asset 2',
+            decimals: 5,
+            status: AssetStatus.STATUS_PENDING_LISTING,
+            source: {
+              __typename: 'ERC20',
+              contractAddress: '0x444b9aDA947130Fc320a144cd22bC1641e5c9d82',
+            },
+            __typename: 'Asset',
+          },
+          __typename: 'AssetEdge',
+        },
+        {
+          node: {
+            id: 'asset-3',
+            symbol: 'AST3',
+            name: 'Asset 3',
+            decimals: 5,
+            status: AssetStatus.STATUS_PROPOSED,
+            source: {
+              __typename: 'ERC20',
+              contractAddress: '0x444b9aDA947130Fc320a144cd22bC1641e5c9d83',
+            },
+            __typename: 'Asset',
+          },
+          __typename: 'AssetEdge',
+        },
+        {
+          node: {
+            id: 'asset-4',
+            symbol: 'AST4',
+            name: 'Asset 4',
+            decimals: 5,
+            status: AssetStatus.STATUS_REJECTED,
+            source: {
+              __typename: 'ERC20',
+              contractAddress: '0x444b9aDA947130Fc320a144cd22bC1641e5c9d84',
+            },
+            __typename: 'Asset',
+          },
+          __typename: 'AssetEdge',
+        },
       ],
       __typename: 'AssetsConnection',
     },


### PR DESCRIPTION
# Related issues 🔗

Closes #1108 

# Description ℹ️

- Add test to check that non-enabled assets are not selectable in deposits
