### PR TITLE
chore: fix market summary tests and remove positions title

### DIFF
--- a/apps/trading-e2e/src/integration/market-summary.cy.ts
+++ b/apps/trading-e2e/src/integration/market-summary.cy.ts
@@ -118,11 +118,11 @@ describe('Market trading page', () => {
       const toolTipValue = 'tooltip-value';
       const auctionToolTipLabels = [
         'Auction start',
-        'Est auction end',
+        'Est. auction end',
         'Target liquidity',
         'Current liquidity',
-        'Est uncrossing price',
-        'Est uncrossing vol',
+        'Est. uncrossing price',
+        'Est. uncrossing vol',
       ];
 
       cy.getByTestId(marketSummaryBlock).within(() => {

--- a/apps/trading/pages/portfolio/index.page.tsx
+++ b/apps/trading/pages/portfolio/index.page.tsx
@@ -30,12 +30,7 @@ const Portfolio = () => {
             <Tabs>
               <Tab id="positions" name={t('Positions')}>
                 <VegaWalletContainer>
-                  <div className={tabContentClassName}>
-                    <h4 className="text-xl p-4">{t('Positions')}</h4>
-                    <div>
-                      <PositionsContainer />
-                    </div>
-                  </div>
+                  <PositionsContainer />
                 </VegaWalletContainer>
               </Tab>
               <Tab id="orders" name={t('Orders')}>


### PR DESCRIPTION
# Description ℹ️

- Fix e2e tests
- Removes redundant positions title above table. Allow table to fill space

![Screen Shot 2022-10-25 at 10 40 17](https://user-images.githubusercontent.com/6803987/197844150-f9911d7f-5047-471c-82e0-cce24f2db1da.jpg)
