### PR TITLE
fix: 1403 format with asset decimals withdrawal threshold and lifetime limit values

### DIFF
--- a/libs/assets/src/lib/asset-details-dialog.spec.tsx
+++ b/libs/assets/src/lib/asset-details-dialog.spec.tsx
@@ -239,7 +239,7 @@ const mockedData = {
             quantum: '1',
             source: {
               contractAddress: '0x8ec701DA58394F5d2c8C2873D31039454D5845C1',
-              lifetimeLimit: '0',
+              lifetimeLimit: '1000000000000',
               withdrawThreshold: '0',
               __typename: 'ERC20',
             },
@@ -257,7 +257,7 @@ const mockedData = {
             source: {
               contractAddress: '0xDc335304979D378255015c33AbFf09B60c31EBAb',
               lifetimeLimit: '0',
-              withdrawThreshold: '0',
+              withdrawThreshold: '100000000',
               __typename: 'ERC20',
             },
             __typename: 'Asset',

--- a/libs/assets/src/lib/asset-details-dialog.tsx
+++ b/libs/assets/src/lib/asset-details-dialog.tsx
@@ -1,4 +1,4 @@
-import { t } from '@vegaprotocol/react-helpers';
+import { addDecimalsFormatNumber, t } from '@vegaprotocol/react-helpers';
 import type { Asset } from '@vegaprotocol/react-helpers';
 import {
   Button,
@@ -104,7 +104,10 @@ export const AssetDetailsDialog = ({
       {
         key: 'withdrawalthreshold',
         label: t('Withdrawal threshold'),
-        value: (asset.node.source as Schema.ERC20).withdrawThreshold,
+        value: addDecimalsFormatNumber(
+          (asset.node.source as Schema.ERC20).withdrawThreshold,
+          asset.node.decimals
+        ),
         tooltip: t(
           'The maximum allowed per withdraw note: this is a temporary measure for restricted mainnet'
         ),
@@ -112,7 +115,10 @@ export const AssetDetailsDialog = ({
       {
         key: 'lifetimelimit',
         label: t('Lifetime limit'),
-        value: (asset.node.source as Schema.ERC20).lifetimeLimit,
+        value: addDecimalsFormatNumber(
+          (asset.node.source as Schema.ERC20).lifetimeLimit,
+          asset.node.decimals
+        ),
         tooltip: t(
           'The lifetime limits deposit per address note: this is a temporary measure for restricted mainnet'
         ),


### PR DESCRIPTION
# Related issues 🔗

Closes #1403

# Description ℹ️

Use asset decimals to format withdraw limit and threshold. 

# Demo 📺

<img width="668" alt="Screenshot 2022-09-21 at 12 03 11" src="https://user-images.githubusercontent.com/13255539/191488604-b986f6e2-8c09-4ec8-a451-08e02ff46861.png">

```
{
	asset(id:"29287681e4d9a6457d02ded602f72002a50f25749c5edfe9e9a58241b8e97ebc"){
    source{
      ...on ERC20{
        contractAddress
      }
    }
    decimals
  }
}
```

