### PR TITLE
feat(1675): server side sort and filters of orders

### DIFF
--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 import { gql } from '@apollo/client';
 import orderBy from 'lodash/orderBy';
 import uniqBy from 'lodash/uniqBy';
+import type { OperationVariables } from '@apollo/client';
 import {
   makeDataProvider,
   makeDerivedDataProvider,
@@ -87,7 +88,8 @@ export const ORDERS_SUB = gql`
 
 export const update = (
   data: Orders_party_ordersConnection_edges[],
-  delta: OrderSub_orders[]
+  delta: OrderSub_orders[],
+  variables: OperationVariables
 ) => {
   return produce(data, (draft) => {
     // A single update can contain the same order with multiple updates, so we need to find

--- a/libs/orders/src/lib/components/order-list-manager/use-order-list-data.ts
+++ b/libs/orders/src/lib/components/order-list-manager/use-order-list-data.ts
@@ -8,14 +8,25 @@ import {
 import { ordersWithMarketProvider } from '../';
 import type { OrderEdge, Order } from '../';
 
+export interface Sort {
+  colId: string;
+  sort: string;
+}
+export interface Filter {
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
 interface Props {
   partyId: string;
+  filter?: Filter;
+  sort?: Sort[];
   gridRef: RefObject<AgGridReact>;
   scrolledToTop: RefObject<boolean>;
 }
 
 export const useOrderListData = ({
   partyId,
+  sort,
+  filter,
   gridRef,
   scrolledToTop,
 }: Props) => {
@@ -23,7 +34,10 @@ export const useOrderListData = ({
   const totalCountRef = useRef<number | undefined>(undefined);
   const newRows = useRef(0);
 
-  const variables = useMemo(() => ({ partyId }), [partyId]);
+  const variables = useMemo(
+    () => ({ partyId, sort, filter }),
+    [partyId, sort, filter]
+  );
 
   const addNewRows = useCallback(() => {
     if (newRows.current === 0) {

--- a/libs/orders/src/lib/components/order-list/order-list.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.tsx
@@ -104,7 +104,13 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
       <AgGrid
         ref={ref}
         overlayNoRowsTemplate="No orders"
-        defaultColDef={{ flex: 1, resizable: true }}
+        defaultColDef={{
+          flex: 1,
+          resizable: true,
+          sortable: true,
+          filter: true,
+          filterParams: { buttons: ['reset'] },
+        }}
         style={{ width: '100%', height: '100%' }}
         getRowId={({ data }) => data.id}
         rowHeight={34}
@@ -117,6 +123,7 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         <AgGridColumn
           headerName={t('Size')}
           field="size"
+          filter="agNumberColumnFilter"
           cellClass="font-mono text-right"
           type="rightAligned"
           cellClassRules={{
@@ -144,6 +151,8 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         />
         <AgGridColumn
           field="type"
+          filter={false}
+          sortable={false}
           valueFormatter={({
             data: order,
             value,
@@ -156,6 +165,8 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         />
         <AgGridColumn
           field="status"
+          filter={false}
+          sortable={false}
           valueFormatter={({
             value,
             data,
@@ -172,6 +183,7 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         <AgGridColumn
           headerName={t('Filled')}
           field="remaining"
+          filter="agNumberColumnFilter"
           cellClass="font-mono text-right"
           type="rightAligned"
           valueFormatter={({
@@ -193,6 +205,7 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         />
         <AgGridColumn
           field="price"
+          filter="agNumberColumnFilter"
           type="rightAligned"
           cellClass="font-mono text-right"
           valueFormatter={({
@@ -211,6 +224,7 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
         />
         <AgGridColumn
           field="timeInForce"
+          filter="agDateColumnFilter"
           valueFormatter={({
             value,
             data,

--- a/libs/react-helpers/src/hooks/use-data-provider.ts
+++ b/libs/react-helpers/src/hooks/use-data-provider.ts
@@ -31,7 +31,15 @@ export function useDataProvider<Data, Delta>({
   skip,
 }: {
   dataProvider: Subscribe<Data, Delta>;
-  update?: ({ delta, data }: { delta?: Delta; data: Data }) => boolean;
+  update?: ({
+    delta,
+    data,
+    variables,
+  }: {
+    delta?: Delta;
+    data: Data;
+    variables?: OperationVariables;
+  }) => boolean;
   insert?: ({
     insertionData,
     data,
@@ -93,7 +101,7 @@ export function useDataProvider<Data, Delta>({
             !noUpdate &&
             update &&
             hasDelta<Delta>(arg) &&
-            update({ delta: arg.delta, data })
+            update({ delta: arg.delta, data, variables })
           ) {
             return;
           }
@@ -113,7 +121,7 @@ export function useDataProvider<Data, Delta>({
         initialized.current = true;
       }
     },
-    [update, insert, noUpdate, updateOnInit]
+    [update, insert, noUpdate, updateOnInit, variables]
   );
   useEffect(() => {
     if (skip) {

--- a/libs/react-helpers/src/lib/generic-data-provider.ts
+++ b/libs/react-helpers/src/lib/generic-data-provider.ts
@@ -62,7 +62,12 @@ export interface Subscribe<Data, Delta> {
 export type Query<Result> = DocumentNode | TypedDocumentNode<Result, any>;
 
 export interface Update<Data, Delta> {
-  (data: Data, delta: Delta, reload: (forceReset?: boolean) => void): Data;
+  (
+    data: Data,
+    delta: Delta,
+    reload: (forceReset?: boolean) => void,
+    variables?: OperationVariables
+  ): Data;
 }
 
 export interface Append<Data> {
@@ -302,7 +307,7 @@ function makeDataProviderInternal<QueryData, Data, SubscriptionData, Delta>({
         while (updateQueue.length) {
           const delta = updateQueue.shift();
           if (delta) {
-            data = update(data, delta, reload);
+            data = update(data, delta, reload, variables);
           }
         }
       }
@@ -365,7 +370,7 @@ function makeDataProviderInternal<QueryData, Data, SubscriptionData, Delta>({
             if (loading || !data) {
               updateQueue.push(delta);
             } else {
-              const updatedData = update(data, delta, reload);
+              const updatedData = update(data, delta, reload, variables);
               if (updatedData === data) {
                 return;
               }


### PR DESCRIPTION
# Related issues 🔗

Closes #1675

# Description ℹ️

This is POC of sort and filter of paginated data 

# Technical 👨‍🔧

Order and sort of paginated data needs to be done on server side. To achieve that sort and filter parameters needs to be passed to data provider as a part of variables.
Update function both from data provider and from use data provider hook needs to support sorting and filtering by all supported columns. After received update via Apollo subscription row needs to be checked if it matches filter and if it's index should change accordingly to selected to sort parameter.
