### PR TITLE
feat: page title (660)

### DIFF
--- a/apps/trading-e2e/src/integration/home.cy.ts
+++ b/apps/trading-e2e/src/integration/home.cy.ts
@@ -63,9 +63,13 @@ describe('home', { tags: '@regression' }, () => {
           },
         };
         aliasQuery(req, 'Markets', data);
+        aliasQuery(req, 'MarketsDataQuery', data);
+        aliasQuery(req, 'MarketsCandlesQuery', data);
       });
       cy.visit('/');
       cy.wait('@Markets');
+      cy.wait('@MarketsDataQuery');
+      cy.wait('@MarketsCandlesQuery');
       cy.url().should('eq', Cypress.config().baseUrl + '/markets');
     });
   });

--- a/apps/trading/pages/_app.page.tsx
+++ b/apps/trading/pages/_app.page.tsx
@@ -3,7 +3,11 @@ import Head from 'next/head';
 import { Navbar } from '../components/navbar';
 import { t, ThemeContext, useThemeSwitcher } from '@vegaprotocol/react-helpers';
 import { VegaConnectDialog, VegaWalletProvider } from '@vegaprotocol/wallet';
-import { EnvironmentProvider } from '@vegaprotocol/environment';
+import {
+  EnvironmentProvider,
+  envTriggerMapping,
+  useEnvironment,
+} from '@vegaprotocol/environment';
 import { Connectors } from '../lib/vega-connectors';
 import { AppLoader } from '../components/app-loader';
 import { RiskNoticeDialog } from '../components/risk-notice-dialog';
@@ -14,19 +18,32 @@ import {
   useAssetDetailsDialogStore,
 } from '@vegaprotocol/assets';
 import { Footer } from '../components/footer';
+import { useMemo } from 'react';
+
+const DEFAULT_TITLE = t('Welcome to Vega trading!');
 
 function AppBody({ Component, pageProps }: AppProps) {
-  const { connectDialog, update } = useGlobalStore((store) => ({
+  const { connectDialog, pageTitle, update } = useGlobalStore((store) => ({
     connectDialog: store.connectDialog,
+    pageTitle: store.pageTitle,
     update: store.update,
   }));
   const { isOpen, symbol, trigger, setOpen } = useAssetDetailsDialogStore();
   const [theme, toggleTheme] = useThemeSwitcher();
 
+  const { VEGA_ENV } = useEnvironment();
+  const networkName = envTriggerMapping[VEGA_ENV];
+
+  const title = useMemo(() => {
+    if (!pageTitle) return DEFAULT_TITLE;
+    if (networkName) return `${pageTitle} [${networkName}]`;
+    return pageTitle;
+  }, [pageTitle, networkName]);
+
   return (
     <ThemeContext.Provider value={theme}>
       <Head>
-        <title>{t('Welcome to Vega trading!')}</title>
+        <title>{title}</title>
       </Head>
       <div className="h-full relative dark:bg-black dark:text-white z-0 grid grid-rows-[min-content,1fr,min-content]">
         <AppLoader>

--- a/apps/trading/pages/index.page.tsx
+++ b/apps/trading/pages/index.page.tsx
@@ -1,5 +1,5 @@
-import { activeMarketsProvider } from '@vegaprotocol/market-list';
-import { useDataProvider } from '@vegaprotocol/react-helpers';
+import { useMarketList } from '@vegaprotocol/market-list';
+import { addDecimalsFormatNumber, titlefy } from '@vegaprotocol/react-helpers';
 import { AsyncRenderer } from '@vegaprotocol/ui-toolkit';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -9,10 +9,7 @@ export function Index() {
   const { replace } = useRouter();
   // The default market selected in the platform behind the overlay
   // should be the oldest market that is currently trading in continuous mode(i.e. not in auction).
-  const { data, error, loading } = useDataProvider({
-    dataProvider: activeMarketsProvider,
-    noUpdate: true,
-  });
+  const { data, error, loading } = useMarketList();
   const { riskNoticeDialog, update } = useGlobalStore((store) => ({
     riskNoticeDialog: store.riskNoticeDialog,
     update: store.update,
@@ -22,11 +19,19 @@ export function Index() {
     update({ landingDialog: true });
 
     if (data) {
-      const marketId = data[0]?.id;
+      const marketId = data.markets[0]?.id;
+      const marketName = data.markets[0]?.tradableInstrument.instrument.name;
+      const marketPrice = data.marketsData[0]?.markPrice
+        ? addDecimalsFormatNumber(
+            data.marketsData[0]?.markPrice,
+            data.markets[0].decimalPlaces
+          )
+        : null;
+      const pageTitle = titlefy([marketName, marketPrice]);
 
       if (marketId) {
         replace(`/markets/${marketId}`);
-        update({ marketId });
+        update({ marketId, pageTitle });
       }
       // Fallback to the markets list page
       else {

--- a/apps/trading/pages/markets/index.page.tsx
+++ b/apps/trading/pages/markets/index.page.tsx
@@ -1,9 +1,15 @@
 import { useRouter } from 'next/router';
 import { MarketsContainer } from '@vegaprotocol/market-list';
 import { useGlobalStore } from '../../stores';
+import { useEffect } from 'react';
+import { titlefy } from '@vegaprotocol/react-helpers';
 
 const Markets = () => {
   const { update } = useGlobalStore((store) => ({ update: store.update }));
+  useEffect(() => {
+    update({ pageTitle: titlefy(['Markets']) });
+  }, [update]);
+
   const router = useRouter();
   return (
     <MarketsContainer

--- a/apps/trading/pages/portfolio/deposit/index.page.tsx
+++ b/apps/trading/pages/portfolio/deposit/index.page.tsx
@@ -1,8 +1,17 @@
-import { t } from '@vegaprotocol/react-helpers';
+import { t, titlefy } from '@vegaprotocol/react-helpers';
 import { Web3Container } from '@vegaprotocol/web3';
+import { useEffect } from 'react';
+import { useGlobalStore } from '../../../stores';
 import { DepositContainer } from './deposit-container';
 
 const Deposit = () => {
+  const { update } = useGlobalStore((store) => ({
+    update: store.update,
+  }));
+  useEffect(() => {
+    update({ pageTitle: titlefy([t('Deposits')]) });
+  }, [update]);
+
   return (
     <Web3Container>
       <div className="max-w-[420px] p-8 mx-auto">

--- a/apps/trading/pages/portfolio/index.page.tsx
+++ b/apps/trading/pages/portfolio/index.page.tsx
@@ -1,4 +1,4 @@
-import { t } from '@vegaprotocol/react-helpers';
+import { t, titlefy } from '@vegaprotocol/react-helpers';
 import { PositionsContainer } from '@vegaprotocol/positions';
 import { OrderListContainer } from '@vegaprotocol/orders';
 import { AccountsContainer } from '@vegaprotocol/accounts';
@@ -6,12 +6,20 @@ import { ResizableGridPanel, Tab, Tabs } from '@vegaprotocol/ui-toolkit';
 import { WithdrawalsContainer } from './withdrawals-container';
 import { FillsContainer } from '@vegaprotocol/fills';
 import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import { VegaWalletContainer } from '../../components/vega-wallet-container';
 import { DepositsContainer } from './deposits-container';
 import { ResizableGrid } from '@vegaprotocol/ui-toolkit';
 import { LayoutPriority } from 'allotment';
+import { useGlobalStore } from '../../stores';
 
 const Portfolio = () => {
+  const { update } = useGlobalStore((store) => ({
+    update: store.update,
+  }));
+  useEffect(() => {
+    update({ pageTitle: titlefy([t('Portfolio')]) });
+  }, [update]);
   const wrapperClasses = 'h-full max-h-full flex flex-col';
   const tabContentClassName = 'h-full grid grid-rows-[min-content_1fr]';
   return (

--- a/apps/trading/stores/global.ts
+++ b/apps/trading/stores/global.ts
@@ -6,6 +6,7 @@ interface GlobalStore {
   landingDialog: boolean;
   riskNoticeDialog: boolean;
   marketId: string | null;
+  pageTitle: string | null;
   update: (store: Partial<Omit<GlobalStore, 'update'>>) => void;
 }
 
@@ -15,6 +16,7 @@ export const useGlobalStore = create<GlobalStore>((set) => ({
   landingDialog: false,
   riskNoticeDialog: false,
   marketId: null,
+  pageTitle: null,
   update: (state) => {
     set(state);
   },

--- a/libs/react-helpers/src/lib/format/strings.spec.ts
+++ b/libs/react-helpers/src/lib/format/strings.spec.ts
@@ -1,4 +1,4 @@
-import { truncateByChars, ELLIPSIS, shorten } from './strings';
+import { truncateByChars, ELLIPSIS, shorten, titlefy } from './strings';
 
 describe('truncateByChars', () => {
   it.each([
@@ -25,5 +25,27 @@ describe('shorten', () => {
   ])('should shorten given string by specific limit', ({ i, l, o }) => {
     const output = shorten(i, l);
     expect(output).toStrictEqual(o);
+  });
+});
+
+describe('titlefy', () => {
+  it.each([
+    { words: [], o: 'Vega' },
+    { words: ['one'], o: 'one - Vega' },
+    { words: ['one'], o: 'one - Vega' },
+    {
+      words: ['one', 'two', 'three'],
+      o: 'one - two - three - Vega',
+    },
+    {
+      words: ['one', null, undefined, 'two'],
+      o: 'one - two - Vega',
+    },
+    {
+      words: ['VEGAUSD', '123.22'],
+      o: 'VEGAUSD - 123.22 - Vega',
+    },
+  ])('should convert to title-like string', ({ words, o }) => {
+    expect(titlefy(words)).toEqual(o);
   });
 });

--- a/libs/react-helpers/src/lib/format/strings.ts
+++ b/libs/react-helpers/src/lib/format/strings.ts
@@ -17,3 +17,12 @@ export function shorten(input: string, limit?: number) {
   const suffix = output.length < limit ? ELLIPSIS : '';
   return input.substring(0, limit - 1) + suffix;
 }
+
+const TITLE_SEPARATOR = ' - ';
+const TITLE_SUFFIX = 'Vega';
+export function titlefy(words: (string | null | undefined)[]) {
+  const title = [...words, TITLE_SUFFIX]
+    .filter((w) => w && w.length > 0)
+    .join(TITLE_SEPARATOR);
+  return title;
+}


### PR DESCRIPTION
# Related issues 🔗

Closes #660 

# Description ℹ️

It adds custom titles for "Markets", "Portfolio", "Deposits", "[marketId]" pages.

# Demo 📺

![Screenshot 2022-09-22 at 18 14 18](https://user-images.githubusercontent.com/1980305/191800278-a52815f2-1f02-4de4-b793-9fdf1e502d1e.png)
![Screenshot 2022-09-22 at 18 15 04](https://user-images.githubusercontent.com/1980305/191800351-78554334-e7a9-4c1e-a5cc-4767faf67d4a.png)
![Screenshot 2022-09-22 at 18 17 04](https://user-images.githubusercontent.com/1980305/191800316-7cb8f1d0-43dd-4938-a009-3fafd930b5fd.png)


# Technical 👨‍🔧

I've added `pageTitle` to the global store.
