### PR TITLE
fix(stats-manager): fix uptime pointing to incorrect field

### DIFF
--- a/libs/network-stats/src/components/stats-manager/__generated__/NetworkStats.ts
+++ b/libs/network-stats/src/components/stats-manager/__generated__/NetworkStats.ts
@@ -25,10 +25,6 @@ export interface NetworkStats_nodeData {
    * Number of nodes validating
    */
   validatingNodes: number;
-  /**
-   * Total uptime for all epochs across all nodes. Or specify a number of epochs
-   */
-  uptime: number;
 }
 
 export interface NetworkStats_statistics {
@@ -81,6 +77,10 @@ export interface NetworkStats_statistics {
    * Current chain ID
    */
   chainId: string;
+  /**
+   * RFC3339Nano uptime of the node
+   */
+  upTime: string;
 }
 
 export interface NetworkStats {

--- a/libs/network-stats/src/components/stats-manager/stats-manager.tsx
+++ b/libs/network-stats/src/components/stats-manager/stats-manager.tsx
@@ -24,7 +24,6 @@ const STATS_QUERY = gql`
       totalNodes
       inactiveNodes
       validatingNodes
-      uptime
     }
     statistics {
       status
@@ -39,6 +38,7 @@ const STATS_QUERY = gql`
       appVersion
       chainVersion
       chainId
+      upTime
     }
   }
 `;

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -140,7 +140,7 @@ export const statsFields: { [key in keyof Stats]: StatFields[] } = {
       description: t('Tendermint software version on this node'),
     },
   ],
-  uptime: [
+  upTime: [
     {
       title: t('Uptime'),
       formatter: (t: string) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #1199 

# Description ℹ️

Fixes the uptime pointing to the nodeData rather than statistics

# Demo 📺

N/A

# Technical 👨‍🔧

- regenerated types
- querying upTime in stats instead of network node