### PR TITLE
fix: docs URL not showing up correctly

### DIFF
--- a/apps/token/.env
+++ b/apps/token/.env
@@ -10,6 +10,7 @@ NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_EXPLORER_URL=https://explorer.fairground.wtf
 NX_HOSTED_WALLET_URL=https://wallet.testnet.vega.xyz
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/docs/testnet
 
 #Test configuration variables
 CYPRESS_FAIRGROUND=false

--- a/apps/token/.env.capsule
+++ b/apps/token/.env.capsule
@@ -13,6 +13,7 @@ NX_ETH_URL_CONNECT=1
 NX_ETH_WALLET_MNEMONIC=ozone access unlock valid olympic save include omit supply green clown session
 NX_LOCAL_PROVIDER_URL=http://localhost:8545/
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/docs/testnet
 
 #Test configuration variables
 CYPRESS_FAIRGROUND=false


### PR DESCRIPTION
# Related issues 🔗

Closes #1377

# Description ℹ️

The documentation links were already present but because of the environment file changes meant that these were not being rendered. 

# Demo 📺

<img width="858" alt="Screenshot 2022-10-15 at 11 37 40" src="https://user-images.githubusercontent.com/26136207/195982046-704964ab-3797-4657-a9c9-2bb24df90927.png">
