### PR TITLE
fix: 1863 market info reference price should be formatted with asset dp

### DIFF
--- a/libs/market-info/src/components/market-info/info-key-value-table.tsx
+++ b/libs/market-info/src/components/market-info/info-key-value-table.tsx
@@ -1,19 +1,11 @@
-import {
-  t,
-  addDecimalsFormatNumber,
-  formatNumberPercentage,
-  formatNumber,
-} from '@vegaprotocol/react-helpers';
-import {
-  KeyValueTableRow,
-  KeyValueTable,
-  Tooltip,
-} from '@vegaprotocol/ui-toolkit';
+import { addDecimalsFormatNumber, formatNumber, formatNumberPercentage, t } from '@vegaprotocol/react-helpers';
+import { KeyValueTable, KeyValueTableRow, Tooltip } from '@vegaprotocol/ui-toolkit';
 import BigNumber from 'bignumber.js';
 import startCase from 'lodash/startCase';
-import type { ReactNode } from 'react';
+
 import { tooltipMapping } from './tooltip-mapping';
 
+import type { ReactNode } from 'react';
 interface RowProps {
   field: string;
   value: unknown;
@@ -39,7 +31,9 @@ const Row = ({
       return value;
     }
     if (decimalPlaces) {
-      return `${addDecimalsFormatNumber(value, decimalPlaces)} ${assetSymbol}`;
+      return `${parseFloat(
+        addDecimalsFormatNumber(value, decimalPlaces)
+      )} ${assetSymbol}`;
     }
     if (asPercentage) {
       return formatNumberPercentage(new BigNumber(value).times(100));

--- a/libs/market-info/src/components/market-info/info-key-value-table.tsx
+++ b/libs/market-info/src/components/market-info/info-key-value-table.tsx
@@ -1,5 +1,14 @@
-import { addDecimalsFormatNumber, formatNumber, formatNumberPercentage, t } from '@vegaprotocol/react-helpers';
-import { KeyValueTable, KeyValueTableRow, Tooltip } from '@vegaprotocol/ui-toolkit';
+import {
+  addDecimalsFormatNumber,
+  formatNumber,
+  formatNumberPercentage,
+  t,
+} from '@vegaprotocol/react-helpers';
+import {
+  KeyValueTable,
+  KeyValueTableRow,
+  Tooltip,
+} from '@vegaprotocol/ui-toolkit';
 import BigNumber from 'bignumber.js';
 import startCase from 'lodash/startCase';
 

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -1,9 +1,25 @@
 import { AssetDetailsTable, useAssetDataProvider } from '@vegaprotocol/assets';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { totalFeesPercentage } from '@vegaprotocol/market-list';
-import { formatNumber, t, useDataProvider, useYesterday } from '@vegaprotocol/react-helpers';
-import { AccountType, Interval, MarketStateMapping, MarketTradingModeMapping } from '@vegaprotocol/types';
-import { Accordion, AsyncRenderer, ExternalLink, Link as UiToolkitLink, Splash } from '@vegaprotocol/ui-toolkit';
+import {
+  formatNumber,
+  t,
+  useDataProvider,
+  useYesterday,
+} from '@vegaprotocol/react-helpers';
+import {
+  AccountType,
+  Interval,
+  MarketStateMapping,
+  MarketTradingModeMapping,
+} from '@vegaprotocol/types';
+import {
+  Accordion,
+  AsyncRenderer,
+  ExternalLink,
+  Link as UiToolkitLink,
+  Splash,
+} from '@vegaprotocol/ui-toolkit';
 import BigNumber from 'bignumber.js';
 import pick from 'lodash/pick';
 import Link from 'next/link';

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -1,31 +1,20 @@
-import { useMemo } from 'react';
-import {
-  formatNumber,
-  t,
-  useDataProvider,
-  useYesterday,
-} from '@vegaprotocol/react-helpers';
-import { AsyncRenderer, Splash, Accordion } from '@vegaprotocol/ui-toolkit';
-import pick from 'lodash/pick';
-import BigNumber from 'bignumber.js';
-import { totalFeesPercentage } from '@vegaprotocol/market-list';
-import {
-  AccountType,
-  Interval,
-  MarketStateMapping,
-  MarketTradingModeMapping,
-} from '@vegaprotocol/types';
-import { MarketInfoTable } from './info-key-value-table';
-import { ExternalLink } from '@vegaprotocol/ui-toolkit';
-import { generatePath } from 'react-router-dom';
-import { useEnvironment } from '@vegaprotocol/environment';
-import { Link as UiToolkitLink } from '@vegaprotocol/ui-toolkit';
-import Link from 'next/link';
-import { marketInfoDataProvider } from './market-info-data-provider';
 import { AssetDetailsTable, useAssetDataProvider } from '@vegaprotocol/assets';
-import type { MarketInfoQuery } from './__generated___/MarketInfo';
-import { getMarketExpiryDateFormatted } from '../market-expires';
+import { useEnvironment } from '@vegaprotocol/environment';
+import { totalFeesPercentage } from '@vegaprotocol/market-list';
+import { formatNumber, t, useDataProvider, useYesterday } from '@vegaprotocol/react-helpers';
+import { AccountType, Interval, MarketStateMapping, MarketTradingModeMapping } from '@vegaprotocol/types';
+import { Accordion, AsyncRenderer, ExternalLink, Link as UiToolkitLink, Splash } from '@vegaprotocol/ui-toolkit';
+import BigNumber from 'bignumber.js';
+import pick from 'lodash/pick';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { generatePath } from 'react-router-dom';
 
+import { getMarketExpiryDateFormatted } from '../market-expires';
+import { MarketInfoTable } from './info-key-value-table';
+import { marketInfoDataProvider } from './market-info-data-provider';
+
+import type { MarketInfoQuery } from './__generated___/MarketInfo';
 const Links = {
   PROPOSAL_PAGE: ':tokenUrl/governance/:proposalId',
 };
@@ -271,7 +260,20 @@ export const Info = ({ market, onSelect }: InfoProps) => {
     ...(market.data?.priceMonitoringBounds || []).map((trigger, i) => ({
       title: t(`Price monitoring bound ${i + 1}`),
       content: (
-        <MarketInfoTable data={trigger} decimalPlaces={market.decimalPlaces} />
+        <>
+          <MarketInfoTable
+            data={trigger}
+            decimalPlaces={market.decimalPlaces}
+            omits={['referencePrice', '__typename']}
+          />
+          <MarketInfoTable
+            data={{ referencePrice: trigger.referencePrice }}
+            decimalPlaces={
+              market?.tradableInstrument.instrument.product?.settlementAsset
+                .decimals
+            }
+          />
+        </>
       ),
     })),
     {

--- a/libs/orders/src/lib/components/order-list/order-list.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.tsx
@@ -1,5 +1,5 @@
 import {
-  addDecimal,
+  addDecimalsFormatNumber,
   getDateTimeFormat,
   isNumeric,
   negativeClassNames,
@@ -157,7 +157,8 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
                 : '-'
               : '';
             return (
-              prefix + addDecimal(value, data.market.positionDecimalPlaces)
+              prefix +
+              addDecimalsFormatNumber(value, data.market.positionDecimalPlaces)
             );
           }}
         />
@@ -204,10 +205,10 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
             const size = new BigNumber(data.size);
             const remaining = new BigNumber(value);
             const fills = size.minus(remaining);
-            return `${addDecimal(fills.toString(), dps)}/${addDecimal(
-              size.toString(),
+            return `${addDecimalsFormatNumber(
+              fills.toString(),
               dps
-            )}`;
+            )}/${addDecimalsFormatNumber(size.toString(), dps)}`;
           }}
         />
         <AgGridColumn
@@ -225,7 +226,7 @@ export const OrderListTable = forwardRef<AgGridReact, OrderListTableProps>(
             ) {
               return '-';
             }
-            return addDecimal(value, data.market.decimalPlaces);
+            return addDecimalsFormatNumber(value, data.market.decimalPlaces);
           }}
         />
         <AgGridColumn


### PR DESCRIPTION
# Related issues 🔗

Closes #1863 

- [x] format market info reference price
- [x] format order list numbers

# Description ℹ️ & # Demo 📺

<img width="369" alt="Screenshot 2022-10-26 at 15 45 25" src="https://user-images.githubusercontent.com/16125548/198063342-53ffe9fd-0cd1-41a2-9f69-06458578d052.png">

should be

<img width="431" alt="Screenshot 2022-10-26 at 15 55 47" src="https://user-images.githubusercontent.com/16125548/198063278-6ed77454-baf8-4332-99b5-513e6ddf8098.png">


<img width="1131" alt="image" src="https://user-images.githubusercontent.com/16125548/198071074-055bb9da-7c04-4dab-9db1-c68fc34259d3.png">
