### PR TITLE
feat(#1536): remove zero volume rows from orderbook

### DIFF
--- a/libs/market-depth/src/lib/orderbook-data.ts
+++ b/libs/market-depth/src/lib/orderbook-data.ts
@@ -1,4 +1,5 @@
 import groupBy from 'lodash/groupBy';
+import uniqBy from 'lodash/uniqBy';
 import { VolumeType } from '@vegaprotocol/react-helpers';
 import { MarketTradingMode } from '@vegaprotocol/types';
 import type { MarketData } from '@vegaprotocol/market-list';
@@ -264,7 +265,7 @@ export const updateCompactedRows = (
 ) => {
   let sellModifiedIndex = -1;
   let data = [...rows];
-  sell?.forEach((delta) => {
+  uniqBy(sell?.reverse(), 'price')?.forEach((delta) => {
     [sellModifiedIndex, data] = partiallyUpdateCompactedRows(
       VolumeType.ask,
       data,
@@ -274,7 +275,7 @@ export const updateCompactedRows = (
     );
   });
   let buyModifiedIndex = data.length;
-  buy?.forEach((delta) => {
+  uniqBy(buy?.reverse(), 'price')?.forEach((delta) => {
     [buyModifiedIndex, data] = partiallyUpdateCompactedRows(
       VolumeType.bid,
       data,

--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -154,6 +154,7 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
     >
       <Orderbook
         {...orderbookData}
+        fillGaps={false}
         decimalPlaces={market?.decimalPlaces ?? 0}
         positionDecimalPlaces={market?.positionDecimalPlaces ?? 0}
         resolution={resolution}

--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -154,7 +154,6 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
     >
       <Orderbook
         {...orderbookData}
-        fillGaps={false}
         decimalPlaces={market?.decimalPlaces ?? 0}
         positionDecimalPlaces={market?.positionDecimalPlaces ?? 0}
         resolution={resolution}

--- a/libs/market-depth/src/lib/orderbook-row.tsx
+++ b/libs/market-depth/src/lib/orderbook-row.tsx
@@ -47,17 +47,17 @@ export const OrderbookRow = React.memo(
           relativeValue={relativeBid}
           type={VolumeType.bid}
         />
-        <PriceCell
-          testId={`price-${price}`}
-          value={BigInt(price)}
-          valueFormatted={addDecimalsFormatNumber(price, decimalPlaces)}
-        />
         <Vol
           testId={`ask-vol-${price}`}
           value={ask}
           valueFormatted={addDecimal(ask, positionDecimalPlaces)}
           relativeValue={relativeAsk}
           type={VolumeType.ask}
+        />
+        <PriceCell
+          testId={`price-${price}`}
+          value={BigInt(price)}
+          valueFormatted={addDecimalsFormatNumber(price, decimalPlaces)}
         />
         <CumulativeVol
           testId={`cumulative-vol-${price}`}

--- a/libs/market-depth/src/lib/orderbook.spec.tsx
+++ b/libs/market-depth/src/lib/orderbook.spec.tsx
@@ -23,6 +23,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -37,6 +38,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -47,6 +49,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData({
           ...params,
           numberOfSellRows: params.numberOfSellRows - 1,
@@ -64,6 +67,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -74,6 +78,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData({
           ...params,
           bestStaticBidPrice: params.bestStaticBidPrice + 1,
@@ -92,6 +97,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -105,6 +111,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData({
           ...params,
           numberOfSellRows: params.numberOfSellRows - 1,
@@ -122,6 +129,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -143,6 +151,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData(params)}
         onResolutionChange={onResolutionChange}
       />
@@ -163,6 +172,7 @@ describe('Orderbook', () => {
       <Orderbook
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
+        fillGaps
         {...generateMockData({
           ...params,
           resolution: 10,

--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -102,7 +102,80 @@ const bufferSize = 30;
 // margin size in px, when reached scrollOffset will be updated
 const marginSize = bufferSize * 0.9 * rowHeight;
 
-
+const getBestStaticBidPriceLinePosition = (
+  bestStaticBidPrice: string | undefined,
+  fillGaps: boolean,
+  maxPriceLevel: string,
+  minPriceLevel: string,
+  resolution: number,
+  rows: OrderbookRowData[] | null
+) => {
+  let bestStaticBidPriceLinePosition = '';
+  if (maxPriceLevel !== '0' && minPriceLevel !== '0') {
+    if (
+      bestStaticBidPrice &&
+      BigInt(bestStaticBidPrice) < BigInt(maxPriceLevel) &&
+      BigInt(bestStaticBidPrice) > BigInt(minPriceLevel)
+    ) {
+      if (fillGaps) {
+        bestStaticBidPriceLinePosition = (
+          ((BigInt(maxPriceLevel) - BigInt(bestStaticBidPrice)) /
+            BigInt(resolution) +
+            BigInt(1)) *
+            BigInt(rowHeight) +
+          BigInt(1)
+        ).toString();
+      } else {
+        const index = rows?.findIndex(
+          (row) => BigInt(row.price) <= BigInt(bestStaticBidPrice)
+        );
+        if (index !== undefined && index !== -1) {
+          bestStaticBidPriceLinePosition = (
+            (index + 1) * rowHeight +
+            1
+          ).toString();
+        }
+      }
+    }
+  }
+  return bestStaticBidPriceLinePosition;
+};
+const getBestStaticOfferPriceLinePosition = (
+  bestStaticOfferPrice: string | undefined,
+  fillGaps: boolean,
+  maxPriceLevel: string,
+  minPriceLevel: string,
+  resolution: number,
+  rows: OrderbookRowData[] | null
+) => {
+  let bestStaticOfferPriceLinePosition = '';
+  if (
+    bestStaticOfferPrice &&
+    BigInt(bestStaticOfferPrice) <= BigInt(maxPriceLevel) &&
+    BigInt(bestStaticOfferPrice) > BigInt(minPriceLevel)
+  ) {
+    if (fillGaps) {
+      bestStaticOfferPriceLinePosition = (
+        ((BigInt(maxPriceLevel) - BigInt(bestStaticOfferPrice)) /
+          BigInt(resolution) +
+          BigInt(2)) *
+          BigInt(rowHeight) +
+        BigInt(1)
+      ).toString();
+    } else {
+      const index = rows?.findIndex(
+        (row) => BigInt(row.price) <= BigInt(bestStaticOfferPrice)
+      );
+      if (index !== undefined && index !== -1) {
+        bestStaticOfferPriceLinePosition = (
+          (index + 2) * rowHeight +
+          1
+        ).toString();
+      }
+    }
+  }
+  return bestStaticOfferPriceLinePosition;
+};
 const OrderbookDebugInfo = ({
   decimalPlaces,
   numberOfRows,
@@ -471,60 +544,23 @@ export const Orderbook = ({
     .fill(null)
     .map((v, i) => Math.pow(10, i));
 
-  let bestStaticBidPriceLinePosition = '';
-  let bestStaticOfferPriceLinePosition = '';
-  if (maxPriceLevel !== '0' && minPriceLevel !== '0') {
-    if (
-      bestStaticBidPrice &&
-      BigInt(bestStaticBidPrice) < BigInt(maxPriceLevel) &&
-      BigInt(bestStaticBidPrice) > BigInt(minPriceLevel)
-    ) {
-      if (fillGaps) {
-        bestStaticBidPriceLinePosition = (
-          ((BigInt(maxPriceLevel) - BigInt(bestStaticBidPrice)) /
-            BigInt(resolution) +
-            BigInt(1)) *
-            BigInt(rowHeight) +
-          BigInt(1)
-        ).toString();
-      } else {
-        const index = rows?.findIndex(
-          (row) => BigInt(row.price) <= BigInt(bestStaticBidPrice)
-        );
-        if (index !== undefined && index !== -1) {
-          bestStaticBidPriceLinePosition = (
-            (index + 1) * rowHeight +
-            1
-          ).toString();
-        }
-      }
-    }
-    if (
-      bestStaticOfferPrice &&
-      BigInt(bestStaticOfferPrice) <= BigInt(maxPriceLevel) &&
-      BigInt(bestStaticOfferPrice) > BigInt(minPriceLevel)
-    ) {
-      if (fillGaps) {
-        bestStaticOfferPriceLinePosition = (
-          ((BigInt(maxPriceLevel) - BigInt(bestStaticOfferPrice)) /
-            BigInt(resolution) +
-            BigInt(2)) *
-            BigInt(rowHeight) +
-          BigInt(1)
-        ).toString();
-      } else {
-        const index = rows?.findIndex(
-          (row) => BigInt(row.price) <= BigInt(bestStaticOfferPrice)
-        );
-        if (index !== undefined && index !== -1) {
-          bestStaticOfferPriceLinePosition = (
-            (index + 2) * rowHeight +
-            1
-          ).toString();
-        }
-      }
-    }
-  }
+  const bestStaticBidPriceLinePosition = getBestStaticBidPriceLinePosition(
+    bestStaticBidPrice,
+    fillGaps,
+    maxPriceLevel,
+    minPriceLevel,
+    resolution,
+    rows
+  );
+
+  const bestStaticOfferPriceLinePosition = getBestStaticOfferPriceLinePosition(
+    bestStaticOfferPrice,
+    fillGaps,
+    maxPriceLevel,
+    minPriceLevel,
+    resolution,
+    rows
+  );
 
   /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (


### PR DESCRIPTION
# Related issues 🔗

Closes #1536
Closes #1151

# Description ℹ️

 - Remove zero volume rows from orderbook.
 - Add option to enable zero volume rows
 - Use only newest value per price level from delta 
 - Infor console added for debugging purposes (show and hide on dblclick)

# Demo 📺

<img width="215" alt="image" src="https://user-images.githubusercontent.com/1754247/194826503-baa4cdb5-4ffe-4a88-8721-8cf4e4bce8a0.png">

# Technical 👨‍🔧

Optimized update in data provider by taking into consideration only last value at specific price level `uniqBy(sell?.reverse(), 'price')`

