### PR TITLE
fix: token and percentage amounts in vote information

### DIFF
--- a/apps/token/src/routes/governance/hooks/use-vote-information.spec.ts
+++ b/apps/token/src/routes/governance/hooks/use-vote-information.spec.ts
@@ -74,7 +74,7 @@ describe('use-vote-information', () => {
     const yesEquityLikeShareWeight = '30';
     const noEquityLikeShareWeight = '70';
     // Note - giving a fixedTokenValue of 1 means a ratio of 1:1 votes to tokens, making sums easier :)
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       terms: {
@@ -128,7 +128,7 @@ describe('use-vote-information', () => {
   it('correctly returns majority, participation and will-pass status for a proposal with no votes', () => {
     const yesVotes = 0;
     const noVotes = 0;
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       votes: {
@@ -150,7 +150,7 @@ describe('use-vote-information', () => {
   it('correctly shows lack of participation for a failing proposal lacking votes', () => {
     const yesVotes = 20;
     const noVotes = 10;
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       votes: {
@@ -170,7 +170,7 @@ describe('use-vote-information', () => {
   it('correctly shows participation but lack of majority for a failing proposal with enough votes but not enough majority', () => {
     const yesVotes = 20;
     const noVotes = 70;
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       votes: {
@@ -192,7 +192,7 @@ describe('use-vote-information', () => {
   it('correctly shows participation, majority and will-pass data for successful proposal', () => {
     const yesVotes = 70;
     const noVotes = 20;
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       votes: {
@@ -216,7 +216,7 @@ describe('use-vote-information', () => {
     const noVotes = 70;
     const yesEquityLikeShareWeight = '30';
     const noEquityLikeShareWeight = '60';
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       terms: {
@@ -249,7 +249,7 @@ describe('use-vote-information', () => {
     const noVotes = 70;
     const yesEquityLikeShareWeight = '80';
     const noEquityLikeShareWeight = '20';
-    const fixedTokenValue = 1;
+    const fixedTokenValue = 1000000000000000000;
 
     const proposal = generateProposal({
       terms: {

--- a/apps/token/src/routes/governance/hooks/use-vote-information.ts
+++ b/apps/token/src/routes/governance/hooks/use-vote-information.ts
@@ -3,6 +3,7 @@ import { useAppState } from '../../../contexts/app-state/app-state-context';
 import { BigNumber } from '../../../lib/bignumber';
 import { useProposalNetworkParams } from './use-proposal-network-params';
 import type { Proposal_proposal } from '../proposal/__generated__/Proposal';
+import { addDecimal } from '@vegaprotocol/react-helpers';
 
 export const useVoteInformation = ({
   proposal,
@@ -10,7 +11,7 @@ export const useVoteInformation = ({
   proposal: Proposal_proposal;
 }) => {
   const {
-    appState: { totalSupply },
+    appState: { totalSupply, decimals },
   } = useAppState();
 
   const {
@@ -52,14 +53,18 @@ export const useVoteInformation = ({
       ? new BigNumber(requiredMajorityLP).times(100)
       : new BigNumber(100);
 
-    const noTokens = new BigNumber(proposal.votes.no.totalTokens);
+    const noTokens = new BigNumber(
+      addDecimal(proposal.votes.no.totalTokens, decimals)
+    );
 
     const noEquityLikeShareWeight = !proposal.votes.no
       .totalEquityLikeShareWeight
       ? new BigNumber(0)
       : new BigNumber(proposal.votes.no.totalEquityLikeShareWeight);
 
-    const yesTokens = new BigNumber(proposal.votes.yes.totalTokens);
+    const yesTokens = new BigNumber(
+      addDecimal(proposal.votes.yes.totalTokens, decimals)
+    );
 
     const yesEquityLikeShareWeight = !proposal.votes.yes
       .totalEquityLikeShareWeight

--- a/apps/token/src/routes/governance/hooks/use-vote-information.ts
+++ b/apps/token/src/routes/governance/hooks/use-vote-information.ts
@@ -158,6 +158,7 @@ export const useVoteInformation = ({
       willPassByLPVote,
     };
   }, [
+    decimals,
     proposal.votes.no.totalEquityLikeShareWeight,
     proposal.votes.no.totalTokens,
     proposal.votes.yes.totalEquityLikeShareWeight,


### PR DESCRIPTION
# Related issues 🔗

Closes #1766

# Description ℹ️

The decimals were not added to the totalYes and totalNo tokens amounts, causing the calculations to become incorrect. Add these in appropriately.
