### PR TITLE
Fix/1676 ag horizontal scrollbars

### DIFF
--- a/libs/ui-toolkit/src/components/ag-grid/ag-grid-dark.tsx
+++ b/libs/ui-toolkit/src/components/ag-grid/ag-grid-dark.tsx
@@ -17,6 +17,10 @@ const agGridDarkVariables = `
   .ag-theme-balham-dark .ag-root-wrapper {
     border: 0;
   }
+  
+  .ag-theme-balham-dark .ag-row {
+    border-width: 1px 0;
+  }
 
   .ag-theme-balham-dark .ag-react-container {
     overflow: hidden;

--- a/libs/ui-toolkit/src/components/ag-grid/ag-grid-light.tsx
+++ b/libs/ui-toolkit/src/components/ag-grid/ag-grid-light.tsx
@@ -4,7 +4,7 @@ import 'ag-grid-community/dist/styles/ag-theme-balham.css';
 
 const agGridLightVariables = `
   .ag-theme-balham {
-    --ag-background-color: ${colors};
+    --ag-background-color: ${colors.white};
     --ag-border-color: ${colors.neutral[300]};
     --ag-header-background-color: ${colors.white};
     --ag-odd-row-background-color: ${colors.white};
@@ -16,6 +16,10 @@ const agGridLightVariables = `
 
   .ag-theme-balham .ag-root-wrapper {
     border: 0;
+  }
+
+  .ag-theme-balham .ag-row {
+    border-width: 1px 0;
   }
 
   .ag-theme-balham .ag-react-container {


### PR DESCRIPTION
# Related issues 🔗

Closes #1676 

# Description

Couple of AgGrids when flexed occupied a little more space (width) than 100% because of the `border-width` set to `1px` for the whole row. I've set it to `0` for x-axis.
