### PR TITLE
fix: 1644 default to existing price and change label

### DIFF
--- a/libs/orders/src/lib/components/order-list/order-edit-dialog.tsx
+++ b/libs/orders/src/lib/components/order-list/order-edit-dialog.tsx
@@ -40,7 +40,11 @@ export const OrderEditDialog = ({
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<FormFields>();
+  } = useForm<FormFields>({
+    defaultValues: {
+      entryPrice: addDecimalsFormatNumber(order.price, order.market?.decimalPlaces ?? 0),
+    },
+  });
 
   const step = toDecimal(order.market?.decimalPlaces ?? 0);
 
@@ -92,7 +96,7 @@ export const OrderEditDialog = ({
         data-testid="edit-order"
         className="w-1/2 mt-4"
       >
-        <FormGroup label={t('Entry price')} labelFor="entryPrice">
+        <FormGroup label={t('Price')} labelFor="entryPrice">
           <Input
             type="number"
             step={step}


### PR DESCRIPTION
# Related issues 🔗

Closes #1644 

# Description ℹ️

Change price label default to existing order price.

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
