### PR TITLE
Chore/1535 update ac code refrences to new 

### DIFF
--- a/apps/token-e2e/src/integration/flow/staking-flow.cy.js
+++ b/apps/token-e2e/src/integration/flow/staking-flow.cy.js
@@ -30,7 +30,7 @@ context(
   'Staking Tab - with eth and vega wallets connected',
   { tags: '@slow' },
   function () {
-    // 1002-STKE-002, 1002-STKE-032
+    // 2001-STKE-002, 2001-STKE-032
     before('visit staking tab and connect vega wallet', function () {
       cy.vega_wallet_import();
       cy.visit('/');
@@ -74,10 +74,10 @@ context(
 
         cy.get('button').contains('Select a validator to nominate').click();
 
-        // 1002-STKE-031
+        // 2001-STKE-031
         cy.click_on_validator_from_list(0);
 
-        // 1002-STKE-033, 1002-STKE-034, 1002-STKE-037
+        // 2001-STKE-033, 2001-STKE-034, 2001-STKE-037
         cy.staking_validator_page_add_stake('2');
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(
@@ -86,16 +86,16 @@ context(
           txTimeout
         );
 
-        // 1002-STKE-039
+        // 2001-STKE-039
         cy.get(vegaWalletStakedBalances, txTimeout)
           .should('contain', 2.0, txTimeout)
           .and('contain', partValidatorId);
 
-        cy.get(stakeNextEpochValue, epochTimeout) // 1002-STKE-016
+        cy.get(stakeNextEpochValue, epochTimeout) // 2001-STKE-016
           .contains(2.0, epochTimeout)
           .should('be.visible');
 
-        cy.get(stakeThisEpochValue, epochTimeout) // 1002-STKE-013
+        cy.get(stakeThisEpochValue, epochTimeout) // 2001-STKE-013
           .contains(2.0, epochTimeout)
           .should('be.visible');
 
@@ -303,7 +303,7 @@ context(
         });
       });
 
-      // 1002-STKE-041
+      // 2001-STKE-041
       it('Able to remove part of a stake against a validator', function () {
         cy.staking_page_associate_tokens('4');
 
@@ -330,13 +330,13 @@ context(
         );
 
         cy.navigate_to('staking');
-        // 1002-STKE-040
+        // 2001-STKE-040
         cy.click_on_validator_from_list(0);
 
-        // 1002-STKE-044, 1002-STKE-048
+        // 2001-STKE-044, 2001-STKE-048
         cy.staking_validator_page_remove_stake('1');
 
-        // 1002-STKE-049
+        // 2001-STKE-049
         cy.get(stakeNextEpochValue, epochTimeout).contains(2.0, epochTimeout);
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(
@@ -670,7 +670,7 @@ context(
       });
 
       it('Associating wallet tokens - when some already staked - auto stakes tokens to staked validator', function () {
-        // 1002-STKE-004
+        // 2001-STKE-004
         cy.staking_page_associate_tokens('3');
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(
@@ -706,7 +706,7 @@ context(
       });
 
       it('Associating vesting contract tokens - when some already staked - auto stakes tokens to staked validator', function () {
-        // 1002-STKE-004
+        // 2001-STKE-004
         cy.staking_page_associate_tokens('3', { type: 'contract' });
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(
@@ -742,7 +742,7 @@ context(
       });
 
       it('Associating vesting contract tokens - when wallet tokens already staked - auto stakes tokens to staked validator', function () {
-        // 1002-STKE-004
+        // 2001-STKE-004
         cy.staking_page_associate_tokens('3', { type: 'wallet' });
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(
@@ -778,7 +778,7 @@ context(
       });
 
       it('Associating tokens - with multiple validators already staked - auto stakes to staked validators - abiding by existing stake ratio', function () {
-        // 1002-STKE-004
+        // 2001-STKE-004
         cy.staking_page_associate_tokens('6');
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should(

--- a/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
+++ b/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
@@ -47,14 +47,14 @@ context(
       );
 
       it('Able to associate tokens - from wallet', function () {
-        //1000-ASSO-0008
-        //1000-ASSO-0009
-        //1000-ASSO-0030
-        //1000-ASSO-0012
-        //1000-ASSO-0013
-        //1000-ASSO-0014
-        //1000-ASSO-0015
-        //1000-ASSO-0030
+        //1004-ASSO-008
+        //1004-ASSO-009
+        //1004-ASSO-030
+        //1004-ASSO-012
+        //1004-ASSO-013
+        //1004-ASSO-014
+        //1004-ASSO-015
+        //1004-ASSO-030
         cy.staking_page_associate_tokens('2');
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
@@ -74,10 +74,10 @@ context(
       });
 
       it('Able to disassociate all associated tokens - manually', function () {
-        // 1000-ASSO-0025
-        // 1000-ASSO-0027
-        // 1000-ASSO-0028
-        // 1000-ASSO-0029
+        // 1004-ASSO-025
+        // 1004-ASSO-027
+        // 1004-ASSO-028
+        // 1004-ASSO-029
 
         cy.staking_page_associate_tokens('2');
 
@@ -102,7 +102,7 @@ context(
       });
 
       it('Able to associate more tokens than the approved amount of 1000 - requires re-approval', function () {
-        //1000-ASSO-0011
+        //1004-ASSO-011
         cy.staking_page_associate_tokens('1001', { approve: true });
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
@@ -149,7 +149,7 @@ context(
       });
 
       it('Able to disassociate all tokens - using max', function () {
-        // 1000-ASSO-0026
+        // 1004-ASSO-026
         const warningText =
           'Warning: Any tokens that have been nominated to a node will sacrifice rewards they are due for the current epoch. If you do not wish to sacrifice these, you should remove stake from a node at the end of an epoch before disassociation.';
 
@@ -184,9 +184,9 @@ context(
       });
 
       it('Able to associate and disassociate vesting contract tokens', function () {
-        // 1000-ASSO-0006
-        // 1000-ASSO-0024
-        // 1000-ASSO-0023
+        // 1004-ASSO-006
+        // 1004-ASSO-024
+        // 1004-ASSO-023
 
         cy.staking_page_associate_tokens('2', { type: 'contract' });
 
@@ -217,10 +217,10 @@ context(
       });
 
       it('Able to associate & disassociate both wallet and vesting contract tokens', function () {
-        // 1000-ASSO-0019
-        // 1000-ASSO-0020
-        // 1000-ASSO-0021
-        // 1000-ASSO-0022
+        // 1004-ASSO-019
+        // 1004-ASSO-020
+        // 1004-ASSO-021
+        // 1004-ASSO-022
 
         cy.staking_page_associate_tokens('21', { type: 'wallet' });
         cy.get('button').contains('Select a validator to nominate').click();
@@ -268,7 +268,7 @@ context(
       });
 
       it('Not able to associate more tokens than owned', function () {
-        // 1000-ASSO-0010
+        // 1004-ASSO-010
         // No warning visible as described in AC, but the button is disabled
 
         cy.get(ethWalletAssociateButton).first().click();

--- a/apps/token-e2e/src/integration/view/home.cy.js
+++ b/apps/token-e2e/src/integration/view/home.cy.js
@@ -76,7 +76,7 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
         });
       });
       it('should have VESTING CONTRACT', function () {
-        // 1000-ASSO-0001
+        // 1004-ASSO-001
         cy.get(tokenDetailsTable).within(() => {
           cy.get(contract)
             .should('be.visible')

--- a/apps/token-e2e/src/integration/view/staking.cy.js
+++ b/apps/token-e2e/src/integration/view/staking.cy.js
@@ -33,7 +33,7 @@ context(
         });
 
         it('should have Staking Guide link visible', function () {
-          // 1002-STKE-003
+          // 2001-STKE-003
           cy.get(guideLink)
             .should('be.visible')
             .and('have.text', 'Read more about staking on Vega')
@@ -46,7 +46,7 @@ context(
       });
 
       describe('Should be able to see validator list from the staking page', function () {
-        // 1002-STKE-050
+        // 2001-STKE-050
         it('Should be able to see validator names', function () {
           cy.get('[col-id="validator"]')
             .should('have.length.at.least', 1)
@@ -87,7 +87,7 @@ context(
             });
         });
 
-        // 1002-STKE-021
+        // 2001-STKE-021
         it('Should be able to see validator ranking score', function () {
           cy.get('.ag-body-horizontal-scroll-viewport').scrollTo('right');
           cy.get('[col-id="rankingScore"]')
@@ -97,7 +97,7 @@ context(
             });
         });
 
-        // 1002-STKE-022
+        // 2001-STKE-022
         it('Should be able to see validator stake score', function () {
           cy.get('[col-id="stakeScore"]')
             .should('have.length.at.least', 1)
@@ -106,7 +106,7 @@ context(
             });
         });
 
-        // 1002-STKE-023
+        // 2001-STKE-023
         it('Should be able to see validator performance score', function () {
           cy.get('[col-id="performanceScore"]')
             .should('have.length.at.least', 1)
@@ -115,7 +115,7 @@ context(
             });
         });
 
-        // 1002-STKE-024
+        // 2001-STKE-024
         it('Should be able to see validator voting power score', function () {
           cy.get('[col-id="votingPower"]')
             .should('have.length.at.least', 1)
@@ -126,7 +126,7 @@ context(
       });
     });
 
-    // 1002-STKE-050
+    // 2001-STKE-050
     describe('Should be able to see static information about a validator', function () {
       before('connect wallets and click on validator', function () {
         cy.vega_wallet_import();
@@ -134,28 +134,28 @@ context(
         cy.click_on_validator_from_list(0);
       });
 
-      // 1002-STKE-005
+      // 2001-STKE-005
       it('Should be able to see validator name', function () {
         cy.get(validatorTitle).should('not.be.empty');
       });
 
-      // 1002-STKE-007
+      // 2001-STKE-007
       it('Should be able to see validator id', function () {
         cy.get(validatorId).should('not.be.empty');
       });
 
-      // 1002-STKE-008
+      // 2001-STKE-008
       it('Should be able to see validator public key', function () {
         cy.get(validatorPubKey).should('not.be.empty');
       });
 
-      // 1002-STKE-010
+      // 2001-STKE-010
       it('Should be able to see Ethereum address', function () {
         cy.get(ethAddressLink).should('not.be.empty').and('have.attr', 'href');
       });
-      // TODO validators missing url for more information about them 1002-STKE-09
+      // TODO validators missing url for more information about them 2001-STKE-09
 
-      // 1002-STKE-012
+      // 2001-STKE-012
       it('Should be able to see total stake', function () {
         cy.get(totalStake).invoke('text').should('match', stakeNumberRegex);
       });
@@ -176,7 +176,7 @@ context(
           .should('match', stakeNumberRegex);
       });
 
-      // 1002-STKE-051
+      // 2001-STKE-051
       it('Should be able to see stake share in percentage', function () {
         cy.get(stakeShare)
           .invoke('text')
@@ -190,17 +190,17 @@ context(
           });
       });
 
-      // 1002-STKE-013
+      // 2001-STKE-013
       it('Should be able to see own stake this epoch', function () {
         cy.get(ownStake).invoke('text').should('match', stakeNumberRegex);
       });
 
-      // 1002-STKE-014
+      // 2001-STKE-014
       it('Should be able to see nominated stake this epoch', function () {
         cy.get(nominatedStake).invoke('text').should('match', stakeNumberRegex);
       });
 
-      // 1002-STKE-011
+      // 2001-STKE-011
       it('should be able to see epoch information', function () {
         const epochTitle = 'h3';
         const nextEpochInfo = 'p';

--- a/apps/token-e2e/src/integration/view/wallet-eth.cy.js
+++ b/apps/token-e2e/src/integration/view/wallet-eth.cy.js
@@ -48,7 +48,7 @@ context(
     });
 
     describe('when Connect Ethereum clicked', function () {
-      // 1000-ASSO-0002
+      // 1004-ASSO-002
       before('', function () {
         cy.get(connectToEthButton).click();
       });
@@ -127,7 +127,7 @@ context(
       });
 
       describe('VEGA IN VESTING CONTRACT', function () {
-        // 1000-ASSO-0007
+        // 1004-ASSO-007
         it('should have currency title visible', function () {
           cy.get(vegaInVesting).within(() => {
             cy.get(currencyTitle)
@@ -196,7 +196,7 @@ context(
       });
 
       describe('VEGA IN WALLET', function () {
-        // 1000-ASSO-0007
+        // 1004-ASSO-007
         it('should have currency title visible', function () {
           cy.get(vegaInWallet).within(() => {
             cy.get(currencyTitle)


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/frontend-monorepo/issues/1535

# Description ℹ️

The file names containing acceptance criteria are changing. This changes the references in e2e tests so that they match the new codes.

note: none of these Acceptance criteria have been merged. But when they are we'll start seeing coverage output like this 👇   

# Demo 📺

<img width="1279" alt="Screenshot 2022-09-29 at 18 44 01" src="https://user-images.githubusercontent.com/13255539/193104523-d06dd640-0a2c-4df2-8a0a-11ac1dbec209.png">
See the STKE and ASSO files at the bottom.