### PR TITLE
Chore/use cache in GitHub jobs

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -79,21 +79,15 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: frontend-monorepo/node_modules
+          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
 
       # Install frontend dependencies
       - name: Install root dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
         working-directory: frontend-monorepo
 
       #######

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -106,18 +106,18 @@ jobs:
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
-          unzip vega-linux-amd64.zip vega/vega
+          unzip vega-linux-amd64.zip -d vega
 
       - name: Install date-node binaries
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
-          unzip data-node-linux-amd64.zip vega/data-node
+          unzip data-node-linux-amd64.zip -d vega
 
       - name: Install Vega wallet binaries
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
-          unzip vegawallet-linux-amd64.zip vega/vegawallet
+          unzip vegawallet-linux-amd64.zip -d vega
 
       ######
       ## Start capsule

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -79,6 +79,18 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       # Install frontend dependencies
       - name: Install root dependencies
         run: yarn install
@@ -149,16 +161,12 @@ jobs:
         run: vegawallet service run --network fairground --automatic-consent --home ~/.vegacapsule/testnet/wallet &
 
       - name: Start service using capsule network
-        if: ${{ env.RUN_CAPSULE==true }}
+        if: ${{ env.RUN_CAPSULE }}
         run: vegawallet service run --network DV --automatic-consent  --home ~/.vegacapsule/testnet/wallet &
 
       ######
       ## Run some tests
       ######
-
-      - name: Install root dependencies
-        run: yarn install
-        working-directory: frontend-monorepo
 
       - name: Run smoke Cypress tests
         if: ${{ github.event.inputs.runAlltests == 'true' }}

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -106,18 +106,18 @@ jobs:
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
-          unzip vega-linux-amd64.zip -d vega
+          unzip vega-linux-amd64.zip
 
       - name: Install date-node binaries
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
-          unzip data-node-linux-amd64.zip -d vega
+          unzip data-node-linux-amd64.zip
 
       - name: Install Vega wallet binaries
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
-          unzip vegawallet-linux-amd64.zip -d vega
+          unzip vegawallet-linux-amd64.zip
 
       ######
       ## Start capsule

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       GO111MODULE: 'on'
       GOPROXY: ${{ secrets.GO_PROXY }}
+      VEGA_VERSION: 'v0.55.0'
     steps:
       #######
       ## Setup langs
@@ -75,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vega
-          ref: v0.54.0
+          ref: ${{ env.VEGA_VERSION }}
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './vega'
 
@@ -103,17 +104,20 @@ jobs:
 
       - name: Install Vega binaries
         if: ${{ env.RUN_CAPSULE }}
-        run: go install -v ./cmd/vega
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
+          unzip vega-linux-amd64.zip vega/vega
 
       - name: Install date-node binaries
         if: ${{ env.RUN_CAPSULE }}
-        run: go install ./cmd/data-node
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
+          unzip data-node-linux-amd64.zip vega/data-node
 
       - name: Install Vega wallet binaries
-        run: go install ./cmd/vegawallet
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
+          unzip vegawallet-linux-amd64.zip vega/vegawallet
 
       ######
       ## Start capsule

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO111MODULE: 'on'
-      GOPROXY: ${{ secrets.GO_PROXY }}
       VEGA_VERSION: 'v0.55.0'
     steps:
       #######
@@ -71,15 +70,7 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 
-      # Checkout vega
-      - name: Checkout Vega
-        uses: actions/checkout@v2
-        with:
-          repository: vegaprotocol/vega
-          ref: ${{ env.VEGA_VERSION }}
-          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          path: './vega'
-
+      # Restore node_modules from cache if possible
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
@@ -191,11 +182,11 @@ jobs:
       ######
 
       - name: Logs
-        if: ${{ env.RUN_CAPSULE==true }}
+        if: ${{ env.RUN_CAPSULE }}
         run: vegacapsule network logs > vega-capsule-logs.txt
 
       - uses: actions/upload-artifact@v2
-        if: ${{ env.RUN_CAPSULE==true }}
+        if: ${{ env.RUN_CAPSULE }}
         with:
           name: logs
           path: ./vega-capsule-logs.txt

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -74,8 +74,10 @@ jobs:
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
-          path: frontend-monorepo/node_modules
-          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -106,18 +106,18 @@ jobs:
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
-          unzip vega-linux-amd64.zip
+          unzip vega-linux-amd64.zip -d ${{ env.GOBIN }}
 
       - name: Install date-node binaries
         if: ${{ env.RUN_CAPSULE }}
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
-          unzip data-node-linux-amd64.zip
+          unzip data-node-linux-amd64.zip -d ${{ env.GOBIN }}
 
       - name: Install Vega wallet binaries
         run: |
           wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
-          unzip vegawallet-linux-amd64.zip
+          unzip vegawallet-linux-amd64.zip -d ${{ env.GOBIN }}
 
       ######
       ## Start capsule

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO111MODULE: 'on'
+      VEGA_VERSION: 'v0.55.0'
     steps:
       #######
       ## Setup langs
@@ -28,7 +29,7 @@ jobs:
           node-version: 16
 
       #######
-      ## Checkout capsule
+      ## Checkout repos
       #######
 
       # Checkout front ends
@@ -48,6 +49,18 @@ jobs:
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: frontend-monorepo/node_modules
+          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # Install frontend dependencies
+      - name: Install root dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: frontend-monorepo
+
       #######
       ## Build binaries
       #######
@@ -58,25 +71,20 @@ jobs:
       - name: Set GOBIN
         run: echo GOBIN=$(go env GOPATH)/bin >> $GITHUB_ENV
 
-      - name: Checkout Vega
-        uses: actions/checkout@v2
-        with:
-          repository: vegaprotocol/vega
-          ref: v0.55.0
-          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          path: './vega'
-
       - name: Install Vega binaries
-        run: go install -v ./cmd/vega
-        working-directory: vega
-
-      - name: Install Vega wallet binaries
-        run: go install ./cmd/vegawallet
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
+          unzip vega-linux-amd64.zip -d ${{ env.GOBIN }}
 
       - name: Install date-node binaries
-        run: go install ./cmd/data-node
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
+          unzip data-node-linux-amd64.zip -d ${{ env.GOBIN }}
+
+      - name: Install Vega wallet binaries
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
+          unzip vegawallet-linux-amd64.zip -d ${{ env.GOBIN }}
 
       ######
       ## Start capsule
@@ -112,10 +120,6 @@ jobs:
       ## Run some tests
       ######
 
-      - name: Install root dependencies
-        run: yarn install
-        working-directory: frontend-monorepo
-
       - name: Run Cypress tests
         run: yarn nx run-many --target=e2e --all --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
         working-directory: frontend-monorepo
@@ -131,7 +135,6 @@ jobs:
       ######
 
       - name: Logs
-        if: ${{ always() }}
         run: vegacapsule network logs > vega-capsule-logs.txt
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
-          path: frontend-monorepo/node_modules
-          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -70,8 +70,10 @@ jobs:
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         with:
-          path: frontend-monorepo/node_modules
-          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -3,8 +3,8 @@ name: Capsule tests
 on:
   push:
     branches:
-      - master
       - develop
+      - main
   pull_request:
     types:
       - opened
@@ -14,11 +14,12 @@ on:
 
 jobs:
   pr:
-    name: Run capsule tests - PR
+    name: Run Cypress tests - PR
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     env:
       GO111MODULE: 'on'
+      VEGA_VERSION: 'v0.55.0'
     steps:
       #######
       ## Setup langs
@@ -46,29 +47,6 @@ jobs:
           fetch-depth: 0
           path: './frontend-monorepo'
 
-      # Checkout capsule to build local network
-      - name: Checkout capsule
-        uses: actions/checkout@v2
-        with:
-          repository: vegaprotocol/vegacapsule
-          ref: main
-          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          path: './capsule'
-
-      # Checkout vega
-      - name: Checkout Vega
-        uses: actions/checkout@v2
-        with:
-          repository: vegaprotocol/vega
-          ref: v0.54.0
-          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
-          path: './vega'
-
-      # Install frontend dependencies
-      - name: Install root dependencies
-        run: yarn install
-        working-directory: frontend-monorepo
-
       # See affected apps to see if building all binaries is necessary
       - name: See affected apps
         run: echo AFFECTED=$(yarn nx print-affected --base=origin/${{github.base_ref}} --head=${{github.head_ref}} --select=projects) >> $GITHUB_ENV
@@ -77,6 +55,28 @@ jobs:
       - name: See if capsule is necessary
         if: ${{ contains(env.AFFECTED, 'token') || contains(env.AFFECTED, 'token-e2e') || contains(env.AFFECTED, 'explorer') || contains(env.AFFECTED, 'explorer-e2e') }}
         run: echo RUN_CAPSULE=true >> $GITHUB_ENV
+
+      # Checkout capsule to build local network
+      - name: Checkout capsule
+        if: ${{ env.RUN_CAPSULE }}
+        uses: actions/checkout@v2
+        with:
+          repository: vegaprotocol/vegacapsule
+          ref: main
+          token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+          path: './capsule'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: frontend-monorepo/node_modules
+          key: node_modules-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # Install frontend dependencies
+      - name: Install root dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: frontend-monorepo
 
       #######
       ## Build binaries
@@ -91,17 +91,20 @@ jobs:
 
       - name: Install Vega binaries
         if: ${{ env.RUN_CAPSULE }}
-        run: go install -v ./cmd/vega
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vega-linux-amd64.zip'
+          unzip vega-linux-amd64.zip -d ${{ env.GOBIN }}
 
       - name: Install date-node binaries
         if: ${{ env.RUN_CAPSULE }}
-        run: go install ./cmd/data-node
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/data-node-linux-amd64.zip'
+          unzip data-node-linux-amd64.zip -d ${{ env.GOBIN }}
 
       - name: Install Vega wallet binaries
-        run: go install ./cmd/vegawallet
-        working-directory: vega
+        run: |
+          wget 'https://github.com/vegaprotocol/vega/releases/download/${{ env.VEGA_VERSION }}/vegawallet-linux-amd64.zip'
+          unzip vegawallet-linux-amd64.zip -d ${{ env.GOBIN }}
 
       ######
       ## Start capsule

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -143,7 +143,7 @@ jobs:
         run: vegawallet service run --network fairground --automatic-consent --home ~/.vegacapsule/testnet/wallet &
 
       - name: Start service using capsule network
-        if: ${{ env.RUN_CAPSULE==true }}
+        if: ${{ env.RUN_CAPSULE }}
         run: vegawallet service run --network DV --automatic-consent  --home ~/.vegacapsule/testnet/wallet &
 
       ######

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pr:
-    name: Run Cypress tests - PR
+    name: Run capsule tests - PR
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,50 +3,16 @@ name: Unit tests & build
 on:
   push:
     branches:
-      - master
       - develop
+      - main
   pull_request:
-
 jobs:
-  master:
-    name: Test and lint - main
-    runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      actions: 'read'
-    if: ${{ github.event_name != 'pull_request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
-        with:
-          main-branch-name: master
-      - name: Use Node.js 16
-        id: Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.14.0
-      - name: Install root dependencies
-        run: yarn install
-      - name: Check formatting
-        run: yarn nx format:check
-      - name: Lint affected
-        run: yarn nx affected:lint --max-warnings=0
-      - name: Test affected
-        run: yarn nx affected:test
-      - name: Build affected
-        run: yarn nx affected:build
   pr:
     name: Test and lint - PR
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       actions: 'read'
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,14 +21,19 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
         with:
-          main-branch-name: develop
+          main-branch-name: ${{ github.base_ref }}
       - name: Use Node.js 16
         id: Node
         uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: node_modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install root dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Check formatting
         run: yarn nx format:check
       - name: Lint affected

--- a/apps/trading-e2e/src/integration/global.cy.ts
+++ b/apps/trading-e2e/src/integration/global.cy.ts
@@ -76,7 +76,7 @@ describe('ethereum wallet', { tags: '@smoke' }, () => {
     cy.getByTestId('Withdrawals').click();
   });
 
-  it('can connect', () => {
+  it('can connect', { defaultCommandTimeout: 20000 }, () => {
     cy.wait('@NetworkParamsQuery');
     cy.getByTestId('connect-eth-wallet-btn').click();
     cy.getByTestId('web3-connector-list').should('exist');

--- a/apps/trading-e2e/src/integration/global.cy.ts
+++ b/apps/trading-e2e/src/integration/global.cy.ts
@@ -76,7 +76,7 @@ describe('ethereum wallet', { tags: '@smoke' }, () => {
     cy.getByTestId('Withdrawals').click();
   });
 
-  it('can connect', { defaultCommandTimeout: 20000 }, () => {
+  it('can connect', () => {
     cy.wait('@NetworkParamsQuery');
     cy.getByTestId('connect-eth-wallet-btn').click();
     cy.getByTestId('web3-connector-list').should('exist');


### PR DESCRIPTION
# Description ℹ️

Two changes in workflows:
- cache node_modules and Cypress runner to be used in other runs, if yarn.lock is not changed
- Download specific binaries version of vega, vegawallet & data-nodes instead of building them each time

It should improve timing in PRs.