### PR TITLE
fix: hide enacted on proposal details page for freeform proposals

### DIFF
--- a/apps/token/src/i18n/translations/dev.json
+++ b/apps/token/src/i18n/translations/dev.json
@@ -686,5 +686,6 @@
   "MoreMarketsInfo": "To see Explorer data on existing markets visit",
   "MoreAssetsInfo": "To see Explorer data on existing assets visit",
   "ProposalNotFound": "Proposal not found",
-  "ProposalNotFoundDetails": "The proposal you are looking for is not here, it may have been enacted before the last chain restore. You could check the Vega forums/discord instead for information about it."
+  "ProposalNotFoundDetails": "The proposal you are looking for is not here, it may have been enacted before the last chain restore. You could check the Vega forums/discord instead for information about it.",
+  "FreeformProposal": "Freeform proposal"
 }

--- a/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.spec.tsx
+++ b/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.spec.tsx
@@ -79,6 +79,28 @@ it('Changes data based on if data is in future or past', () => {
   ).toBeInTheDocument();
 });
 
+it('Does not render enactment time for freeform proposal', () => {
+  const proposal = generateProposal({
+    state: ProposalState.STATE_ENACTED,
+    terms: {
+      __typename: 'ProposalTerms',
+      change: {
+        __typename: 'NewFreeform',
+      },
+    },
+  });
+  render(<ProposalChangeTable proposal={proposal} />);
+  expect(screen.queryByText('Enacted on')).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      format(
+        new Date(proposal.terms.enactmentDatetime || 0),
+        DATE_FORMAT_DETAILED
+      )
+    )
+  ).not.toBeInTheDocument();
+});
+
 it('Renders error details and rejection reason if present', () => {
   const errorDetails = 'Error message';
   const proposal = generateProposal({

--- a/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
+++ b/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
@@ -31,12 +31,14 @@ export const ProposalChangeTable = ({ proposal }: ProposalChangeTableProps) => {
           : t('closedOn')}
         {format(new Date(terms.closingDatetime), DATE_FORMAT_DETAILED)}
       </KeyValueTableRow>
-      <KeyValueTableRow>
-        {isFuture(new Date(terms.enactmentDatetime || 0))
-          ? t('proposedEnactment')
-          : t('enactedOn')}
-        {format(new Date(terms.enactmentDatetime || 0), DATE_FORMAT_DETAILED)}
-      </KeyValueTableRow>
+      {terms.change.__typename !== 'NewFreeform' ? (
+        <KeyValueTableRow>
+          {isFuture(new Date(terms.enactmentDatetime || 0))
+            ? t('proposedEnactment')
+            : t('enactedOn')}
+          {format(new Date(terms.enactmentDatetime || 0), DATE_FORMAT_DETAILED)}
+        </KeyValueTableRow>
+      ) : null}
       <KeyValueTableRow>
         {t('proposedBy')}
         <span style={{ wordBreak: 'break-word' }}>{proposal.party.id}</span>

--- a/apps/token/src/routes/governance/components/proposal-detail-header/proposal-header.tsx
+++ b/apps/token/src/routes/governance/components/proposal-detail-header/proposal-header.tsx
@@ -73,8 +73,7 @@ export const ProposalHeader = ({ proposal }: { proposal: ProposalFields }) => {
       break;
     }
     case 'NewFreeform': {
-      details = `${proposal.id}`;
-
+      details = `${t('FreeformProposal')}: ${proposal.id}`;
       break;
     }
   }


### PR DESCRIPTION
# Related issues 🔗

Closes #1373, Closes #1374 

# Description ℹ️

Hide enacted on freeform proposal details page as this does not exist anymore, generate a better title than just outputting the id which looked like an error
