### PR TITLE
fix: use correct graphql candle timestamp field

### DIFF
--- a/apps/trading-e2e/src/support/mocks/generate-candles.ts
+++ b/apps/trading-e2e/src/support/mocks/generate-candles.ts
@@ -10,7 +10,7 @@ export const generateCandles = (
 ): CandlesQuery => {
   const candles: CandleFieldsFragment[] = [
     {
-      datetime: '2022-04-06T09:15:00Z',
+      timestamp: '1661515200000000000',
       high: '17481092',
       low: '17403651',
       open: '17458833',
@@ -19,7 +19,7 @@ export const generateCandles = (
       __typename: 'Candle',
     },
     {
-      datetime: '2022-04-06T09:30:00Z',
+      timestamp: '1661516100000000000',
       high: '17491202',
       low: '17361138',
       open: '17446470',
@@ -28,7 +28,7 @@ export const generateCandles = (
       __typename: 'Candle',
     },
     {
-      datetime: '2022-04-06T09:45:00Z',
+      timestamp: '1661517000000000000',
       high: '17424522',
       low: '17337719',
       open: '17367174',

--- a/libs/candles-chart/src/lib/Candles.graphql
+++ b/libs/candles-chart/src/lib/Candles.graphql
@@ -1,5 +1,5 @@
 fragment CandleFields on Candle {
-  datetime
+  timestamp
   high
   low
   open

--- a/libs/candles-chart/src/lib/__generated__/Candles.ts
+++ b/libs/candles-chart/src/lib/__generated__/Candles.ts
@@ -3,7 +3,7 @@ import { Schema as Types } from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type CandleFieldsFragment = { __typename?: 'Candle', datetime: string, high: string, low: string, open: string, close: string, volume: string };
+export type CandleFieldsFragment = { __typename?: 'Candle', timestamp: string, high: string, low: string, open: string, close: string, volume: string };
 
 export type CandlesQueryVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
@@ -12,7 +12,7 @@ export type CandlesQueryVariables = Types.Exact<{
 }>;
 
 
-export type CandlesQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', id: string, name: string, code: string } }, candles?: Array<{ __typename?: 'Candle', datetime: string, high: string, low: string, open: string, close: string, volume: string } | null> | null } | null };
+export type CandlesQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', id: string, name: string, code: string } }, candles?: Array<{ __typename?: 'Candle', timestamp: string, high: string, low: string, open: string, close: string, volume: string } | null> | null } | null };
 
 export type CandlesEventsSubscriptionVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
@@ -20,11 +20,11 @@ export type CandlesEventsSubscriptionVariables = Types.Exact<{
 }>;
 
 
-export type CandlesEventsSubscription = { __typename?: 'Subscription', candles: { __typename?: 'Candle', datetime: string, high: string, low: string, open: string, close: string, volume: string } };
+export type CandlesEventsSubscription = { __typename?: 'Subscription', candles: { __typename?: 'Candle', timestamp: string, high: string, low: string, open: string, close: string, volume: string } };
 
 export const CandleFieldsFragmentDoc = gql`
     fragment CandleFields on Candle {
-  datetime
+  timestamp
   high
   low
   open

--- a/libs/candles-chart/src/lib/data-source.ts
+++ b/libs/candles-chart/src/lib/data-source.ts
@@ -199,7 +199,7 @@ function parseCandle(
   decimalPlaces: number
 ): Candle {
   return {
-    date: new Date(candle.datetime),
+    date: new Date(Number(candle.timestamp) / 1_000_000),
     high: Number(addDecimal(candle.high, decimalPlaces)),
     low: Number(addDecimal(candle.low, decimalPlaces)),
     open: Number(addDecimal(candle.open, decimalPlaces)),


### PR DESCRIPTION
# Related issues 🔗

Closes #1323 

# Description ℹ️

Uses `timestamp` rather than `datetime` when querying for candles. The former is the time at which the candle occurred. The latter is the time the candle data was last updated.

# Technical 👨‍🔧

The `timestamp` field represents the UNIX epoch in nanoseconds.