### PR TITLE
chore: update wallet link in wallet UI

### DIFF
--- a/libs/wallet/src/connect-dialog/connect-dialog-elements.tsx
+++ b/libs/wallet/src/connect-dialog/connect-dialog-elements.tsx
@@ -1,10 +1,7 @@
 import { t } from '@vegaprotocol/react-helpers';
 import { Link } from '@vegaprotocol/ui-toolkit';
 import type { ReactNode } from 'react';
-import {
-  VEGA_WALLET_CONCEPTS_URL,
-  VEGA_WALLET_RELEASE_URL,
-} from '../constants';
+import { VEGA_WALLET_CONCEPTS_URL, VEGA_WALLET_URL } from '../constants';
 
 export const ConnectDialogTitle = ({ children }: { children: ReactNode }) => {
   return (
@@ -28,7 +25,7 @@ export const ConnectDialogFooter = ({ children }: { children?: ReactNode }) => {
         children
       ) : (
         <>
-          <Link href={VEGA_WALLET_RELEASE_URL}>{t('Get a Vega Wallet')}</Link>
+          <Link href={VEGA_WALLET_URL}>{t('Get a Vega Wallet')}</Link>
           {' | '}
           <Link href={VEGA_WALLET_CONCEPTS_URL}>{t('Having trouble?')}</Link>
         </>

--- a/libs/wallet/src/connect-dialog/connect-dialog.tsx
+++ b/libs/wallet/src/connect-dialog/connect-dialog.tsx
@@ -272,7 +272,7 @@ const SelectedForm = ({
                 {t('hosted wallet')}
               </Link>
               {t(', or for the real experience create a wallet in the ')}
-              <Link href={constants.VEGA_WALLET_RELEASE_URL}>
+              <Link href={constants.VEGA_WALLET_URL}>
                 {t('Vega wallet app')}
               </Link>
             </p>

--- a/libs/wallet/src/constants.ts
+++ b/libs/wallet/src/constants.ts
@@ -1,5 +1,4 @@
-export const VEGA_WALLET_RELEASE_URL =
-  'https://github.com/vegaprotocol/vega/releases';
+export const VEGA_WALLET_URL = 'https://vega.xyz/wallet';
 export const VEGA_WALLET_CONCEPTS_URL =
   'https://docs.vega.xyz/docs/mainnet/concepts/vega-wallet';
 export const VEGA_WALLET_HOSTED_URL = 'https://vega-hosted-wallet.on.fleek.co/';


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Updates 'Get a wallet' links in wallet UI to go to vega.xyz/wallet rather than the github releases page
