### PR TITLE
chore: single position table (1645)

### DIFF
--- a/apps/console-lite/src/app/components/portfolio/positions/use-column-definitions.tsx
+++ b/apps/console-lite/src/app/components/portfolio/positions/use-column-definitions.tsx
@@ -7,10 +7,7 @@ import {
   signedNumberCssClassRules,
   t,
 } from '@vegaprotocol/react-helpers';
-import type {
-  PositionsTableValueFormatterParams,
-  Position,
-} from '@vegaprotocol/positions';
+import type { Position } from '@vegaprotocol/positions';
 import { AmountCell } from '@vegaprotocol/positions';
 import type {
   CellRendererSelectorResult,
@@ -20,6 +17,7 @@ import type {
   ColDef,
 } from 'ag-grid-community';
 import { MarketTradingMode } from '@vegaprotocol/types';
+import type { VegaValueFormatterParams } from '@vegaprotocol/ui-toolkit';
 import { Intent, ProgressBarCell } from '@vegaprotocol/ui-toolkit';
 
 const EmptyCell = () => '';
@@ -77,9 +75,7 @@ const useColumnDefinitions = () => {
           value,
           data,
           node,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['openVolume'];
-        }) => {
+        }: VegaValueFormatterParams<Position, 'openVolume'>) => {
           let ret;
           if (value && data) {
             ret = node?.rowPinned
@@ -107,9 +103,7 @@ const useColumnDefinitions = () => {
           value,
           data,
           node,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['markPrice'];
-        }) => {
+        }: VegaValueFormatterParams<Position, 'markPrice'>) => {
           if (
             data &&
             value &&
@@ -186,9 +180,8 @@ const useColumnDefinitions = () => {
         valueFormatter: ({
           value,
           node,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['currentLeverage'];
-        }) => (value === undefined ? '' : formatNumber(value.toString(), 1)),
+        }: VegaValueFormatterParams<Position, 'currentLeverage'>) =>
+          value === undefined ? '' : formatNumber(value.toString(), 1),
       },
       {
         colId: 'marginallocated',
@@ -229,10 +222,8 @@ const useColumnDefinitions = () => {
         valueFormatter: ({
           value,
           data,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['realisedPNL'];
-        }) =>
-          value === undefined
+        }: VegaValueFormatterParams<Position, 'realisedPNL'>) =>
+          value === undefined || data === undefined
             ? ''
             : addDecimalsFormatNumber(value.toString(), data.decimals),
         cellRenderer: 'PriceFlashCell',
@@ -249,10 +240,8 @@ const useColumnDefinitions = () => {
         valueFormatter: ({
           value,
           data,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['unrealisedPNL'];
-        }) =>
-          value === undefined
+        }: VegaValueFormatterParams<Position, 'unrealisedPNL'>) =>
+          value === undefined || data === undefined
             ? ''
             : addDecimalsFormatNumber(value.toString(), data.decimals),
         cellRenderer: 'PriceFlashCell',
@@ -266,9 +255,7 @@ const useColumnDefinitions = () => {
         type: 'rightAligned',
         valueFormatter: ({
           value,
-        }: PositionsTableValueFormatterParams & {
-          value: Position['updatedAt'];
-        }) => {
+        }: VegaValueFormatterParams<Position, 'updatedAt'>) => {
           if (!value) {
             return '';
           }

--- a/apps/trading-e2e/src/integration/trading-positions.cy.ts
+++ b/apps/trading-e2e/src/integration/trading-positions.cy.ts
@@ -43,26 +43,23 @@ describe('positions', { tags: '@smoke' }, () => {
         cy.wrap($prices).invoke('text').should('not.be.empty');
       });
 
-      cy.get('[col-id="averageEntryPrice"]')
+      cy.get('[col-id="liquidationPrice"]')
         .should('contain.text', '85,093.38') // entry price
         .should('contain.text', '0.00'); // liquidation price
 
       cy.get('[col-id="currentLeverage"]').should('contain.text', '0.8');
 
-      cy.get('[col-id="capitalUtilisation"]') // margin allocated
-        .should('contain.text', '0.00%')
-        .should('contain.text', '1,000.01000');
+      cy.get('[col-id="marginAccountBalance"]') // margin allocated
+        .should('contain.text', '1,000.00000');
 
       cy.get('[col-id="unrealisedPNL"]').each(($unrealisedPnl) => {
         cy.wrap($unrealisedPnl).invoke('text').should('not.be.empty');
       });
 
-      cy.getByTestId('flash-cell').should('contain.text', '276,761.40348'); // Total tDAI position
-      cy.getByTestId('flash-cell').should('contain.text', '0.00000'); // Total Realised PNL
+      cy.get('[col-id="notional"]').should('contain.text', '276,761.40348'); // Total tDAI position
+      cy.get('[col-id="realisedPNL"]').should('contain.text', '0.00100'); // Total Realised PNL
       cy.get('[col-id="unrealisedPNL"]').should('contain.text', '8.95000'); // Total Unrealised PNL
     });
-
-    cy.getByTestId('balance').eq(1).should('have.text', '1,000.01000'); // Asset balance
 
     cy.getByTestId('close-position').should('be.visible').and('have.length', 3);
   }

--- a/apps/trading-e2e/src/integration/trading-positions.cy.ts
+++ b/apps/trading-e2e/src/integration/trading-positions.cy.ts
@@ -34,9 +34,11 @@ describe('positions', { tags: '@smoke' }, () => {
           cy.wrap($marketSymbol).invoke('text').should('not.be.empty');
         });
 
-      cy.get('[col-id="openVolume"]').each(($openVolume) => {
-        cy.wrap($openVolume).invoke('text').should('not.be.empty');
-      });
+      cy.get('.ag-center-cols-container [col-id="openVolume"]').each(
+        ($openVolume) => {
+          cy.wrap($openVolume).invoke('text').should('not.be.empty');
+        }
+      );
 
       // includes average entry price, mark price, realised PNL & leverage
       cy.getByTestId('flash-cell').each(($prices) => {

--- a/libs/positions/src/lib/positions-data-providers.ts
+++ b/libs/positions/src/lib/positions-data-providers.ts
@@ -42,6 +42,7 @@ interface PositionRejoined {
 export interface Position {
   marketName: string;
   averageEntryPrice: string;
+  marginAccountBalance: BigNumber;
   capitalUtilisation: number;
   currentLeverage: number;
   decimals: number;
@@ -151,6 +152,7 @@ export const getMetrics = (
     metrics.push({
       marketName: market.tradableInstrument.instrument.name,
       averageEntryPrice: position.averageEntryPrice,
+      marginAccountBalance,
       capitalUtilisation: Math.round(capitalUtilisation.toNumber()),
       currentLeverage: currentLeverage.toNumber(),
       marketDecimalPlaces,

--- a/libs/positions/src/lib/positions-manager.tsx
+++ b/libs/positions/src/lib/positions-manager.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { AsyncRenderer } from '@vegaprotocol/ui-toolkit';
 import type { Position } from './positions-data-providers';
-import { Positions } from './positions';
-import { useClosePosition, usePositionsAssets } from '../';
+import { PositionsTable, useClosePosition, usePositionsData } from '../';
+import type { AgGridReact } from 'ag-grid-react';
 
 interface PositionsManagerProps {
   partyId: string;
@@ -17,18 +17,20 @@ export const PositionsManager = ({ partyId }: PositionsManagerProps) => {
     [submit]
   );
 
-  const { data, error, loading, assetSymbols } = usePositionsAssets(partyId);
+  const gridRef = useRef<AgGridReact | null>(null);
+  const { data, error, loading, getRows } = usePositionsData(partyId, gridRef);
   return (
     <>
       <AsyncRenderer loading={loading} error={error} data={data}>
-        {assetSymbols?.map((assetSymbol) => (
-          <Positions
-            partyId={partyId}
-            assetSymbol={assetSymbol}
-            key={assetSymbol}
-            onClose={onClose}
-          />
-        ))}
+        <PositionsTable
+          domLayout="autoHeight"
+          style={{ width: '100%' }}
+          ref={gridRef}
+          rowModelType={data?.length ? 'infinite' : 'clientSide'}
+          rowData={data?.length ? undefined : []}
+          datasource={{ getRows }}
+          onClose={onClose}
+        />
       </AsyncRenderer>
 
       <Dialog>

--- a/libs/positions/src/lib/positions-table.tsx
+++ b/libs/positions/src/lib/positions-table.tsx
@@ -2,11 +2,13 @@ import classNames from 'classnames';
 import { forwardRef } from 'react';
 import type { CSSProperties } from 'react';
 import type {
-  ValueFormatterParams,
   ICellRendererParams,
   CellRendererSelectorResult,
 } from 'ag-grid-community';
-import type { ValueProps as PriceCellProps } from '@vegaprotocol/ui-toolkit';
+import type {
+  ValueProps as PriceCellProps,
+  VegaValueFormatterParams,
+} from '@vegaprotocol/ui-toolkit';
 import { EmptyCell, ProgressBarCell } from '@vegaprotocol/ui-toolkit';
 import {
   PriceFlashCell,
@@ -42,12 +44,12 @@ interface Props extends AgGridReactProps {
   style?: CSSProperties;
 }
 
-export type PositionsTableValueFormatterParams = Omit<
-  ValueFormatterParams,
-  'data' | 'value'
-> & {
-  data: Position;
-};
+// export type PositionsTableValueFormatterParams = Omit<
+//   ValueFormatterParams,
+//   'data' | 'value'
+// > & {
+//   data: Position;
+// };
 
 export interface MarketNameCellProps {
   valueFormatted?: [string, string];
@@ -117,7 +119,7 @@ const ButtonCell = ({
 const progressBarValueFormatter = ({
   data,
   node,
-}: PositionsTableValueFormatterParams):
+}: VegaValueFormatterParams<Position, 'liquidationPrice'>):
   | PriceCellProps['valueFormatted']
   | undefined => {
   if (!data || node?.rowPinned) {
@@ -159,9 +161,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           cellRenderer={MarketNameCell}
           valueFormatter={({
             value,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['marketName'];
-          }) => {
+          }: VegaValueFormatterParams<Position, 'marketName'>) => {
             if (!value) {
               return undefined;
             }
@@ -181,9 +181,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           valueFormatter={({
             value,
             data,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['notional'];
-          }): string => {
+          }: VegaValueFormatterParams<Position, 'notional'>): string => {
             if (!value || !data) {
               return '';
             }
@@ -199,9 +197,9 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           valueFormatter={({
             value,
             data,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['openVolume'];
-          }): string | undefined => {
+          }: VegaValueFormatterParams<Position, 'openVolume'>):
+            | string
+            | undefined => {
             if (!value || !data) {
               return undefined;
             }
@@ -225,9 +223,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
             value,
             data,
             node,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['markPrice'];
-          }) => {
+          }: VegaValueFormatterParams<Position, 'markPrice'>) => {
             if (!data || !value || node?.rowPinned) {
               return undefined;
             }
@@ -259,10 +255,10 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
             data,
             value,
             node,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['averageEntryPrice'];
-          }): string | undefined => {
-            if (!data || node?.rowPinned) {
+          }: VegaValueFormatterParams<Position, 'averageEntryPrice'>):
+            | string
+            | undefined => {
+            if (!data || node?.rowPinned || !value) {
               return undefined;
             }
             return addDecimalsFormatNumber(value, data.marketDecimalPlaces);
@@ -297,9 +293,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           }}
           valueFormatter={({
             value,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['currentLeverage'];
-          }) =>
+          }: VegaValueFormatterParams<Position, 'currentLeverage'>) =>
             value === undefined ? undefined : formatNumber(value.toString(), 1)
           }
         />
@@ -318,10 +312,10 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
             data,
             value,
             node,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['marginAccountBalance'];
-          }): string | undefined => {
-            if (!data || node?.rowPinned) {
+          }: VegaValueFormatterParams<Position, 'marginAccountBalance'>):
+            | string
+            | undefined => {
+            if (!data || node?.rowPinned || !value) {
               return undefined;
             }
             return formatNumber(value, data.decimals);
@@ -335,10 +329,8 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           valueFormatter={({
             value,
             data,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['realisedPNL'];
-          }) =>
-            value === undefined
+          }: VegaValueFormatterParams<Position, 'realisedPNL'>) =>
+            value === undefined || data === undefined
               ? undefined
               : addDecimalsFormatNumber(value.toString(), data.decimals)
           }
@@ -355,10 +347,8 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           valueFormatter={({
             value,
             data,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['unrealisedPNL'];
-          }) =>
-            value === undefined
+          }: VegaValueFormatterParams<Position, 'unrealisedPNL'>) =>
+            value === undefined || data === undefined
               ? undefined
               : addDecimalsFormatNumber(value.toString(), data.decimals)
           }
@@ -373,9 +363,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
           type="rightAligned"
           valueFormatter={({
             value,
-          }: PositionsTableValueFormatterParams & {
-            value: Position['updatedAt'];
-          }) => {
+          }: VegaValueFormatterParams<Position, 'updatedAt'>) => {
             if (!value) {
               return value;
             }

--- a/libs/positions/src/lib/positions-table.tsx
+++ b/libs/positions/src/lib/positions-table.tsx
@@ -44,13 +44,6 @@ interface Props extends AgGridReactProps {
   style?: CSSProperties;
 }
 
-// export type PositionsTableValueFormatterParams = Omit<
-//   ValueFormatterParams,
-//   'data' | 'value'
-// > & {
-//   data: Position;
-// };
-
 export interface MarketNameCellProps {
   valueFormatted?: [string, string];
 }

--- a/libs/positions/src/lib/positions-table.tsx
+++ b/libs/positions/src/lib/positions-table.tsx
@@ -270,7 +270,7 @@ export const PositionsTable = forwardRef<AgGridReact, Props>(
         />
         <AgGridColumn
           headerName={t('Liquidation price (est)')}
-          field="averageEntryPrice"
+          field="liquidationPrice"
           flex={2}
           headerTooltip={t(
             'Liquidation prices are based on the amount of collateral you have available, the risk of your position and the liquidity on the order book. They can change rapidly based on the profit and loss of your positions and any changes to collateral from opening/closing other positions and making deposits/withdrawals.'

--- a/libs/positions/src/lib/use-positions-data.tsx
+++ b/libs/positions/src/lib/use-positions-data.tsx
@@ -38,7 +38,8 @@ const getSummaryRow = (positions: Position[]) => {
 export const usePositionsData = (
   partyId: string,
   gridRef: RefObject<AgGridReact>,
-  assetSymbol?: string
+  assetSymbol?: string,
+  withSummaryRow?: boolean
 ) => {
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const dataRef = useRef<Position[] | null>(null);
@@ -65,13 +66,13 @@ export const usePositionsData = (
         : [];
       const lastRow = dataRef.current?.length ?? -1;
       successCallback(rowsThisBlock, lastRow);
-      if (gridRef.current?.api) {
+      if (withSummaryRow && gridRef.current?.api) {
         gridRef.current.api.setPinnedBottomRowData([
           getSummaryRow(rowsThisBlock),
         ]);
       }
     },
-    [gridRef]
+    [gridRef, withSummaryRow]
   );
   return {
     data,

--- a/libs/positions/src/lib/use-positions-data.tsx
+++ b/libs/positions/src/lib/use-positions-data.tsx
@@ -38,8 +38,7 @@ const getSummaryRow = (positions: Position[]) => {
 export const usePositionsData = (
   partyId: string,
   gridRef: RefObject<AgGridReact>,
-  assetSymbol?: string,
-  withSummaryRow?: boolean
+  assetSymbol?: string
 ) => {
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const dataRef = useRef<Position[] | null>(null);
@@ -66,13 +65,13 @@ export const usePositionsData = (
         : [];
       const lastRow = dataRef.current?.length ?? -1;
       successCallback(rowsThisBlock, lastRow);
-      if (withSummaryRow && gridRef.current?.api) {
+      if (gridRef.current?.api) {
         gridRef.current.api.setPinnedBottomRowData([
           getSummaryRow(rowsThisBlock),
         ]);
       }
     },
-    [gridRef, withSummaryRow]
+    [gridRef]
   );
   return {
     data,


### PR DESCRIPTION
# Related issues 🔗

Closes #1645

# Description ℹ️

* Render a single data grid that fills the positions panel, with all positions not aggregated by asset
* Add settlement asset column
* Split size cell into notional and open volume columns
* Split entry price and liquidation price into separate columns, progress bar can be displayed in liquidation price column
* Margin allocated cell to use single actual value (not percentage)
* Total value across positions gets removed

# Demo 📺

![Screenshot 2022-10-14 at 15 55 06](https://user-images.githubusercontent.com/1980305/195864412-50f4bc92-5130-4262-8de2-7cd88f372067.png)

