### PR TITLE
test: use vegawallet dummy in e2e test workflows

### DIFF
--- a/.github/actions/install-vega-binaries/action.yml
+++ b/.github/actions/install-vega-binaries/action.yml
@@ -11,21 +11,18 @@ runs:
   using: 'composite'
   steps:
     - name: Install Vega binaries
-      if: ${{ inputs.all }}
       shell: bash
       run: |
         wget 'https://github.com/vegaprotocol/vega/releases/download/${{ inputs.version }}/vega-linux-amd64.zip' -q
         unzip vega-linux-amd64.zip -d ${{ inputs.gobin }}
 
-    - name: Install date-node binaries
-      if: ${{ inputs.all  }}
-      shell: bash
-      run: |
-        wget 'https://github.com/vegaprotocol/vega/releases/download/${{ inputs.version }}/data-node-linux-amd64.zip' -q
-        unzip data-node-linux-amd64.zip -d ${{ inputs.gobin }}
+    - name: Checkout vegawallet-dummy
+      uses: actions/checkout@v3
+      with:
+        repository: 'https://github.com/vegaprotocol/vegawallet-dummy'
+        path: './dummy'
 
-    - name: Install Vega wallet binaries
+    - name: Install vegawallet-dummy binaries
       shell: bash
-      run: |
-        wget 'https://github.com/vegaprotocol/vega/releases/download/${{ inputs.version }}/vegawallet-linux-amd64.zip' -q
-        unzip vegawallet-linux-amd64.zip -d ${{ inputs.gobin }}
+      run: go install
+      working-directory: ./dummy

--- a/.github/actions/install-vega-binaries/action.yml
+++ b/.github/actions/install-vega-binaries/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Checkout vegawallet-dummy
       uses: actions/checkout@v3
       with:
-        repository: 'https://github.com/vegaprotocol/vegawallet-dummy'
+        repository: 'vegaprotocol/vegawallet-dummy'
         path: './dummy'
 
     - name: Install vegawallet-dummy binaries

--- a/.github/actions/setup-vegawallet/action.yml
+++ b/.github/actions/setup-vegawallet/action.yml
@@ -19,27 +19,29 @@ runs:
 
     - name: Initialize wallet
       shell: bash
-      run: vegawallet init -f --home ~/.vegacapsule/testnet/wallet
+      run: vega wallet init -f --home ~/.vegacapsule/testnet/wallet
 
     - name: Import wallet
       shell: bash
-      run: vegawallet import -w UI_Trading_Test --recovery-phrase-file ./recovery -p ./passphrase --home ~/.vegacapsule/testnet/wallet
+      if: ${{ inputs.capsule=='false' }}
+      run: vega wallet import -w UI_Trading_Test --recovery-phrase-file ./recovery -p ./passphrase --home ~/.vegacapsule/testnet/wallet
 
     - name: Create public key 2
       shell: bash
-      run: vegawallet key generate -w UI_Trading_Test -p ./passphrase --home ~/.vegacapsule/testnet/wallet
+      if: ${{ inputs.capsule=='false' }}
+      run: vega wallet key generate -w UI_Trading_Test -p ./passphrase --home ~/.vegacapsule/testnet/wallet
 
     - name: Import network
       shell: bash
       if: ${{ inputs.capsule=='false' }}
-      run: vegawallet network import --from-url="https://raw.githubusercontent.com/vegaprotocol/networks-internal/master/stagnet3/stagnet3.toml" --force --home ~/.vegacapsule/testnet/wallet
+      run: vega wallet network import --from-url="https://raw.githubusercontent.com/vegaprotocol/networks-internal/master/stagnet3/stagnet3.toml" --force --home ~/.vegacapsule/testnet/wallet
 
     - name: Start service using fairground network
       shell: bash
       if: ${{ inputs.capsule=='false' }}
-      run: vegawallet service run --network stagnet3 --automatic-consent --no-version-check --home ~/.vegacapsule/testnet/wallet &
+      run: vegawallet-dummy service run --network stagnet3 --wallet UI_Trading_Test --passphrase-file ./passphrase --automatic-consent --no-version-check --home ~/.vegacapsule/testnet/wallet &
 
     - name: Start service using capsule network
       shell: bash
       if: ${{ inputs.capsule=='true' }}
-      run: vegawallet service run --network DV --automatic-consent  --home ~/.vegacapsule/testnet/wallet &
+      run: vegawallet-dummy service run --network DV --wallet capsule_wallet --passphrase-file ./passphrase --automatic-consent  --home ~/.vegacapsule/testnet/wallet &

--- a/.github/actions/setup-vegawallet/action.yml
+++ b/.github/actions/setup-vegawallet/action.yml
@@ -39,9 +39,9 @@ runs:
     - name: Start service using fairground network
       shell: bash
       if: ${{ inputs.capsule=='false' }}
-      run: vegawallet-dummy service run --network stagnet3 --wallet UI_Trading_Test --passphrase-file ./passphrase --automatic-consent --no-version-check --home ~/.vegacapsule/testnet/wallet &
+      run: vegawallet-dummy service run --network stagnet3 --wallet UI_Trading_Test --passphrase-file ./passphrase --home ~/.vegacapsule/testnet/wallet &
 
     - name: Start service using capsule network
       shell: bash
       if: ${{ inputs.capsule=='true' }}
-      run: vegawallet-dummy service run --network DV --wallet capsule_wallet --passphrase-file ./passphrase --automatic-consent  --home ~/.vegacapsule/testnet/wallet &
+      run: vegawallet-dummy service run --network DV --wallet capsule_wallet --passphrase-file ./passphrase --home ~/.vegacapsule/testnet/wallet &

--- a/.github/workflows/cypress-console-lite-e2e.yml
+++ b/.github/workflows/cypress-console-lite-e2e.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Install Vega binaries
         uses: ./frontend-monorepo/.github/actions/install-vega-binaries
         with:
-          all: false
           version: ${{ inputs.vega-version }}
           gobin: ${{ inputs.gobin }}
 

--- a/.github/workflows/cypress-explorer-e2e.yml
+++ b/.github/workflows/cypress-explorer-e2e.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Install Vega binaries
         uses: ./frontend-monorepo/.github/actions/install-vega-binaries
         with:
-          all: true
           version: ${{ inputs.vega-version }}
           gobin: ${{ inputs.gobin }}
 

--- a/.github/workflows/cypress-token-e2e.yml
+++ b/.github/workflows/cypress-token-e2e.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Install Vega binaries
         uses: ./frontend-monorepo/.github/actions/install-vega-binaries
         with:
-          all: true
           version: ${{ inputs.vega-version }}
           gobin: ${{ inputs.gobin }}
 

--- a/.github/workflows/cypress-trading-e2e.yml
+++ b/.github/workflows/cypress-trading-e2e.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Install Vega binaries
         uses: ./frontend-monorepo/.github/actions/install-vega-binaries
         with:
-          all: false
           version: ${{ inputs.vega-version }}
           gobin: ${{ inputs.gobin }}
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,14 @@ Run `yarn nx run <my-app>-e2e:e2e` to execute the e2e tests with [cypress](https
 
 Run `nx test my-app` to execute the unit tests with [Jest](https://jestjs.io), or `nx affected:test` to execute just unit tests affected by a change. You can also use `--watch` with these test to run jest in watch mode, see [Jest executor](https://nx.dev/packages/jest/executors/jest) for all CLI flags.
 
-#### Trading app E2E tests
+### Using wallet
 
 To run tests locally using your own wallets you can add the following environment variables to `cypress.json`
 
 1. Change `TRADING_TEST_VEGA_WALLET_NAME` to your Vega wallet name
 2. Add `TRADING_TEST_VEGA_WALLET_PASSPHRASE` as your wallet passphrase
 3. Add `ETH_WALLET_MNEMONIC` as your Ethereum wallet mnemonic
+4. Use [vegawallet-dummy](https://github.com/vegaprotocol/vegawallet-dummy) to avoid being prompted in CLI during test execution.
 
 ### Formatting
 


### PR DESCRIPTION
# Related issues 🔗

Closes #1892 

# Description ℹ️

This is a prerequisite for using vegawallet v2 in our e2e tests. In normal usage condition vegawallet v2 requires interaction with CLI when making wallet-related actions in dApps. Vegawallet-dummy sorts that out, so e2e tests can be run smoothly. More information - https://github.com/vegaprotocol/vegawallet-dummy
