### PR TITLE
fix: do not show success state if user cancels tx

### DIFF
--- a/apps/token/src/routes/staking/stake-success.tsx
+++ b/apps/token/src/routes/staking/stake-success.tsx
@@ -34,7 +34,9 @@ export const StakeSuccess = ({
       <div>
         <p>{message}</p>
         <p>
-          <Link to={Routes.STAKING}>{t('backToStaking')}</Link>
+          <Link className="underline" to={Routes.STAKING}>
+            {t('backToStaking')}
+          </Link>
         </p>
       </div>
     </Callout>

--- a/apps/token/src/routes/staking/staking-form.tsx
+++ b/apps/token/src/routes/staking/staking-form.tsx
@@ -147,8 +147,12 @@ export const StakingForm = ({
     };
     try {
       const command = action === Actions.Add ? delegateInput : undelegateInput;
-      await sendTx(command);
-      setFormState(FormState.Pending);
+      const res = await sendTx(command);
+      if (res) {
+        setFormState(FormState.Pending);
+      } else {
+        setFormState(FormState.Default);
+      }
 
       // await success via poll
     } catch (err) {


### PR DESCRIPTION
# Related issues 🔗

Closes #1069

# Description ℹ️

When unstaking if a transaction was rejected and incorrect message to the user stating that the unstake was successful was shown. This fixes that.

