### PR TITLE
chore: update trading testnet config

### DIFF
--- a/apps/trading/.env.testnet
+++ b/apps/trading/.env.testnet
@@ -1,8 +1,10 @@
 # App configuration variables
 NX_VEGA_ENV=TESTNET
-NX_VEGA_URL=https://api.n09.testnet.vega.xyz/graphql
+NX_VEGA_URL=https://api.n07.testnet.vega.xyz/graphql
 NX_VEGA_NETWORKS='{\"MAINNET\":\"https://alpha.console.vega.xyz\"}'
 NX_ETHEREUM_PROVIDER_URL=https://ropsten.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
 NX_ETHERSCAN_URL=https://ropsten.etherscan.io
+NX_USE_ENV_OVERRIDES=1
 NX_VEGA_EXPLORER_URL=https://explorer.fairground.wtf
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
+NX_VEGA_WALLET_URL=http://localhost:1789/api/v1


### PR DESCRIPTION
# Description ℹ️

`.env.testnet` in trading was most probably outdated resulting with error during build. It's updated now.
