### PR TITLE
Fix/1639 use connected button to populate ETH address in withdraw dialog

### DIFF
--- a/libs/withdraws/src/lib/withdraw-form.tsx
+++ b/libs/withdraws/src/lib/withdraw-form.tsx
@@ -133,6 +133,16 @@ export const WithdrawForm = ({
           label={t('To (Ethereum address)')}
           labelFor="ethereum-address"
         >
+          {address && (
+            <UseButton
+              onClick={() => {
+                setValue('to', address);
+                clearErrors('to');
+              }}
+            >
+              {t('Use connected')}
+            </UseButton>
+          )}
           <Input
             id="ethereum-address"
             data-testid="eth-address-input"


### PR DESCRIPTION


# Related issues 🔗

Closes #1639

# Description ℹ️

`Use connected` button to populate ETH address in withdrawal dialog. 

# Demo 📺

<img width="699" alt="Screenshot 2022-11-03 at 17 45 02" src="https://user-images.githubusercontent.com/16125548/199796984-ec662e66-e0df-46b6-a54f-8492e918de13.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
