### PR TITLE
fix: ensure sub is cancelled if dialog is closed

### DIFF
--- a/libs/governance/src/lib/proposals-hooks/use-proposal-event.ts
+++ b/libs/governance/src/lib/proposals-hooks/use-proposal-event.ts
@@ -6,6 +6,7 @@ import type {
   ProposalEvent_busEvents_event_Proposal,
 } from './__generated__/ProposalEvent';
 import type { Subscription } from 'zen-observable-ts';
+import type { VegaTxState } from '@vegaprotocol/wallet';
 
 export const PROPOSAL_EVENT_SUB = gql`
   subscription ProposalEvent($partyId: ID!) {
@@ -24,7 +25,7 @@ export const PROPOSAL_EVENT_SUB = gql`
   }
 `;
 
-export const useProposalEvent = () => {
+export const useProposalEvent = (transaction: VegaTxState) => {
   const client = useApolloClient();
   const subRef = useRef<Subscription | null>(null);
 
@@ -66,10 +67,13 @@ export const useProposalEvent = () => {
   );
 
   useEffect(() => {
+    if (!transaction.dialogOpen) {
+      subRef.current?.unsubscribe();
+    }
     return () => {
       subRef.current?.unsubscribe();
     };
-  }, []);
+  }, [transaction.dialogOpen]);
 
   return waitForProposalEvent;
 };

--- a/libs/governance/src/lib/proposals-hooks/use-proposal-submit.ts
+++ b/libs/governance/src/lib/proposals-hooks/use-proposal-submit.ts
@@ -8,9 +8,9 @@ import type { ProposalEvent_busEvents_event_Proposal } from './__generated__/Pro
 
 export const useProposalSubmit = () => {
   const { keypair } = useVegaWallet();
-  const waitForProposalEvent = useProposalEvent();
 
   const { send, transaction, setComplete, Dialog } = useVegaTransaction();
+  const waitForProposalEvent = useProposalEvent(transaction);
 
   const [finalizedProposal, setFinalizedProposal] =
     useState<ProposalEvent_busEvents_event_Proposal | null>(null);

--- a/libs/orders/src/lib/order-hooks/use-order-cancel.tsx
+++ b/libs/orders/src/lib/order-hooks/use-order-cancel.tsx
@@ -11,7 +11,6 @@ export interface CancelOrderArgs {
 
 export const useOrderCancel = () => {
   const { keypair } = useVegaWallet();
-  const waitForOrderEvent = useOrderEvent();
 
   const [cancelledOrder, setCancelledOrder] =
     useState<OrderEvent_busEvents_event_Order | null>(null);
@@ -23,6 +22,8 @@ export const useOrderCancel = () => {
     setComplete,
     Dialog,
   } = useVegaTransaction();
+
+  const waitForOrderEvent = useOrderEvent(transaction);
 
   const reset = useCallback(() => {
     resetTransaction();

--- a/libs/orders/src/lib/order-hooks/use-order-edit.tsx
+++ b/libs/orders/src/lib/order-hooks/use-order-edit.tsx
@@ -25,7 +25,7 @@ export const useOrderEdit = (order: OrderWithMarket | null) => {
     Dialog,
   } = useVegaTransaction();
 
-  const waitForOrderEvent = useOrderEvent();
+  const waitForOrderEvent = useOrderEvent(transaction);
 
   const reset = useCallback(() => {
     resetTransaction();

--- a/libs/orders/src/lib/order-hooks/use-order-event.ts
+++ b/libs/orders/src/lib/order-hooks/use-order-event.ts
@@ -7,8 +7,9 @@ import type {
   OrderEvent_busEvents_event_Order,
 } from './';
 import type { Subscription } from 'zen-observable-ts';
+import type { VegaTxState } from '@vegaprotocol/wallet';
 
-export const useOrderEvent = () => {
+export const useOrderEvent = (transaction: VegaTxState) => {
   const client = useApolloClient();
   const subRef = useRef<Subscription | null>(null);
 
@@ -50,10 +51,14 @@ export const useOrderEvent = () => {
   );
 
   useEffect(() => {
+    if (!transaction.dialogOpen) {
+      subRef.current?.unsubscribe();
+    }
+
     return () => {
       subRef.current?.unsubscribe();
     };
-  }, []);
+  }, [transaction.dialogOpen]);
 
   return waitForOrderEvent;
 };

--- a/libs/orders/src/lib/order-hooks/use-order-submit.tsx
+++ b/libs/orders/src/lib/order-hooks/use-order-submit.tsx
@@ -96,7 +96,6 @@ export const getOrderDialogIcon = (
 
 export const useOrderSubmit = () => {
   const { keypair } = useVegaWallet();
-  const waitForOrderEvent = useOrderEvent();
 
   const {
     send,
@@ -105,6 +104,8 @@ export const useOrderSubmit = () => {
     setComplete,
     Dialog,
   } = useVegaTransaction();
+
+  const waitForOrderEvent = useOrderEvent(transaction);
 
   const [finalizedOrder, setFinalizedOrder] =
     useState<OrderEvent_busEvents_event_Order | null>(null);

--- a/libs/positions/src/lib/use-close-position.ts
+++ b/libs/positions/src/lib/use-close-position.ts
@@ -8,7 +8,6 @@ import type { Position } from '../';
 
 export const useClosePosition = () => {
   const { keypair } = useVegaWallet();
-  const waitForPositionEvent = usePositionEvent();
 
   const {
     send,
@@ -17,6 +16,7 @@ export const useClosePosition = () => {
     setComplete,
     Dialog,
   } = useVegaTransaction();
+  const waitForPositionEvent = usePositionEvent(transaction);
 
   const reset = useCallback(() => {
     resetTransaction();

--- a/libs/positions/src/lib/use-position-event.ts
+++ b/libs/positions/src/lib/use-position-event.ts
@@ -1,7 +1,8 @@
+import type { VegaTxState } from '@vegaprotocol/wallet';
 import { useCallback } from 'react';
 
 // this should be replaced by implementation of busEvents listener when it will be available
-export const usePositionEvent = () => {
+export const usePositionEvent = (transaction: VegaTxState) => {
   const waitForOrderEvent = useCallback(
     (id: string, partyId: string, callback: () => void) => {
       Promise.resolve().then(() => {

--- a/libs/withdraws/src/lib/use-create-withdraw.ts
+++ b/libs/withdraws/src/lib/use-create-withdraw.ts
@@ -15,7 +15,6 @@ export interface WithdrawalArgs {
 
 export const useCreateWithdraw = () => {
   const waitForWithdrawalApproval = useWithdrawalApproval();
-  const waitForWithdrawal = useWithdrawalEvent();
   const [approval, setApproval] =
     useState<Erc20Approval_erc20WithdrawalApproval | null>(null);
   const [withdrawal, setWithdrawal] = useState<WithdrawalFields | null>(null);
@@ -26,6 +25,8 @@ export const useCreateWithdraw = () => {
   const { keypair } = useVegaWallet();
   const { transaction, send, setComplete, reset, Dialog } =
     useVegaTransaction();
+
+  const waitForWithdrawal = useWithdrawalEvent(transaction);
 
   const submit = useCallback(
     async (withdrawal: WithdrawalArgs) => {

--- a/libs/withdraws/src/lib/use-withdrawal-event.ts
+++ b/libs/withdraws/src/lib/use-withdrawal-event.ts
@@ -1,4 +1,5 @@
 import { useApolloClient } from '@apollo/client';
+import type { VegaTxState } from '@vegaprotocol/wallet';
 import { useCallback, useEffect, useRef } from 'react';
 import type { Subscription } from 'zen-observable-ts';
 import { WITHDRAWAL_BUS_EVENT_SUB } from './use-withdrawals';
@@ -12,7 +13,8 @@ type WaitForWithdrawalEvent = (
   id: string,
   partyId: string
 ) => Promise<WithdrawalEvent_busEvents_event_Withdrawal>;
-export const useWithdrawalEvent = () => {
+
+export const useWithdrawalEvent = (transaction: VegaTxState) => {
   const client = useApolloClient();
   const subRef = useRef<Subscription | null>(null);
 
@@ -52,10 +54,13 @@ export const useWithdrawalEvent = () => {
   );
 
   useEffect(() => {
+    if (!transaction.dialogOpen) {
+      subRef.current?.unsubscribe();
+    }
     return () => {
       subRef.current?.unsubscribe();
     };
-  }, []);
+  }, [transaction.dialogOpen]);
 
   return waitForWithdrawalEvent;
 };


### PR DESCRIPTION
# Description ℹ️

Ensures that subscriptions started to track vega transactions are cancelled if the dialog is closed