### PR TITLE
feat(1355): lp dashboard adding equity like share

### DIFF
--- a/apps/liquidity-provision-dashboard/src/app/components/detail/detail.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/detail/detail.tsx
@@ -11,7 +11,7 @@ import {
   getFeeLevels,
   sumLiquidityCommitted,
   marketLiquidityDataProvider,
-  liquidityProvisionsDataProvider,
+  lpAggregatedDataProvider,
 } from '@vegaprotocol/liquidity';
 import type { MarketLpQuery } from '@vegaprotocol/liquidity';
 
@@ -34,10 +34,10 @@ const formatMarket = (data: MarketLpQuery) => {
 };
 
 export const lpDataProvider = makeDerivedDataProvider(
-  [marketLiquidityDataProvider, liquidityProvisionsDataProvider],
-  ([market, providers]) => ({
+  [marketLiquidityDataProvider, lpAggregatedDataProvider],
+  ([market, lpAggregatedData]) => ({
     market: { ...formatMarket(market) },
-    liquidityProviders: providers || [],
+    liquidityProviders: lpAggregatedData || [],
   })
 );
 

--- a/apps/liquidity-provision-dashboard/src/app/components/detail/providers/providers.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/detail/providers/providers.tsx
@@ -4,7 +4,10 @@ import { AgGridColumn } from 'ag-grid-react';
 import type { GetRowIdParams } from 'ag-grid-community';
 import { t } from '@vegaprotocol/react-helpers';
 
-import type { LiquidityProvisionFieldsFragment } from '@vegaprotocol/liquidity';
+import type {
+  LiquidityProviderFeeShareFieldsFragment,
+  LiquidityProvisionFieldsFragment,
+} from '@vegaprotocol/liquidity';
 import { formatWithAsset } from '@vegaprotocol/liquidity';
 
 import { Grid } from '../../grid';
@@ -24,7 +27,8 @@ export const LPProvidersGrid = ({
   liquidityProviders,
   settlementAsset,
 }: {
-  liquidityProviders: LiquidityProvisionFieldsFragment[];
+  liquidityProviders: LiquidityProvisionFieldsFragment &
+    LiquidityProviderFeeShareFieldsFragment[];
   settlementAsset: {
     decimals?: number;
     symbol?: string;
@@ -55,7 +59,14 @@ export const LPProvidersGrid = ({
         valueFormatter={formatToHours}
         field="createdAt"
       />
-      <AgGridColumn headerName={t('Galps')} field="Galps" />
+      <AgGridColumn
+        headerName={t('Equity-like share')}
+        field="equityLikeShare"
+        valueFormatter={({ value }: { value?: string | null }) => {
+          const valueOr0 = value ? value : '';
+          return `${parseInt(valueOr0) * 100}%`;
+        }}
+      />
       <AgGridColumn
         headerName={t('committed bond/stake')}
         field="commitmentAmount"


### PR DESCRIPTION
# Related issues 🔗

Part of #1355(https://github.com/vegaprotocol/frontend-monorepo/issues/1355)

# Description ℹ️

Replaces the (empty) `GALPS` field with `Equity-like share`, and provides values for this from the aggregated liquidity provider data.

# Demo 📺
Screenshot of new column with value:
<img width="1423" alt="Screenshot 2022-11-10 at 13 55 38" src="https://user-images.githubusercontent.com/6756742/201110371-3850a139-a7ef-4959-be69-db190b5e52d3.png">

# Technical 👨‍🔧

Refactors `apps/liquidity-provision-dashboard/src/app/components/detail/detail.tsx` to use `lpAggregatedDataProvider` rather than `liquidityProvisionsDataProvider` which includes both the currently required values plus the necessary data to introduce Equity-like share.
