### PR TITLE
Fix/1847: Withdrawal form displaying lack of assets when connected wi…

### DIFF
--- a/libs/withdraws/src/lib/withdraw-form-container.tsx
+++ b/libs/withdraws/src/lib/withdraw-form-container.tsx
@@ -5,6 +5,7 @@ import { accountsOnlyDataProvider } from '@vegaprotocol/accounts';
 import type { WithdrawalArgs } from './use-create-withdraw';
 import { WithdrawManager } from './withdraw-manager';
 import { useMemo } from 'react';
+import { t } from '@vegaprotocol/react-helpers';
 
 interface WithdrawFormContainerProps {
   partyId?: string;
@@ -37,6 +38,7 @@ export const WithdrawFormContainer = ({
       loading={loading && assetsLoading}
       error={error && assetsError}
       data={data}
+      noDataMessage={t('You have no assets to withdraw')}
     >
       {assets && data && (
         <WithdrawManager


### PR DESCRIPTION
…th an uninitialised party id

# Related issues 🔗

Closes #1847

# Description ℹ️

The withdrawal form, if opened with an uninitialised party id, would show the default 'no data' message. This has been changed to display "you have no assets to withdraw". Note, for initialised party id's with no assets to withdraw, the full withdrawal from will still be shown, but this could change as part of upcoming ticket #1957

# Demo 📺
![Screenshot 2022-11-04 at 14 05 27](https://user-images.githubusercontent.com/2410498/199993104-a85670c1-9fa5-4caa-91be-476d53178872.png)

