### PR TITLE
chore: update to v0.58

### DIFF
--- a/.github/workflows/capsule-cypress-manual-trigger.yml
+++ b/.github/workflows/capsule-cypress-manual-trigger.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       GO111MODULE: 'on'
       GOBIN: /home/runner/go/bin
-      VEGA_VERSION: 'v0.57.0'
+      VEGA_VERSION: 'v0.58.0'
     steps:
       #######
       ## Setup flags

--- a/.github/workflows/capsule-cypress-night-run.yml
+++ b/.github/workflows/capsule-cypress-night-run.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       GO111MODULE: 'on'
       GOBIN: /home/runner/go/bin
-      VEGA_VERSION: 'v0.57.0'
+      VEGA_VERSION: 'v0.58.0'
       RUN_CAPSULE: true
     steps:
       #######

--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GO111MODULE: 'on'
       GOBIN: /home/runner/go/bin
-      VEGA_VERSION: 'v0.57.0'
+      VEGA_VERSION: 'v0.58.0'
     steps:
       #######
       ## Setup langs


### PR DESCRIPTION
# Related issues 🔗

Updates test pipeline to use latest release version of Vega `v.0.58.0`
