### PR TITLE
chore: accounts-table reload after partyId change

### DIFF
--- a/libs/accounts/src/lib/accounts-manager.spec.tsx
+++ b/libs/accounts/src/lib/accounts-manager.spec.tsx
@@ -1,0 +1,24 @@
+import { act, render } from '@testing-library/react';
+import { AccountManager } from './accounts-manager';
+
+const mockReload = jest.fn();
+jest.mock('@vegaprotocol/react-helpers', () => ({
+  ...jest.requireActual('@vegaprotocol/react-helpers'),
+  useDataProvider: jest.fn(() => ({
+    data: [],
+    reload: mockReload,
+  })),
+}));
+
+describe('AccountManager', () => {
+  it('change partyId should reload data provider', async () => {
+    const { rerender } = render(
+      <AccountManager partyId="partyOne" onClickAsset={jest.fn} />
+    );
+    expect(mockReload).not.toHaveBeenCalled();
+    await act(() => {
+      rerender(<AccountManager partyId="partyTwo" onClickAsset={jest.fn} />);
+    });
+    expect(mockReload).toHaveBeenCalledWith(true);
+  });
+});

--- a/libs/accounts/src/lib/accounts-manager.tsx
+++ b/libs/accounts/src/lib/accounts-manager.tsx
@@ -21,6 +21,7 @@ export const AccountManager = ({
   onClickDeposit,
   partyId,
 }: AccountManagerProps) => {
+  const partyIdRef = useRef<string>(partyId);
   const gridRef = useRef<AgGridReact | null>(null);
   const dataRef = useRef<AccountFields[] | null>(null);
   const variables = useMemo(() => ({ partyId }), [partyId]);
@@ -32,11 +33,19 @@ export const AccountManager = ({
     },
     [gridRef]
   );
-  const { data, loading, error } = useDataProvider<AccountFields[], never>({
+
+  const { data, loading, error, reload } = useDataProvider<
+    AccountFields[],
+    never
+  >({
     dataProvider: aggregatedAccountsDataProvider,
     update,
     variables,
   });
+  if (partyId !== partyIdRef.current) {
+    reload(true);
+    partyIdRef.current = partyId;
+  }
   if (!dataRef.current && data) {
     dataRef.current = data;
   }


### PR DESCRIPTION
# Related issues 🔗

Closes #1756 

# Description ℹ️

Fix re-creating ag-grid instance after changes of dataProvider variables

# Technical 👨‍🔧

Use `reload` method of `use-data-provider` hook
