### PR TITLE
chore: update add issues to project action

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,25 +1,28 @@
 ---
-name: Auto Assign Issue to New Project
 
-'on':
+name: "Add Issues To Project Board"
+
+"on":
   issues:
-    types: [opened]
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
 
 jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add Issue to New Front End Project Board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add issue to project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER

--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,8 +1,7 @@
 ---
+name: 'Add Issues To Project Board'
 
-name: "Add Issues To Project Board"
-
-"on":
+'on':
   issues:
     types:
       - opened
@@ -16,7 +15,7 @@ jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: "Add issue to project board"
+      - name: 'Add issue to project board'
         run: |
           gh api graphql -f query='
             mutation($user:String!, $project:ID!, $issue:ID!) {


### PR DESCRIPTION
chore: update add issues to project action

The GitHub projects API has been replaced with ProjectsV2. This PR corrects the add issues to project action.

There should be no impact on any FE functionality - this affects Penny and I in terms of tracking new issues