### PR TITLE
fix: network params query name clash

### DIFF
--- a/apps/token/src/routes/governance/propose/freeform/propose-freeform.spec.tsx
+++ b/apps/token/src/routes/governance/propose/freeform/propose-freeform.spec.tsx
@@ -5,9 +5,9 @@ import { mockWalletContext } from '../../test-helpers/mocks';
 import { AppStateProvider } from '../../../../contexts/app-state/app-state-provider';
 import { VegaWalletContext } from '@vegaprotocol/wallet';
 import { MemoryRouter as Router } from 'react-router-dom';
-import { gql } from '@apollo/client';
 import type { NetworkParamsQuery } from '@vegaprotocol/web3';
 import type { MockedResponse } from '@apollo/client/testing';
+import { NETWORK_PARAMETERS_QUERY } from '@vegaprotocol/react-helpers';
 
 jest.mock('@vegaprotocol/environment', () => ({
   useEnvironment: () => ({
@@ -17,14 +17,7 @@ jest.mock('@vegaprotocol/environment', () => ({
 
 const updateMarketNetworkParamsQueryMock: MockedResponse<NetworkParamsQuery> = {
   request: {
-    query: gql`
-      query NetworkParams {
-        networkParameters {
-          key
-          value
-        }
-      }
-    `,
+    query: NETWORK_PARAMETERS_QUERY,
   },
   result: {
     data: {

--- a/apps/token/src/routes/governance/propose/network-parameter/propose-network-parameter.spec.tsx
+++ b/apps/token/src/routes/governance/propose/network-parameter/propose-network-parameter.spec.tsx
@@ -5,9 +5,9 @@ import { mockWalletContext } from '../../test-helpers/mocks';
 import { AppStateProvider } from '../../../../contexts/app-state/app-state-provider';
 import { VegaWalletContext } from '@vegaprotocol/wallet';
 import { MemoryRouter as Router } from 'react-router-dom';
-import { gql } from '@apollo/client';
 import type { NetworkParamsQuery } from '@vegaprotocol/web3';
 import type { MockedResponse } from '@apollo/client/testing';
+import { NETWORK_PARAMETERS_QUERY } from '@vegaprotocol/react-helpers';
 
 jest.mock('@vegaprotocol/environment', () => ({
   useEnvironment: () => ({
@@ -17,14 +17,7 @@ jest.mock('@vegaprotocol/environment', () => ({
 
 const updateMarketNetworkParamsQueryMock: MockedResponse<NetworkParamsQuery> = {
   request: {
-    query: gql`
-      query NetworkParams {
-        networkParameters {
-          key
-          value
-        }
-      }
-    `,
+    query: NETWORK_PARAMETERS_QUERY,
   },
   result: {
     data: {

--- a/apps/token/src/routes/governance/propose/new-asset/propose-new-asset.spec.tsx
+++ b/apps/token/src/routes/governance/propose/new-asset/propose-new-asset.spec.tsx
@@ -5,9 +5,9 @@ import { VegaWalletContext } from '@vegaprotocol/wallet';
 import { AppStateProvider } from '../../../../contexts/app-state/app-state-provider';
 import { mockWalletContext } from '../../test-helpers/mocks';
 import { ProposeNewAsset } from './propose-new-asset';
-import { gql } from '@apollo/client';
 import type { NetworkParamsQuery } from '@vegaprotocol/web3';
 import type { MockedResponse } from '@apollo/client/testing';
+import { NETWORK_PARAMETERS_QUERY } from '@vegaprotocol/react-helpers';
 
 jest.mock('@vegaprotocol/environment', () => ({
   useEnvironment: () => ({
@@ -17,14 +17,7 @@ jest.mock('@vegaprotocol/environment', () => ({
 
 const updateMarketNetworkParamsQueryMock: MockedResponse<NetworkParamsQuery> = {
   request: {
-    query: gql`
-      query NetworkParams {
-        networkParameters {
-          key
-          value
-        }
-      }
-    `,
+    query: NETWORK_PARAMETERS_QUERY,
   },
   result: {
     data: {

--- a/apps/token/src/routes/governance/propose/new-market/propose-new-market.spec.tsx
+++ b/apps/token/src/routes/governance/propose/new-market/propose-new-market.spec.tsx
@@ -1,4 +1,3 @@
-import { gql } from '@apollo/client';
 import { render, screen, waitFor } from '@testing-library/react';
 import { ProposeNewMarket } from './propose-new-market';
 import { MockedProvider } from '@apollo/client/testing';
@@ -8,6 +7,7 @@ import { VegaWalletContext } from '@vegaprotocol/wallet';
 import { BrowserRouter as Router } from 'react-router-dom';
 import type { MockedResponse } from '@apollo/client/testing';
 import type { NetworkParamsQuery } from '@vegaprotocol/web3';
+import { NETWORK_PARAMETERS_QUERY } from '@vegaprotocol/react-helpers';
 
 jest.mock('@vegaprotocol/environment', () => ({
   useEnvironment: () => ({
@@ -17,14 +17,7 @@ jest.mock('@vegaprotocol/environment', () => ({
 
 const newMarketNetworkParamsQueryMock: MockedResponse<NetworkParamsQuery> = {
   request: {
-    query: gql`
-      query NetworkParams {
-        networkParameters {
-          key
-          value
-        }
-      }
-    `,
+    query: NETWORK_PARAMETERS_QUERY,
   },
   result: {
     data: {

--- a/apps/token/src/routes/governance/propose/update-market/propose-update-market.spec.tsx
+++ b/apps/token/src/routes/governance/propose/update-market/propose-update-market.spec.tsx
@@ -9,18 +9,11 @@ import { ProposeUpdateMarket } from './propose-update-market';
 import type { NetworkParamsQuery } from '@vegaprotocol/web3';
 import { MARKETS_QUERY } from './propose-update-market';
 import type { ProposalMarketsQuery } from './__generated__/ProposalMarketsQuery';
-import { gql } from '@apollo/client';
+import { NETWORK_PARAMETERS_QUERY } from '@vegaprotocol/react-helpers';
 
 const updateMarketNetworkParamsQueryMock: MockedResponse<NetworkParamsQuery> = {
   request: {
-    query: gql`
-      query NetworkParams {
-        networkParameters {
-          key
-          value
-        }
-      }
-    `,
+    query: NETWORK_PARAMETERS_QUERY,
   },
   result: {
     data: {


### PR DESCRIPTION
# Description ℹ️

Fixes query naming clash which was erroring during type generation

# Technical 👨‍🔧

Query documents were being created in the test itself, so switched to use the export
