### PR TITLE
chore(deps): update dependency pennant to v0.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",
     "next": "12.2.3",
-    "pennant": "^0.4.14",
+    "pennant": "^0.4.18",
     "react": "18.2.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7522,19 +7522,7 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-allotment@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/allotment/-/allotment-1.15.0.tgz#3e27eb0d048b8da3d1acb8bc53610b63f84d5c5a"
-  integrity sha512-9JXAm59/XD5Djfpso0rgGZdA23n3v5XeicwjNoInp2qlBa/HFZtnMDujm6NHOSjOCQPWhkOt4ybYgz8H3ed+8A==
-  dependencies:
-    classnames "^2.3.0"
-    eventemitter3 "^4.0.0"
-    lodash.clamp "^4.0.0"
-    lodash.debounce "^4.0.0"
-    lodash.isequal "^4.5.0"
-    use-resize-observer "^9.0.0"
-
-allotment@^1.14.5:
+allotment@1.17.0, allotment@^1.14.5:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/allotment/-/allotment-1.17.0.tgz#a664b349c48a16602f27022d6dd6599e4ed53757"
   integrity sha512-Iab4GCVLb9/2R5D2PFlbhR2OWZrGLpYqF6YgmonLmwc9BrA+PEMt2BkltdYaySh7vfG73tuMdBB5R7AdTuMJEA==
@@ -17438,10 +17426,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-pennant@^0.4.14:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.14.tgz#9d51fc47faf9b51efee965c6df8a0746c70bdce6"
-  integrity sha512-O0a5uPGrQfX8eDULVJVuSsYloLjPl/91kdmbaZbc3bq+N9nYIRNu5uRdxAm0LPaqVhNU+Tp1dwNPeL6JFF73xw==
+pennant@^0.4.18:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/pennant/-/pennant-0.4.18.tgz#da287bd74abb41483d9dc732b89ceded249ecb7c"
+  integrity sha512-5CWfiPZLQrbx0EAU319tWjUH7iO+vt/wFfxqPLlAxsg6dyhO6Ix+oi8Z/FOgTaGMNey5tnDgDrZY9Jt3hej1aQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@d3fc/d3fc-technical-indicator" "^8.0.1"
@@ -17461,7 +17449,7 @@ pennant@^0.4.14:
     "@types/react" "^18.0.14"
     "@types/react-dom" "^18.0.5"
     "@types/react-virtualized-auto-sizer" "^1.0.0"
-    allotment "1.15.0"
+    allotment "1.17.0"
     classnames "^2.2.6"
     d3-array "2.3.3"
     d3-delaunay "^6.0.2"


### PR DESCRIPTION
# Related issues 🔗

Closes #1556.

# Description ℹ️

Updates the pennant chart library.

# Technical 👨‍🔧

This brings in the following changes.

### [0.4.18](https://github.com/vegaprotocol/pennant/compare/v0.4.15...v0.4.18) (2022-09-29)

### Features

- sort depth chart data ([#600](https://github.com/vegaprotocol/pennant/issues/600)) ([1d98c3b](https://github.com/vegaprotocol/pennant/commit/1d98c3b142ce4b5bd4e6b71732edc44d84f5c24b))

### Bug Fixes

- show sell side tooltip correctly in depth chart ([#601](https://github.com/vegaprotocol/pennant/issues/601)) ([08c2a30](https://github.com/vegaprotocol/pennant/commit/08c2a30861b8ff2292a8c3ebcfb4a722b2a83b3a))

### [0.4.17](https://github.com/vegaprotocol/pennant/compare/v0.4.15...v0.4.17) (2022-09-28)

### Features

- improve fill colors for depth chart ([18c28dd](https://github.com/vegaprotocol/pennant/commit/18c28dd2ddc9f4563107de9c1e49bd1119645449))

### [0.4.16](https://github.com/vegaprotocol/pennant/compare/v0.4.15...v0.4.16) (2022-09-20)

### Features

- better support for color customization ([#572](https://github.com/vegaprotocol/pennant/issues/572)) ([fdf041a](https://github.com/vegaprotocol/pennant/commit/fdf041adb6116e9e8d82e4e0540eda5cadc07fba))
