### PR TITLE
fix: align market dropdown cells for both my markets and all markets

### DIFF
--- a/libs/market-list/src/lib/components/select-market.tsx
+++ b/libs/market-list/src/lib/components/select-market.tsx
@@ -198,9 +198,9 @@ export const SelectMarketPopover = ({
             Loading market data
           </div>
         ) : (
-          <>
+          <table className="relative text-sm w-full whitespace-nowrap">
             {keypair && (party?.positionsConnection?.edges?.length ?? 0) > 0 ? (
-              <table className="relative text-sm w-full whitespace-nowrap">
+              <>
                 <TableTitle>{t('My markets')}</TableTitle>
                 <SelectAllMarketsTableBody
                   markets={markets}
@@ -223,19 +223,17 @@ export const SelectMarketPopover = ({
                     )
                   }
                 />
-              </table>
+              </>
             ) : null}
-            <table className="relative text-sm w-full whitespace-nowrap">
-              <TableTitle>{t('All markets')}</TableTitle>
-              <SelectAllMarketsTableBody
-                markets={data?.markets}
-                marketsData={data?.marketsData}
-                marketsCandles={data?.marketsCandles}
-                onSelect={onSelectMarket}
-                onCellClick={onCellClick}
-              />
-            </table>
-          </>
+            <TableTitle>{t('All markets')}</TableTitle>
+            <SelectAllMarketsTableBody
+              markets={data?.markets}
+              marketsData={data?.marketsData}
+              marketsCandles={data?.marketsCandles}
+              onSelect={onSelectMarket}
+              onCellClick={onCellClick}
+            />
+          </table>
         )}
       </div>
     </Popover>


### PR DESCRIPTION
Makes 'my markets' and 'all markets' in the select market dropdown rendered within the same table element so that the cells align.

Before:
![Screen Shot 2022-09-26 at 10 37 08 PM](https://user-images.githubusercontent.com/6803987/192441060-9a49097d-b75c-4a82-a5eb-cc329cbf7d9d.jpg)

After:
![Screen Shot 2022-09-26 at 10 36 55 PM](https://user-images.githubusercontent.com/6803987/192441042-878b9269-91da-4b30-8de0-47ce96ea2c8e.jpg)
