### PR TITLE
fix: 1642 show in type column if order is pegged or LP

### DIFF
--- a/libs/orders/src/lib/components/order-list/order-list.spec.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.spec.tsx
@@ -33,7 +33,7 @@ const defaultProps: OrderListTableProps = {
 
 const generateJsx = (
   props: Partial<OrderListTableProps> = defaultProps,
-  context: PartialDeep<VegaWalletContextShape> = { keypair: { pub: '0x123' } }
+  context: PartialDeep<VegaWalletContextShape> = { pubKey: '0x123' }
 ) => {
   return (
     <MockedProvider>
@@ -166,7 +166,7 @@ describe('OrderListTable', () => {
       expect(mockCancel).toHaveBeenCalledWith(order);
     });
 
-    it('doesnt show buttons for liquidity provision orders', async () => {
+    it('does not show buttons for liquidity provision orders', async () => {
       const order = generateOrder({
         type: OrderType.TYPE_LIMIT,
         timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,
@@ -178,10 +178,12 @@ describe('OrderListTable', () => {
       });
 
       const amendCell = getAmendCell();
+      const typeCell = screen.getAllByRole('gridcell')[2];
+      expect(typeCell).toHaveTextContent('Liquidity provision');
       expect(amendCell.queryAllByRole('button')).toHaveLength(0);
     });
 
-    it('doesnt show buttons for pegged orders', async () => {
+    it('does not show buttons for pegged orders', async () => {
       const order = generateOrder({
         type: OrderType.TYPE_LIMIT,
         timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,
@@ -195,6 +197,8 @@ describe('OrderListTable', () => {
       });
 
       const amendCell = getAmendCell();
+      const typeCell = screen.getAllByRole('gridcell')[2];
+      expect(typeCell).toHaveTextContent('Pegged');
       expect(amendCell.queryAllByRole('button')).toHaveLength(0);
     });
 
@@ -221,7 +225,7 @@ describe('OrderListTable', () => {
       OrderStatus.STATUS_FILLED,
       OrderStatus.STATUS_REJECTED,
       OrderStatus.STATUS_STOPPED,
-    ])('doesnt show buttons for %s orders', async (status) => {
+    ])('does not show buttons for %s orders', async (status) => {
       const order = generateOrder({
         type: OrderType.TYPE_LIMIT,
         status,

--- a/libs/orders/src/lib/components/order-list/order-list.spec.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.spec.tsx
@@ -166,7 +166,7 @@ describe('OrderListTable', () => {
       expect(mockCancel).toHaveBeenCalledWith(order);
     });
 
-    it('does not show buttons for liquidity provision orders', async () => {
+    it('shows if an order is a liquidity provision order and does not show order actions', async () => {
       const order = generateOrder({
         type: OrderType.TYPE_LIMIT,
         timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,

--- a/libs/orders/src/lib/components/order-list/order-list.spec.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.spec.tsx
@@ -183,7 +183,7 @@ describe('OrderListTable', () => {
       expect(amendCell.queryAllByRole('button')).toHaveLength(0);
     });
 
-    it('does not show buttons for pegged orders', async () => {
+    it('shows if an order is a pegged order and does not show order actions', async () => {
       const order = generateOrder({
         type: OrderType.TYPE_LIMIT,
         timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,

--- a/libs/orders/src/lib/components/order-list/order-list.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.tsx
@@ -144,9 +144,12 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         <AgGridColumn
           field="type"
           valueFormatter={({
+            data: order,
             value,
           }: VegaValueFormatterParams<Order, 'type'>) => {
             if (!value) return '-';
+            if (order.peggedOrder) return t('Pegged');
+            if (order.liquidityProvision) return t('Liquidity provision');
             return OrderTypeMapping[value];
           }}
         />


### PR DESCRIPTION
# Related issues 🔗

Closes #1642 

# Description ℹ️

Show in order 'type' column if orders are LP or pegged. 

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
