### PR TITLE
fix: use estimate order query with simple order size, no open volume check

### DIFF
--- a/apps/console-lite-e2e/.env
+++ b/apps/console-lite-e2e/.env
@@ -1,7 +1,7 @@
 # App configuration variables
-NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/testnet-network.json
-NX_VEGA_URL=https://api.n06.testnet.vega.xyz/graphql
-NX_VEGA_ENV=TESTNET
+NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/stagnet3-network.json
+NX_VEGA_URL=https://api.n01.stagnet3.vega.xyz/graphql
+NX_VEGA_ENV=STAGNET3
 NX_ETHEREUM_PROVIDER_URL=https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_VEGA_EXPLORER_URL=https://stagnet3.explorer.vega.xyz

--- a/libs/deal-ticket/src/hooks/use-order-margin.spec.ts
+++ b/libs/deal-ticket/src/hooks/use-order-margin.spec.ts
@@ -77,12 +77,8 @@ describe('useOrderMargin', () => {
       })
     );
     expect(result.current?.margin).toEqual('100000');
-
-    const calledSize = new BigNumber(mockMarketPositions?.openVolume || 0)
-      .plus(order.size)
-      .toString();
     expect((useQuery as jest.Mock).mock.calls[1][1].variables.size).toEqual(
-      calledSize
+      order.size
     );
   });
 

--- a/libs/deal-ticket/src/hooks/use-order-margin.ts
+++ b/libs/deal-ticket/src/hooks/use-order-margin.ts
@@ -45,15 +45,7 @@ export const useOrderMargin = ({
       price: order.price
         ? removeDecimal(order.price, market.decimalPlaces)
         : markPriceData?.market?.data?.markPrice || '',
-      size: removeDecimal(
-        BigNumber.maximum(
-          0,
-          new BigNumber(marketPositions?.openVolume || 0)
-            [order.side === Schema.Side.SIDE_BUY ? 'plus' : 'minus'](order.size)
-            .absoluteValue()
-        ).toString(),
-        market.positionDecimalPlaces
-      ),
+      size: removeDecimal(order.size, market.positionDecimalPlaces),
       side:
         order.side === Schema.Side.SIDE_BUY
           ? Schema.Side.SIDE_BUY


### PR DESCRIPTION

# Related issues 🔗

Closes #2002

# Description ℹ️

Estimate order query will simply need the order size and price from the user input.
