### PR TITLE
test: add separate workflows for each app

### DIFF
--- a/.github/workflows/cypress-console-lite-e2e.yml
+++ b/.github/workflows/cypress-console-lite-e2e.yml
@@ -1,0 +1,75 @@
+name: Cypress - console-lite
+
+on:
+  workflow_call:
+    inputs:
+      vega-version:
+        required: true
+        type: string
+      gobin:
+        required: false
+        type: string
+        default: /home/runner/go/bin
+      tags:
+        required: false
+        type: string
+
+jobs:
+  console-lite-e2e:
+    runs-on: self-hosted
+    steps:
+      # Add GOBIN to PATH
+      - name: Add GOBIN to PATH
+        run: echo ${{ inputs.gobin }} >> $GITHUB_PATH
+
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      #######
+      ## Build and run Vegacapsule network
+      #######
+
+      - name: Install Vega binaries
+        uses: ./frontend-monorepo/.github/actions/install-vega-binaries
+        with:
+          all: false
+          version: ${{ inputs.vega-version }}
+          gobin: ${{ inputs.gobin }}
+
+      ######
+      ## Setup a Vega wallet for our user
+      ######
+
+      - name: Set up Vegawallet
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+        with:
+          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
+          passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          capsule: false
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx run console-lite-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome ${{ inputs.tags }}
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_ETH_WALLET_MNEMONIC: ${{ secrets.CYPRESS_ETH_WALLET_MNEMONIC }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false

--- a/.github/workflows/cypress-explorer-e2e.yml
+++ b/.github/workflows/cypress-explorer-e2e.yml
@@ -1,0 +1,103 @@
+name: Cypress - explorer
+
+on:
+  workflow_call:
+    inputs:
+      vega-version:
+        required: true
+        type: string
+      gobin:
+        required: false
+        type: string
+        default: /home/runner/go/bin
+      tags:
+        required: false
+        type: string
+
+jobs:
+  explorer-e2e:
+    name: Run Cypress tests - PR
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      # Add GOBIN to PATH
+      - name: Add GOBIN to PATH
+        run: echo ${{ input.gobin }} >> $GITHUB_PATH
+
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # Install frontend dependencies
+      - name: Install root dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: frontend-monorepo
+
+      #######
+      ## Build and run Vegacapsule network
+      #######
+
+      - name: Install Vega binaries
+        uses: ./frontend-monorepo/.github/actions/install-vega-binaries
+        with:
+          all: true
+          version: ${{ inputs.vega-version }}
+          gobin: ${{ inputs.gobin }}
+
+      - name: Build and run Vegacapsule network
+        uses: ./frontend-monorepo/.github/actions/run-vegacapsule
+        with:
+          github-token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+
+      ######
+      ## Setup a Vega wallet for our user
+      ######
+
+      - name: Set up Vegawallet
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+        with:
+          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
+          passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          capsule: true
+
+      ######
+      ## Run some tests
+      ######
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx explorer-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome ${{ inputs.tags }}
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_ETH_WALLET_MNEMONIC: ${{ secrets.CYPRESS_ETH_WALLET_MNEMONIC }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false
+
+      ######
+      ## Upload logs
+      ######
+
+      - name: Logs
+        run: vegacapsule network logs > vega-capsule-logs.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: ./vega-capsule-logs.txt

--- a/.github/workflows/cypress-liquidity-provision-dashboard-e2e.yml
+++ b/.github/workflows/cypress-liquidity-provision-dashboard-e2e.yml
@@ -1,0 +1,35 @@
+name: Cypress - liquidity provision dashboard
+
+on: workflow_call
+jobs:
+  liquidity-provision-dashboard-e2e:
+    timeout-minutes: 10
+    runs-on: self-hosted
+    steps:
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx run liquidity-provision-dashboard-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false

--- a/.github/workflows/cypress-stats-e2e.yml
+++ b/.github/workflows/cypress-stats-e2e.yml
@@ -1,0 +1,35 @@
+name: Cypress - stats
+
+on: workflow_call
+jobs:
+  stats-e2e:
+    runs-on: self-hosted
+    timeout-minutes: 10
+    steps:
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx run stats-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false

--- a/.github/workflows/cypress-token-e2e.yml
+++ b/.github/workflows/cypress-token-e2e.yml
@@ -1,0 +1,103 @@
+name: Cypress - token
+
+on:
+  workflow_call:
+    inputs:
+      vega-version:
+        required: true
+        type: string
+      gobin:
+        required: false
+        type: string
+        default: /home/runner/go/bin
+      tags:
+        required: false
+        type: string
+
+jobs:
+  token-e2e:
+    name: Run Cypress tests - PR
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      # Add GOBIN to PATH
+      - name: Add GOBIN to PATH
+        run: echo ${{ inputs.gobin }} >> $GITHUB_PATH
+
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      # Install frontend dependencies
+      - name: Install root dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: frontend-monorepo
+
+      #######
+      ## Build and run Vegacapsule network
+      #######
+
+      - name: Install Vega binaries
+        uses: ./frontend-monorepo/.github/actions/install-vega-binaries
+        with:
+          all: true
+          version: ${{ inputs.vega-version }}
+          gobin: ${{ inputs.gobin }}
+
+      - name: Build and run Vegacapsule network
+        uses: ./frontend-monorepo/.github/actions/run-vegacapsule
+        with:
+          github-token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+
+      ######
+      ## Setup a Vega wallet for our user
+      ######
+
+      - name: Set up Vegawallet
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+        with:
+          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
+          passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          capsule: true
+
+      ######
+      ## Run some tests
+      ######
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx token-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome ${{ inputs.tags }}
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_ETH_WALLET_MNEMONIC: ${{ secrets.CYPRESS_ETH_WALLET_MNEMONIC }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false
+
+      ######
+      ## Upload logs
+      ######
+
+      - name: Logs
+        run: vegacapsule network logs > vega-capsule-logs.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: ./vega-capsule-logs.txt

--- a/.github/workflows/cypress-trading-e2e.yml
+++ b/.github/workflows/cypress-trading-e2e.yml
@@ -1,0 +1,76 @@
+name: Cypress - trading
+
+on:
+  workflow_call:
+    inputs:
+      vega-version:
+        required: true
+        type: string
+      gobin:
+        required: false
+        type: string
+        default: /home/runner/go/bin
+      tags:
+        required: false
+        type: string
+
+jobs:
+  trading-e2e:
+    timeout-minutes: 30
+    runs-on: self-hosted
+    steps:
+      # Add GOBIN to PATH
+      - name: Add GOBIN to PATH
+        run: echo ${{ inputs.gobin }} >> $GITHUB_PATH
+
+      # Checkout front ends
+      - name: Checkout frontend mono repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: './frontend-monorepo'
+
+      # Restore node_modules from cache if possible
+      - name: Restore node_modules from cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            frontend-monorepo/node_modules
+            /home/runner/.cache/Cypress
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+
+      #######
+      ## Build and run Vegacapsule network
+      #######
+
+      - name: Install Vega binaries
+        uses: ./frontend-monorepo/.github/actions/install-vega-binaries
+        with:
+          all: false
+          version: ${{ inputs.vega-version }}
+          gobin: ${{ inputs.gobin }}
+
+      ######
+      ## Setup a Vega wallet for our user
+      ######
+
+      - name: Set up Vegawallet
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+        with:
+          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
+          passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          capsule: false
+
+      # To make sure that all Cypress binaries are installed properly
+      - name: Install cypress bins
+        run: yarn cypress install
+        working-directory: frontend-monorepo
+
+      - name: Run Cypress tests
+        run: npx nx run trading-e2e:e2e --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --browser chrome ${{ inputs.tags }}
+        working-directory: frontend-monorepo
+        env:
+          CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
+          CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
+          CYPRESS_ETH_WALLET_MNEMONIC: ${{ secrets.CYPRESS_ETH_WALLET_MNEMONIC }}
+          CYPRESS_TEARDOWN_NETWORK_AFTER_FLOWS: false


### PR DESCRIPTION
# Related issues 🔗

#1897 

# Description ℹ️

Create separate workflows to run tests for each app.

# Technical 👨‍🔧

They are triggered on `workflow_call`. They need to merged before actually using them, to make them available for tests on other branches.
