### PR TITLE
chore: rename link to external link

### DIFF
--- a/apps/token/src/components/transaction-callout/transaction-complete.tsx
+++ b/apps/token/src/components/transaction-callout/transaction-complete.tsx
@@ -1,6 +1,6 @@
 import { Callout, Intent } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import type { ReactElement } from 'react';
 
@@ -25,13 +25,13 @@ export const TransactionComplete = ({
     >
       {body && <p data-testid="transaction-complete-body">{body}</p>}
       <p>
-        <Link
+        <ExternalLink
           title={t('View transaction on Etherscan')}
           target="_blank"
           href={`${ETHERSCAN_URL}/tx/${hash}`}
         >
           {t('View transaction on Etherscan')}
-        </Link>
+        </ExternalLink>
       </p>
       {footer && <p data-testid="transaction-complete-footer">{footer}</p>}
     </Callout>

--- a/apps/token/src/components/transaction-callout/transaction-error.tsx
+++ b/apps/token/src/components/transaction-callout/transaction-error.tsx
@@ -1,7 +1,7 @@
 import { Button, Callout, Intent } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
 
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 
 export interface TransactionErrorProps {
@@ -23,13 +23,13 @@ export const TransactionError = ({
       <p>{error ? error.message : t('Something went wrong')}</p>
       {hash ? (
         <p>
-          <Link
+          <ExternalLink
             title={t('View transaction on Etherscan')}
             href={`${ETHERSCAN_URL}/tx/${hash}`}
             target="_blank"
           >
             {hash}
-          </Link>
+          </ExternalLink>
         </p>
       ) : null}
       <Button onClick={() => onActionClick()}>{t('Try again')}</Button>

--- a/apps/token/src/components/transaction-callout/transaction-pending.tsx
+++ b/apps/token/src/components/transaction-callout/transaction-pending.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Callout, Loader } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 
 export const TransactionPending = ({
@@ -40,13 +40,13 @@ export const TransactionPending = ({
     <Callout icon={<Loader size="small" />} title={title}>
       {body && <p data-testid="transaction-pending-body">{body}</p>}
       <p>
-        <Link
+        <ExternalLink
           title={t('View transaction on Etherscan')}
           target="_blank"
           href={`${ETHERSCAN_URL}/tx/${hash}`}
         >
           {hash}
-        </Link>
+        </ExternalLink>
       </p>
       {footer && <p data-testid="transaction-pending-footer">{footer}</p>}
     </Callout>

--- a/apps/token/src/components/transactions-modal/transactions-modal.tsx
+++ b/apps/token/src/components/transactions-modal/transactions-modal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Link } from '@vegaprotocol/ui-toolkit';
+import { Dialog, ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -82,13 +82,13 @@ export const TransactionModal = () => {
               return (
                 <tr key={transaction.tx.hash}>
                   <TransactionModalTd>
-                    <Link
+                    <ExternalLink
                       title={t('View transaction on Etherscan')}
                       target="_blank"
                       href={`${ETHERSCAN_URL}/tx/${transaction.tx.hash}`}
                     >
                       {truncateMiddle(transaction.tx.hash)}
-                    </Link>
+                    </ExternalLink>
                   </TransactionModalTd>
                   <TransactionModalTd>
                     {renderStatus(transaction)}

--- a/apps/token/src/components/vega-wallet/download-wallet-prompt.tsx
+++ b/apps/token/src/components/vega-wallet/download-wallet-prompt.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
 import { Links } from '../../config';
 
@@ -8,9 +8,9 @@ export const DownloadWalletPrompt = () => {
     <>
       <h3 className="mt-4 mb-2">{t('getWallet')}</h3>
       <p>
-        <Link className="text-neutral-500" href={Links.WALLET_PAGE}>
+        <ExternalLink className="text-neutral-500" href={Links.WALLET_PAGE}>
           {t('getWalletLink')}
-        </Link>
+        </ExternalLink>
       </p>
     </>
   );

--- a/apps/token/src/routes/claim/complete.tsx
+++ b/apps/token/src/routes/claim/complete.tsx
@@ -1,4 +1,9 @@
-import { Callout, Intent, Link, Button } from '@vegaprotocol/ui-toolkit';
+import {
+  Callout,
+  Intent,
+  ExternalLink,
+  Button,
+} from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link as RouteLink } from 'react-router-dom';
@@ -35,25 +40,25 @@ export const Complete = ({
       {commitTxHash && (
         <p style={{ margin: 0 }}>
           {t('Link transaction')}:{' '}
-          <Link
+          <ExternalLink
             title={t('View transaction on Etherscan')}
             href={`${ETHERSCAN_URL}/tx/${commitTxHash}`}
             target="_blank"
           >
             {commitTxHash}
-          </Link>
+          </ExternalLink>
         </p>
       )}
       {claimTxHash && (
         <p>
           {t('Claim transaction')}:{' '}
-          <Link
+          <ExternalLink
             title={t('View transaction on Etherscan')}
             href={`${ETHERSCAN_URL}/tx/${claimTxHash}`}
             target="_blank"
           >
             {claimTxHash}
-          </Link>
+          </ExternalLink>
         </p>
       )}
       <RouteLink to={Routes.VESTING}>

--- a/apps/token/src/routes/contracts/index.tsx
+++ b/apps/token/src/routes/contracts/index.tsx
@@ -1,5 +1,5 @@
 import { t } from '@vegaprotocol/react-helpers';
-import { Link, Splash } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink, Splash } from '@vegaprotocol/ui-toolkit';
 import type { EthereumConfig } from '@vegaprotocol/web3';
 import { useEthereumConfig } from '@vegaprotocol/web3';
 import { useEnvironment } from '@vegaprotocol/environment';
@@ -42,13 +42,13 @@ const Contracts = ({ name }: RouteChildProps) => {
             style={{ display: 'flex', justifyContent: 'space-between' }}
           >
             <div>{key}:</div>
-            <Link
+            <ExternalLink
               title={t('View address on Etherscan')}
               href={`${ETHERSCAN_URL}/address/${contract.address}`}
               target="_blank"
             >
               {contract.address}
-            </Link>
+            </ExternalLink>
           </div>
         );
       })}
@@ -58,13 +58,13 @@ const Contracts = ({ name }: RouteChildProps) => {
           style={{ display: 'flex', justifyContent: 'space-between' }}
         >
           <div>{key}:</div>
-          <Link
+          <ExternalLink
             title={t('View address on Etherscan')}
             href={`${ETHERSCAN_URL}/address/${value}`}
             target="_blank"
           >
             {value}
-          </Link>
+          </ExternalLink>
         </div>
       ))}
     </section>

--- a/apps/token/src/routes/governance/components/propose/proposal-form-terms.tsx
+++ b/apps/token/src/routes/governance/components/propose/proposal-form-terms.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import {
   FormGroup,
   InputError,
-  Link,
+  ExternalLink,
   TextArea,
 } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
@@ -31,10 +31,12 @@ export const ProposalFormTerms = ({
       {VEGA_DOCS_URL && (
         <div className="mt-[-4px] mb-2 text-sm font-light">
           <span className="mr-1">{t('ProposalTermsText')}</span>
-          <Link
+          <ExternalLink
             href={`${VEGA_DOCS_URL}/tutorials/proposals${customDocLink || ''}`}
             target="_blank"
-          >{`${VEGA_DOCS_URL}/tutorials/proposals${customDocLink || ''}`}</Link>
+          >{`${VEGA_DOCS_URL}/tutorials/proposals${
+            customDocLink || ''
+          }`}</ExternalLink>
         </div>
       )}
 

--- a/apps/token/src/routes/governance/propose/freeform/propose-freeform.tsx
+++ b/apps/token/src/routes/governance/propose/freeform/propose-freeform.tsx
@@ -14,7 +14,7 @@ import {
   ProposalFormTransactionDialog,
   ProposalFormVoteAndEnactmentDeadline,
 } from '../../components/propose';
-import { AsyncRenderer, Link } from '@vegaprotocol/ui-toolkit';
+import { AsyncRenderer, ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { Heading } from '../../../../components/heading';
 import { VegaWalletContainer } from '../../../../components/vega-wallet-container';
 import { useNetworkParams, NetworkParams } from '@vegaprotocol/react-helpers';
@@ -75,20 +75,20 @@ export const ProposeFreeform = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreProposalsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/governance`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/governance`}</Link>
+                >{`${VEGA_EXPLORER_URL}/governance`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/governance/propose/network-parameter/propose-network-parameter.tsx
+++ b/apps/token/src/routes/governance/propose/network-parameter/propose-network-parameter.tsx
@@ -25,7 +25,7 @@ import {
   FormGroup,
   Input,
   InputError,
-  Link,
+  ExternalLink,
   Select,
   SyntaxHighlighter,
   TextArea,
@@ -140,20 +140,20 @@ export const ProposeNetworkParameter = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreNetParamsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/network-parameters`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/network-parameters`}</Link>
+                >{`${VEGA_EXPLORER_URL}/network-parameters`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/governance/propose/new-asset/propose-new-asset.tsx
+++ b/apps/token/src/routes/governance/propose/new-asset/propose-new-asset.tsx
@@ -17,7 +17,7 @@ import {
   ProposalFormSubheader,
   ProposalFormVoteAndEnactmentDeadline,
 } from '../../components/propose';
-import { AsyncRenderer, Link } from '@vegaprotocol/ui-toolkit';
+import { AsyncRenderer, ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { Heading } from '../../../../components/heading';
 import { VegaWalletContainer } from '../../../../components/vega-wallet-container';
 import { NetworkParams, useNetworkParams } from '@vegaprotocol/react-helpers';
@@ -99,20 +99,20 @@ export const ProposeNewAsset = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreAssetsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/assets`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/assets`}</Link>
+                >{`${VEGA_EXPLORER_URL}/assets`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/governance/propose/new-market/propose-new-market.tsx
+++ b/apps/token/src/routes/governance/propose/new-market/propose-new-market.tsx
@@ -16,7 +16,7 @@ import {
   ProposalFormSubheader,
   ProposalFormVoteAndEnactmentDeadline,
 } from '../../components/propose';
-import { AsyncRenderer, Link } from '@vegaprotocol/ui-toolkit';
+import { AsyncRenderer, ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { Heading } from '../../../../components/heading';
 import { VegaWalletContainer } from '../../../../components/vega-wallet-container';
 import { NetworkParams, useNetworkParams } from '@vegaprotocol/react-helpers';
@@ -94,20 +94,20 @@ export const ProposeNewMarket = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals/${docsLink}`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreMarketsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/markets`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/markets`}</Link>
+                >{`${VEGA_EXPLORER_URL}/markets`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/governance/propose/propose.tsx
+++ b/apps/token/src/routes/governance/propose/propose.tsx
@@ -1,6 +1,6 @@
 import Routes from '../../routes';
 import { useTranslation } from 'react-i18next';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { Heading } from '../../../components/heading';
 
@@ -16,19 +16,19 @@ export const Propose = () => {
           {VEGA_DOCS_URL && (
             <p>
               <span className="mr-1">{t('ProposalTermsText')}</span>
-              <Link
+              <ExternalLink
                 href={`${VEGA_DOCS_URL}/tutorials/proposals`}
                 target="_blank"
-              >{`${VEGA_DOCS_URL}/tutorials/proposals`}</Link>
+              >{`${VEGA_DOCS_URL}/tutorials/proposals`}</ExternalLink>
             </p>
           )}
           {VEGA_EXPLORER_URL && (
             <p>
               {t('MoreProposalsInfo')}{' '}
-              <Link
+              <ExternalLink
                 href={`${VEGA_EXPLORER_URL}/governance`}
                 target="_blank"
-              >{`${VEGA_EXPLORER_URL}/governance`}</Link>
+              >{`${VEGA_EXPLORER_URL}/governance`}</ExternalLink>
             </p>
           )}
         </div>
@@ -39,44 +39,46 @@ export const Propose = () => {
         <ul>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/network-parameter`}>
+              <ExternalLink
+                href={`${Routes.GOVERNANCE}/propose/network-parameter`}
+              >
                 {t('NetworkParameter')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/new-market`}>
+              <ExternalLink href={`${Routes.GOVERNANCE}/propose/new-market`}>
                 {t('NewMarket')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/update-market`}>
+              <ExternalLink href={`${Routes.GOVERNANCE}/propose/update-market`}>
                 {t('UpdateMarket')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/new-asset`}>
+              <ExternalLink href={`${Routes.GOVERNANCE}/propose/new-asset`}>
                 {t('NewAsset')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/freeform`}>
+              <ExternalLink href={`${Routes.GOVERNANCE}/propose/freeform`}>
                 {t('Freeform')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
           <li>
             <p>
-              <Link href={`${Routes.GOVERNANCE}/propose/raw`}>
+              <ExternalLink href={`${Routes.GOVERNANCE}/propose/raw`}>
                 {t('RawProposal')}
-              </Link>
+              </ExternalLink>
             </p>
           </li>
         </ul>

--- a/apps/token/src/routes/governance/propose/raw/propose-raw.tsx
+++ b/apps/token/src/routes/governance/propose/raw/propose-raw.tsx
@@ -6,7 +6,7 @@ import { VegaWalletContainer } from '../../../../components/vega-wallet-containe
 import {
   FormGroup,
   InputError,
-  Link,
+  ExternalLink,
   TextArea,
 } from '@vegaprotocol/ui-toolkit';
 import { useProposalSubmit } from '@vegaprotocol/governance';
@@ -44,20 +44,20 @@ export const ProposeRaw = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreProposalsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/governance`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/governance`}</Link>
+                >{`${VEGA_EXPLORER_URL}/governance`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/governance/propose/update-market/propose-update-market.tsx
+++ b/apps/token/src/routes/governance/propose/update-market/propose-update-market.tsx
@@ -24,7 +24,7 @@ import {
   InputError,
   KeyValueTable,
   KeyValueTableRow,
-  Link,
+  ExternalLink,
   Select,
 } from '@vegaprotocol/ui-toolkit';
 import { Heading } from '../../../../components/heading';
@@ -157,20 +157,20 @@ export const ProposeUpdateMarket = () => {
             {VEGA_DOCS_URL && (
               <p className="text-sm" data-testid="proposal-docs-link">
                 <span className="mr-1">{t('ProposalTermsText')}</span>
-                <Link
+                <ExternalLink
                   href={`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}
                   target="_blank"
-                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</Link>
+                >{`${VEGA_DOCS_URL}/tutorials/proposals${docsLink}`}</ExternalLink>
               </p>
             )}
 
             {VEGA_EXPLORER_URL && (
               <p className="text-sm">
                 {t('MoreMarketsInfo')}{' '}
-                <Link
+                <ExternalLink
                   href={`${VEGA_EXPLORER_URL}/markets`}
                   target="_blank"
-                >{`${VEGA_EXPLORER_URL}/markets`}</Link>
+                >{`${VEGA_EXPLORER_URL}/markets`}</ExternalLink>
               </p>
             )}
 

--- a/apps/token/src/routes/home/token-details/token-details.tsx
+++ b/apps/token/src/routes/home/token-details/token-details.tsx
@@ -1,6 +1,11 @@
 import { useTranslation } from 'react-i18next';
 
-import { Callout, Link, Intent, Splash } from '@vegaprotocol/ui-toolkit';
+import {
+  Callout,
+  ExternalLink,
+  Intent,
+  Splash,
+} from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { KeyValueTable, KeyValueTableRow } from '@vegaprotocol/ui-toolkit';
 import { useTranches } from '../../../hooks/use-tranches';
@@ -46,7 +51,7 @@ export const TokenDetails = ({
       <KeyValueTable>
         <KeyValueTableRow>
           {t('Token address').toUpperCase()}
-          <Link
+          <ExternalLink
             data-testid="token-address"
             title={t('View on Etherscan (opens in a new tab)')}
             className="font-mono text-white text-right"
@@ -54,11 +59,11 @@ export const TokenDetails = ({
             target="_blank"
           >
             {token.address}
-          </Link>
+          </ExternalLink>
         </KeyValueTableRow>
         <KeyValueTableRow>
           {t('Vesting contract').toUpperCase()}
-          <Link
+          <ExternalLink
             data-testid="token-contract"
             title={t('View on Etherscan (opens in a new tab)')}
             className="font-mono text-white text-right"
@@ -66,7 +71,7 @@ export const TokenDetails = ({
             target="_blank"
           >
             {config.token_vesting_contract.address}
-          </Link>
+          </ExternalLink>
         </KeyValueTableRow>
         <KeyValueTableRow>
           {t('Total supply').toUpperCase()}

--- a/apps/token/src/routes/staking/associate/associate-transaction.tsx
+++ b/apps/token/src/routes/staking/associate/associate-transaction.tsx
@@ -1,4 +1,9 @@
-import { Button, Callout, Link, Loader } from '@vegaprotocol/ui-toolkit';
+import {
+  Button,
+  Callout,
+  ExternalLink,
+  Loader,
+} from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,13 +74,13 @@ export const AssociateTransaction = ({
           })}
         </p>
         <p>
-          <Link
+          <ExternalLink
             title={t('View transaction on Etherscan')}
             href={`${ETHERSCAN_URL}/tx/${state.txData.hash}`}
             target="_blank"
           >
             {t('View on Etherscan (opens in a new tab)')}
-          </Link>
+          </ExternalLink>
         </p>
         <p data-testid="transaction-pending-footer">
           {t('pendingAssociationText', {

--- a/apps/token/src/routes/staking/staking.tsx
+++ b/apps/token/src/routes/staking/staking.tsx
@@ -2,7 +2,7 @@ import {
   Button,
   Callout,
   Intent,
-  Link as UTLink,
+  ExternalLink as UTLink,
 } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/apps/token/src/routes/staking/validator-table.tsx
+++ b/apps/token/src/routes/staking/validator-table.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { KeyValueTable, KeyValueTableRow } from '@vegaprotocol/ui-toolkit';
 import { BigNumber } from '../../lib/bignumber';
@@ -70,13 +70,13 @@ export const ValidatorTable = ({
       <KeyValueTableRow>
         <span>{t('ETHEREUM ADDRESS')}</span>
         <span>
-          <Link
+          <ExternalLink
             title={t('View on Etherscan (opens in a new tab)')}
             href={`${ETHERSCAN_URL}/address/${node.ethereumAddress}`}
             target="_blank"
           >
             {node.ethereumAddress}
-          </Link>
+          </ExternalLink>
         </span>
       </KeyValueTableRow>
       <KeyValueTableRow>

--- a/apps/token/src/routes/tranches/tranche.tsx
+++ b/apps/token/src/routes/tranches/tranche.tsx
@@ -1,5 +1,5 @@
 import type { Tranche as ITranche } from '@vegaprotocol/smart-contracts';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useWeb3React } from '@web3-react/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -75,13 +75,13 @@ export const Tranche = () => {
             const locked = user.remaining_tokens.times(lockedData?.locked || 0);
             return (
               <li className="pb-4" key={i}>
-                <Link
+                <ExternalLink
                   title={t('View on Etherscan (opens in a new tab)')}
                   href={`${ETHERSCAN_URL}/tx/${user.address}`}
                   target="_blank"
                 >
                   {user.address}
-                </Link>
+                </ExternalLink>
                 <TrancheProgressContents>
                   <span>{t('Locked')}</span>
                   <span>{t('Unlocked')}</span>

--- a/libs/deposits/src/lib/deposits-table.tsx
+++ b/libs/deposits/src/lib/deposits-table.tsx
@@ -9,7 +9,10 @@ import type {
   VegaICellRendererParams,
   VegaValueFormatterParams,
 } from '@vegaprotocol/ui-toolkit';
-import { AgGridDynamic as AgGrid, Link } from '@vegaprotocol/ui-toolkit';
+import {
+  AgGridDynamic as AgGrid,
+  ExternalLink,
+} from '@vegaprotocol/ui-toolkit';
 import type { DepositFieldsFragment } from './__generated__/Deposit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { DepositStatusMapping } from '@vegaprotocol/types';
@@ -68,14 +71,14 @@ export const DepositsTable = ({ deposits }: DepositsTableProps) => {
         }: VegaICellRendererParams<DepositFieldsFragment, 'txHash'>) => {
           if (!value) return '-';
           return (
-            <Link
+            <ExternalLink
               title={t('View transaction on Etherscan')}
               href={`${ETHERSCAN_URL}/tx/${value}`}
               data-testid="etherscan-link"
               target="_blank"
             >
               {truncateByChars(value)}
-            </Link>
+            </ExternalLink>
           );
         }}
       />

--- a/libs/environment/src/components/network-switcher/network-switcher.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { t } from '@vegaprotocol/react-helpers';
 import {
-  Link,
+  ExternalLink,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -120,7 +120,9 @@ export const NetworkSwitcher = () => {
             {advancedNetworkKeys.map((key) => (
               <DropdownMenuItem key={key} data-testid="network-item-advanced">
                 <div className="mr-4">
-                  <Link href={VEGA_NETWORKS[key]}>{envNameMapping[key]}</Link>
+                  <ExternalLink href={VEGA_NETWORKS[key]}>
+                    {envNameMapping[key]}
+                  </ExternalLink>
                   <NetworkLabel
                     isCurrent={VEGA_ENV === key}
                     isAvailable={!!VEGA_NETWORKS[key]}

--- a/libs/environment/src/components/node-switcher/node-switcher.tsx
+++ b/libs/environment/src/components/node-switcher/node-switcher.tsx
@@ -4,7 +4,7 @@ import {
   RadioGroup,
   Button,
   Input,
-  Link,
+  ExternalLink,
   Radio,
 } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '../../hooks/use-environment';
@@ -159,7 +159,7 @@ export const NodeSwitcher = ({
                         }
                         onChange={(e) => setCustomNodeText(e.target.value)}
                       />
-                      <Link
+                      <ExternalLink
                         aria-disabled={
                           !customNodeText ||
                           getIsNodeLoading(state[CUSTOM_NODE_KEY])
@@ -173,7 +173,7 @@ export const NodeSwitcher = ({
                         getIsNodeLoading(state[CUSTOM_NODE_KEY])
                           ? t('Checking')
                           : t('Check')}
-                      </Link>
+                      </ExternalLink>
                     </div>
                   )}
                 </div>

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -21,7 +21,7 @@ import { MarketInfoTable } from './info-key-value-table';
 import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { generatePath } from 'react-router-dom';
 import { useEnvironment } from '@vegaprotocol/environment';
-import { Link as UiToolkitLink } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink as UiToolkitLink } from '@vegaprotocol/ui-toolkit';
 import Link from 'next/link';
 
 const Links = {

--- a/libs/market-info/src/components/market-info/tooltip-mapping.tsx
+++ b/libs/market-info/src/components/market-info/tooltip-mapping.tsx
@@ -1,5 +1,5 @@
 import { t } from '@vegaprotocol/react-helpers';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import type { ReactNode } from 'react';
 
 export const tooltipMapping: Record<string, ReactNode> = {
@@ -65,24 +65,24 @@ export const tooltipMapping: Record<string, ReactNode> = {
   tau: (
     <span>
       {t('Projection horizon measured as a year fraction used in ')}
-      <Link
+      <ExternalLink
         href="https://vega.xyz/papers/margins-and-credit-risk.pdf#page=7"
         target="__blank"
       >
         {t('Expected Shortfall')}
-      </Link>
+      </ExternalLink>
       {t(' calculation when obtaining Risk Factor Long and Risk Factor Short')}
     </span>
   ),
   riskAversionParameter: (
     <span>
       {t('Probability level used in ')}
-      <Link
+      <ExternalLink
         href="https://vega.xyz/papers/margins-and-credit-risk.pdf#page=7"
         target="__blank"
       >
         {t('Expected Shortfall')}
-      </Link>
+      </ExternalLink>
       {t(' calculation when obtaining Risk Factor Long and Risk Factor Short')}
     </span>
   ),

--- a/libs/market-list/src/lib/components/select-market.tsx
+++ b/libs/market-list/src/lib/components/select-market.tsx
@@ -4,7 +4,7 @@ import {
   Icon,
   Intent,
   Loader,
-  Link,
+  ExternalLink,
   Popover,
 } from '@vegaprotocol/ui-toolkit';
 
@@ -75,7 +75,7 @@ export const SelectMarketLandingTable = ({
           </tbody>
         </table>
       </div>
-      <Link href="/markets">{'Or view full market list'}</Link>
+      <ExternalLink href="/markets">{'Or view full market list'}</ExternalLink>
     </>
   );
 };

--- a/libs/network-info/src/network-info.tsx
+++ b/libs/network-info/src/network-info.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { t } from '@vegaprotocol/react-helpers';
-import { Link, Lozenge } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink, Lozenge } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 
 const getFeedbackLinks = (gitOriginUrl?: string) =>
@@ -29,7 +29,10 @@ export const NetworkInfo = () => {
         <Lozenge className="bg-neutral-300 dark:bg-neutral-700">
           {VEGA_URL}
         </Lozenge>
-        . <Link onClick={() => setNodeSwitcherOpen()}>{t('Edit')}</Link>
+        .{' '}
+        <ExternalLink onClick={() => setNodeSwitcherOpen()}>
+          {t('Edit')}
+        </ExternalLink>
       </p>
       <p data-testid="git-eth-data" className="mb-2 break-all">
         {t('Reading Ethereum data from')}{' '}
@@ -41,7 +44,7 @@ export const NetworkInfo = () => {
       {GIT_COMMIT_HASH && (
         <p data-testid="git-commit-hash" className="mb-2">
           {t('Version/commit hash')}:{' '}
-          <Link
+          <ExternalLink
             href={
               GIT_ORIGIN_URL
                 ? `${GIT_ORIGIN_URL}/commit/${GIT_COMMIT_HASH}`
@@ -50,7 +53,7 @@ export const NetworkInfo = () => {
             target={GIT_ORIGIN_URL ? '_blank' : undefined}
           >
             {GIT_COMMIT_HASH}
-          </Link>
+          </ExternalLink>
         </p>
       )}
       {feedbackLinks.length > 0 && (
@@ -58,9 +61,9 @@ export const NetworkInfo = () => {
           {t('Known issues and feedback on')}{' '}
           {feedbackLinks.map(({ name, url }, index) => (
             <Fragment key={index}>
-              <Link key={index} href={url}>
+              <ExternalLink key={index} href={url}>
                 {name}
-              </Link>
+              </ExternalLink>
               {feedbackLinks.length > 1 &&
                 index < feedbackLinks.length - 2 &&
                 ','}

--- a/libs/orders/src/lib/components/order-feedback/order-feedback.tsx
+++ b/libs/orders/src/lib/components/order-feedback/order-feedback.tsx
@@ -9,7 +9,7 @@ import {
   OrderType,
 } from '@vegaprotocol/types';
 import type { VegaTxState } from '@vegaprotocol/wallet';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 
 export interface OrderFeedbackProps {
   transaction: VegaTxState;
@@ -59,7 +59,7 @@ export const OrderFeedback = ({ transaction, order }: OrderFeedbackProps) => {
         {transaction.txHash && (
           <div>
             <p className={labelClass}>{t('Transaction')}</p>
-            <Link
+            <ExternalLink
               style={{ wordBreak: 'break-word' }}
               data-testid="tx-block-explorer"
               href={`${VEGA_EXPLORER_URL}/txs/0x${transaction.txHash}`}
@@ -67,7 +67,7 @@ export const OrderFeedback = ({ transaction, order }: OrderFeedbackProps) => {
               rel="noreferrer"
             >
               {transaction.txHash}
-            </Link>
+            </ExternalLink>
           </div>
         )}
 

--- a/libs/ui-toolkit/src/components/link/link.stories.tsx
+++ b/libs/ui-toolkit/src/components/link/link.stories.tsx
@@ -1,14 +1,16 @@
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { Link } from '.';
+import { ExternalLink } from '.';
 import { VegaLogo } from '../vega-logo';
 
 export default {
   title: 'Link',
-  component: Link,
-} as ComponentMeta<typeof Link>;
+  component: ExternalLink,
+} as ComponentMeta<typeof ExternalLink>;
 
-const Template: ComponentStory<typeof Link> = (args) => <Link {...args} />;
+const Template: ComponentStory<typeof ExternalLink> = (args) => (
+  <ExternalLink {...args} />
+);
 
 export const Text = Template.bind({});
 Text.args = {

--- a/libs/ui-toolkit/src/components/link/link.tsx
+++ b/libs/ui-toolkit/src/components/link/link.tsx
@@ -10,7 +10,7 @@ type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 /**
  * Form an HTML link tag
  */
-export const Link = ({ className, children, ...props }: LinkProps) => {
+export const ExternalLink = ({ className, children, ...props }: LinkProps) => {
   const anchorClassName = classNames(className, {
     underline: typeof children === 'string',
     'cursor-pointer': props['aria-disabled'] !== true,
@@ -29,10 +29,10 @@ export const Link = ({ className, children, ...props }: LinkProps) => {
     </a>
   );
 };
-Link.displayName = 'Link';
+ExternalLink.displayName = 'Link';
 
 export const ExternalLink = ({ children, className, ...props }: LinkProps) => (
-  <Link
+  <ExternalLink
     className={classNames(className, 'inline-flex items-baseline')}
     {...props}
     target="_blank"
@@ -50,6 +50,6 @@ export const ExternalLink = ({ children, className, ...props }: LinkProps) => (
     ) : (
       children
     )}
-  </Link>
+  </ExternalLink>
 );
 ExternalLink.displayName = 'ExternalLink';

--- a/libs/web3/src/lib/ethereum-transaction-dialog/dialog-rows.tsx
+++ b/libs/web3/src/lib/ethereum-transaction-dialog/dialog-rows.tsx
@@ -1,5 +1,5 @@
 import { t } from '@vegaprotocol/react-helpers';
-import { Link } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { EthTxStatus } from '../use-ethereum-transaction';
 
@@ -42,14 +42,14 @@ export const TxRow = ({
             `Awaiting Ethereum transaction ${confirmations}/${requiredConfirmations} confirmations...`
           )}
         </span>
-        <Link
+        <ExternalLink
           href={`${ETHERSCAN_URL}/tx/${txHash}`}
           title={t('View transaction on Etherscan')}
           className="text-vega-pink dark:text-vega-yellow"
           target="_blank"
         >
           {t('View on Etherscan')}
-        </Link>
+        </ExternalLink>
       </p>
     );
   }
@@ -62,14 +62,14 @@ export const TxRow = ({
         }`}
       >
         <span>{t('Ethereum transaction complete')}</span>
-        <Link
+        <ExternalLink
           href={`${ETHERSCAN_URL}/tx/${txHash}`}
           title={t('View on Etherscan')}
           className="text-vega-pink dark:text-vega-yellow"
           target="_blank"
         >
           {t('View transaction on Etherscan')}
-        </Link>
+        </ExternalLink>
       </p>
     );
   }

--- a/libs/withdraws/src/lib/withdrawals-table.tsx
+++ b/libs/withdraws/src/lib/withdrawals-table.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@vegaprotocol/ui-toolkit';
 import {
   Dialog,
-  Link,
+  ExternalLink,
   AgGridDynamic as AgGrid,
   Intent,
   Loader,
@@ -96,14 +96,14 @@ export const WithdrawalsTable = ({ withdrawals }: WithdrawalsTableProps) => {
           }: VegaValueFormatterParams<WithdrawalFields, 'txHash'>) => {
             if (!value) return '-';
             return (
-              <Link
+              <ExternalLink
                 title={t('View transaction on Etherscan')}
                 href={`${ETHERSCAN_URL}/tx/${value}`}
                 data-testid="etherscan-link"
                 target="_blank"
               >
                 {truncateByChars(value)}
-              </Link>
+              </ExternalLink>
             );
           }}
         />
@@ -156,14 +156,14 @@ export const StatusCell = ({ ethUrl, data, complete }: StatusCellProps) => {
       <div className="flex justify-between gap-8">
         {t('Pending')}
         {data.txHash && (
-          <Link
+          <ExternalLink
             title={t('View transaction on Etherscan')}
             href={`${ethUrl}/tx/${data.txHash}`}
             data-testid="etherscan-link"
             target="_blank"
           >
             {t('View on Etherscan')}
-          </Link>
+          </ExternalLink>
         )}
       </div>
     );
@@ -194,14 +194,14 @@ const RecipientCell = ({
   valueFormatted,
 }: RecipientCellProps) => {
   return (
-    <Link
+    <ExternalLink
       title={t('View on Etherscan (opens in a new tab)')}
       href={`${ethUrl}/address/${value}`}
       data-testid="etherscan-link"
       target="_blank"
     >
       {valueFormatted}
-    </Link>
+    </ExternalLink>
   );
 };
 


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Link component was poorly named, intelisense was pulling this in instead of react router dom Link which caused #1471. This is actually only used for external links, so rename the component to reflact that. 
