### PR TITLE
fix: wallet errors incorrectly showing as user rejections

### DIFF
--- a/libs/wallet/src/connectors/json-rpc-connector.ts
+++ b/libs/wallet/src/connectors/json-rpc-connector.ts
@@ -254,7 +254,7 @@ export class JsonRpcConnector implements VegaConnector {
     } else {
       // In the case of sending a tx, return null instead of throwing
       // this indicates to the app that the user rejected the tx rather
-      // than it being a true erroor
+      // than it being a true error
       if ('error' in result && result.error.code === 3001) {
         return null;
       }

--- a/libs/wallet/src/connectors/rest-connector.ts
+++ b/libs/wallet/src/connectors/rest-connector.ts
@@ -162,42 +162,37 @@ export class RestConnector implements VegaConnector {
   }
 
   async sendTx(pubKey: string, transaction: Transaction) {
-    try {
-      const body = {
-        pubKey,
-        propagate: true,
-        ...transaction,
-      };
-      const res = await this.request(Endpoints.Command, {
-        method: 'post',
-        body: JSON.stringify(body),
-        headers: {
-          authorization: `Bearer ${this.token}`,
-        },
-      });
+    const body = {
+      pubKey,
+      propagate: true,
+      ...transaction,
+    };
+    const res = await this.request(Endpoints.Command, {
+      method: 'post',
+      body: JSON.stringify(body),
+      headers: {
+        authorization: `Bearer ${this.token}`,
+      },
+    });
 
-      // User rejected
-      if (res.status === 401) {
-        return null;
-      }
-
-      if (res.error) {
-        throw new WalletError(res.error, 1, res.details);
-      }
-
-      const data = TransactionResponseSchema.parse(res.data);
-
-      // Make return value match that of v2 service
-      return {
-        transactionHash: data.txHash,
-        signature: data.tx.signature.value,
-        receivedAt: data.receivedAt,
-        sentAt: data.sentAt,
-      };
-    } catch (err) {
-      Sentry.captureException(err);
+    // User rejected
+    if (res.status === 401) {
       return null;
     }
+
+    if (res.error) {
+      throw new WalletError(res.error, 1, res.details);
+    }
+
+    const data = TransactionResponseSchema.parse(res.data);
+
+    // Make return value match that of v2 service
+    return {
+      transactionHash: data.txHash,
+      signature: data.tx.signature.value,
+      receivedAt: data.receivedAt,
+      sentAt: data.sentAt,
+    };
   }
 
   /** Parse more complex error object into a single string */


### PR DESCRIPTION
# Related issues 🔗

Closes #1605

# Description ℹ️

When the wallet responded with an error due to pre-chain validation the error toast was not being shown correctly resulting in users not being able to see why their transaction failed.

# Demo 📺

![Screenshot 2022-10-13 at 10 13 39](https://user-images.githubusercontent.com/26136207/195555676-48964137-751d-438b-9894-e50deaedd9da.png)

# Technical 👨‍🔧

In cases of errors from the wallet rest API we were returning null which indicates a user rejected transaction. This causes the form to reset preventing the error messages from showing.
