### PR TITLE
feat(#580): add link to update market proposal

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -182,8 +182,9 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       .should('have.text', 'View governance proposal')
       .and('have.attr', 'href')
       .and('contain', '/governance/market-0');
-    cy.getByTestId('propose-a-change-to-market-link')
-      .should('have.text', 'Propose a change to this market ')
+    cy.getByTestId(externalLink)
+      .eq(1)
+      .should('have.text', 'Propose a change to this market')
       .and('have.attr', 'href')
       .and('contain', '/governance/propose/update-market');
   });

--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -182,6 +182,10 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       .should('have.text', 'View governance proposal')
       .and('have.attr', 'href')
       .and('contain', '/governance/market-0');
+    cy.getByTestId('propose-a-change-to-market-link')
+      .should('have.text', 'Propose a change to this market ')
+      .and('have.attr', 'href')
+      .and('contain', '/governance/propose/update-market');
   });
 
   afterEach('close toggle', () => {

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -373,6 +373,7 @@ export const Info = ({ market, onSelect }: InfoProps) => {
             {t('View governance proposal')}
           </ExternalLink>
           <ExternalLink
+            data-testid="propose-a-change-to-market-link"
             className="mt-2"
             href={generatePath(TokenLinks.UPDATE_PROPOSAL_PAGE, {
               tokenUrl: VEGA_TOKEN_URL,

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -28,11 +28,9 @@ import { generatePath, Link } from 'react-router-dom';
 import { getMarketExpiryDateFormatted } from '../market-expires';
 import { MarketInfoTable } from './info-key-value-table';
 import { marketInfoDataProvider } from './market-info-data-provider';
+import { TokenLinks } from '@vegaprotocol/react-helpers';
 
 import type { MarketInfoQuery } from './__generated___/MarketInfo';
-const Links = {
-  PROPOSAL_PAGE: ':tokenUrl/governance/:proposalId',
-};
 
 export interface InfoProps {
   market: MarketInfoQuery['market'];
@@ -359,19 +357,35 @@ export const Info = ({ market, onSelect }: InfoProps) => {
     {
       title: t('Proposal'),
       content: (
-        <ExternalLink
-          href={generatePath(Links.PROPOSAL_PAGE, {
-            tokenUrl: VEGA_TOKEN_URL,
-            proposalId: market.proposal?.id || '',
-          })}
-          title={
-            market.proposal?.rationale.title ||
-            market.proposal?.rationale.description ||
-            ''
-          }
-        >
-          {t('View governance proposal')}
-        </ExternalLink>
+        <div className="">
+          <ExternalLink
+            className="mb-2"
+            href={generatePath(TokenLinks.PROPOSAL_PAGE, {
+              tokenUrl: VEGA_TOKEN_URL,
+              proposalId: market.proposal?.id || '',
+            })}
+            title={
+              market.proposal?.rationale.title ||
+              market.proposal?.rationale.description ||
+              ''
+            }
+          >
+            {t('View governance proposal')}
+          </ExternalLink>
+          <ExternalLink
+            className="mt-2"
+            href={generatePath(TokenLinks.UPDATE_PROPOSAL_PAGE, {
+              tokenUrl: VEGA_TOKEN_URL,
+            })}
+            title={
+              market.proposal?.rationale.title ||
+              market.proposal?.rationale.description ||
+              ''
+            }
+          >
+            {t('Propose a change to this market')}
+          </ExternalLink>
+        </div>
       ),
     },
   ];

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -373,7 +373,6 @@ export const Info = ({ market, onSelect }: InfoProps) => {
             {t('View governance proposal')}
           </ExternalLink>
           <ExternalLink
-            data-testid="propose-a-change-to-market-link"
             className="mt-2"
             href={generatePath(TokenLinks.UPDATE_PROPOSAL_PAGE, {
               tokenUrl: VEGA_TOKEN_URL,

--- a/libs/react-helpers/src/lib/links/links.ts
+++ b/libs/react-helpers/src/lib/links/links.ts
@@ -23,3 +23,8 @@ export const ExternalLinks = {
   VEGA_WALLET_URL: 'https://vega.xyz/wallet',
   VEGA_WALLET_HOSTED_URL: 'https://vega-hosted-wallet.on.fleek.co/',
 };
+
+export const TokenLinks = {
+  PROPOSAL_PAGE: ':tokenUrl/governance/:proposalId',
+  UPDATE_PROPOSAL_PAGE: ':tokenUrl/governance/propose/update-market',
+};


### PR DESCRIPTION
# Related issues 🔗

Closes #580

# Description ℹ️

 Add link to update market proposal

# Demo 📺

<img width="303" alt="image" src="https://user-images.githubusercontent.com/16125548/201902402-d8c02872-4143-408a-ad1a-332aafd8d343.png">


<img width="1515" alt="Screenshot 2022-11-15 at 05 50 16" src="https://user-images.githubusercontent.com/16125548/201902326-f6b8f2ad-e573-4f72-9541-e9756fe8ebb4.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
