### PR TITLE
[trading] IPFS deploys do not work for subfolder gateways

### DIFF
--- a/apps/trading/next.config.js
+++ b/apps/trading/next.config.js
@@ -19,6 +19,7 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: false,
   },
+  assetPrefix: '.',
   pageExtensions: ['page.tsx', 'page.jsx'],
 };
 


### PR DESCRIPTION
Configure assetPrefix for trading so that IPFS works with subfolder or subdomains

next.js builds static pages, and those static pages reference static assets as `/_next/...`, which works fine if the
site is served from a domain root (e.g. `console.fairground.wtf/`, `made-up-url.ipfs.io`) but breaks down on IPFS
gateways that are still configured to use subfolders (e.g. `ipfs.io/ipfs/made-up-url`). Luckily we can fix this by
using `assetPrefix` to turn `/_next/` in to `./_next/`, which works in both cases.

- Update next.js config for trading

Closes #1613