### PR TITLE
chore: add vega_docs_url to all trading envs

### DIFF
--- a/apps/trading-e2e/.env
+++ b/apps/trading-e2e/.env
@@ -9,5 +9,6 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_URL=https://api.n01.stagnet3.vega.xyz/graphql
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
 CYPRESS_VEGA_URL=https://api.n01.stagnet3.vega.xyz/graphql
 CYPRESS_EXPLORER_URL=https://staging3.explorer.vega.xyz

--- a/apps/trading-e2e/src/integration/market-summary.cy.ts
+++ b/apps/trading-e2e/src/integration/market-summary.cy.ts
@@ -100,7 +100,7 @@ describe('Market trading page', () => {
     });
   });
 
-  describe('Market tooltips', { tags: '@regression' }, () => {
+  describe('Market tooltips', { tags: '@smoke' }, () => {
     it('should see expiry tooltip', () => {
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketExpiry).within(() => {

--- a/apps/trading/.env
+++ b/apps/trading/.env
@@ -7,3 +7,4 @@ NX_VEGA_EXPLORER_URL=https://staging3.explorer.vega.xyz
 NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet

--- a/apps/trading/.env.devnet
+++ b/apps/trading/.env.devnet
@@ -7,3 +7,4 @@ NX_VEGA_EXPLORER_URL=https://dev.explorer.vega.xyz
 NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet

--- a/apps/trading/.env.mainnet
+++ b/apps/trading/.env.mainnet
@@ -6,3 +6,4 @@ NX_VEGA_EXPLORER_URL=https://explorer.vega.xyz
 NX_VEGA_NETWORKS={\"MAINNET\":\"https://alpha.console.vega.xyz\",\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://token.vega.xyz
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet

--- a/apps/trading/.env.stagnet1
+++ b/apps/trading/.env.stagnet1
@@ -7,3 +7,4 @@ NX_VEGA_EXPLORER_URL=https://stagnet1.explorer.vega.xyz
 NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://stagnet1.token.vega.xyz
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet

--- a/apps/trading/.env.stagnet3
+++ b/apps/trading/.env.stagnet3
@@ -7,3 +7,4 @@ NX_VEGA_EXPLORER_URL=https://staging3.explorer.vega.xyz
 NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet

--- a/apps/trading/.env.testnet
+++ b/apps/trading/.env.testnet
@@ -7,3 +7,4 @@ NX_VEGA_EXPLORER_URL=https://explorer.fairground.wtf
 NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://stagnet1.console.vega.xyz\",\"STAGNET3\":\"https://stagnet3.console.vega.xyz\"}
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet


### PR DESCRIPTION
`VEGA_DOCS_URL` was missing in `trading` `.env`s. 