### PR TITLE
fix(#2063): console liquidity tab keeps adding duplicate rows

### DIFF
--- a/apps/trading/client-pages/liquidity/liquidity.tsx
+++ b/apps/trading/client-pages/liquidity/liquidity.tsx
@@ -6,7 +6,7 @@ import {
 } from '@vegaprotocol/liquidity';
 import { tooltipMapping } from '@vegaprotocol/market-info';
 import {
-  addDecimalsFormatNumber,
+  addDecimalsNormalizeNumber,
   NetworkParams,
   t,
   useDataProvider,
@@ -151,7 +151,7 @@ export const Liquidity = () => {
           >
             <div>
               {targetStake
-                ? `${addDecimalsFormatNumber(
+                ? `${addDecimalsNormalizeNumber(
                     targetStake,
                     assetDecimalPlaces ?? 0
                   )} ${symbol}`
@@ -164,7 +164,7 @@ export const Liquidity = () => {
           >
             <div>
               {suppliedStake
-                ? `${addDecimalsFormatNumber(
+                ? `${addDecimalsNormalizeNumber(
                     suppliedStake,
                     assetDecimalPlaces ?? 0
                   )} ${symbol}`

--- a/libs/deal-ticket/src/components/trading-mode-tooltip/compile-grid-data.tsx
+++ b/libs/deal-ticket/src/components/trading-mode-tooltip/compile-grid-data.tsx
@@ -1,7 +1,7 @@
 import {
   t,
   getDateTimeFormat,
-  addDecimalsFormatNumber,
+  addDecimalsNormalizeNumber,
 } from '@vegaprotocol/react-helpers';
 import { MarketTradingMode, AuctionTrigger } from '@vegaprotocol/types';
 import { Link as UILink } from '@vegaprotocol/ui-toolkit';
@@ -20,7 +20,7 @@ export const compileGridData = (
     market.data?.trigger === AuctionTrigger.AUCTION_TRIGGER_LIQUIDITY;
 
   const formatStake = (value: string) => {
-    const formattedValue = addDecimalsFormatNumber(
+    const formattedValue = addDecimalsNormalizeNumber(
       value,
       market.tradableInstrument.instrument.product.settlementAsset.decimals
     );
@@ -76,7 +76,7 @@ export const compileGridData = (
       value:
         market.data.indicativePrice && market.data.indicativePrice !== '0'
           ? `~
-            ${addDecimalsFormatNumber(
+            ${addDecimalsNormalizeNumber(
               market.data.indicativePrice,
               market.decimalPlaces
             )}`
@@ -90,7 +90,7 @@ export const compileGridData = (
       value:
         market.data.indicativeVolume && market.data.indicativeVolume !== '0'
           ? '~' +
-            addDecimalsFormatNumber(
+            addDecimalsNormalizeNumber(
               market.data.indicativeVolume,
               market.positionDecimalPlaces
             )

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -78,7 +78,7 @@ export const liquidityProvisionsDataProvider = makeDataProvider<
   },
 });
 
-function isLpProvision(
+function isLpFragment(
   entry:
     | LiquidityProvisionFieldsFragment
     | IterableElement<
@@ -99,7 +99,7 @@ export const getId = (
         LiquidityProvisionsUpdateSubscription['liquidityProvisions']
       >
 ) =>
-  isLpProvision(entry)
+  isLpFragment(entry)
     ? `${entry.party.id}${entry.status}${entry.createdAt}`
     : `${entry.partyID}${entry.status}${entry.createdAt}`;
 

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -85,11 +85,7 @@ function isLpFragment(
         LiquidityProvisionsUpdateSubscription['liquidityProvisions']
       >
 ): entry is LiquidityProvisionFieldsFragment {
-  return (
-    (entry as LiquidityProvisionFieldsFragment).__typename ===
-      'LiquidityProvision' ||
-    Boolean((entry as LiquidityProvisionFieldsFragment).party?.id)
-  );
+  return entry.__typename === 'LiquidityProvision';
 }
 
 export const getId = (

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import {
-  addDecimalsFormatNumber,
+  addDecimalsNormalizeNumber,
   formatNumberPercentage,
   getDateTimeFormat,
   t,
@@ -20,7 +20,7 @@ import { getId } from './liquidity-data-provider';
 
 const percentageFormatter = ({ value }: ValueFormatterParams) => {
   if (!value) return '-';
-  return formatNumberPercentage(new BigNumber(value).times(100), 4) || '-';
+  return formatNumberPercentage(new BigNumber(value).times(100), 2) || '-';
 };
 
 const dateValueFormatter = ({ value }: { value?: string | null }) => {
@@ -41,14 +41,18 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
   ({ data, symbol = '', assetDecimalPlaces, stakeToCcySiskas }, ref) => {
     const assetDecimalsFormatter = ({ value }: ValueFormatterParams) => {
       if (!value) return '-';
-      return `${addDecimalsFormatNumber(value, assetDecimalPlaces ?? 0, 5)}`;
+      return `${addDecimalsNormalizeNumber(value, assetDecimalPlaces ?? 0, 5)}`;
     };
     const stakeToCcySiskasFormatter = ({ value }: ValueFormatterParams) => {
       if (!value) return '-';
       const newValue = new BigNumber(value)
         .times(stakeToCcySiskas ?? 1)
         .toString();
-      return `${addDecimalsFormatNumber(newValue, assetDecimalPlaces ?? 0, 5)}`;
+      return `${addDecimalsNormalizeNumber(
+        newValue,
+        assetDecimalPlaces ?? 0,
+        5
+      )}`;
     };
 
     if (!data) return null;


### PR DESCRIPTION
# Related issues 🔗

Closes #2063 

# Description ℹ️

Liquidity provision entries are unique for any partyId and marketId only if the status is not rejected. 

# Demo 📺

<img width="906" alt="image" src="https://user-images.githubusercontent.com/16125548/201735409-c3e45d45-23f2-43ca-8f81-35eda76bcf22.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
