### PR TITLE
chore: rename wallet label to match app, add more user friendly fetch…

### DIFF
--- a/libs/wallet/src/connect-dialog/rest-connector-form.tsx
+++ b/libs/wallet/src/connect-dialog/rest-connector-form.tsx
@@ -55,7 +55,7 @@ export function RestConnectorForm({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} data-testid="rest-connector-form">
-      <FormGroup label={t('Wallet')} labelFor="wallet">
+      <FormGroup label={t('Wallet name')} labelFor="wallet">
         <Input
           {...register('wallet', { required: t('Required') })}
           id="wallet"

--- a/libs/wallet/src/connectors/rest-connector.ts
+++ b/libs/wallet/src/connectors/rest-connector.ts
@@ -283,7 +283,7 @@ export class RestConnector implements VegaConnector {
       }
     } catch (err) {
       return {
-        error: 'Failed to fetch',
+        error: 'No wallet detected',
       };
     }
   }


### PR DESCRIPTION
# Description ℹ️

- Make failed to fetch message more user friendly for v1 wallet connection
- Align failed to fetch message with v2 wallet: 'No wallet detected'
