### PR TITLE
chore: separate running vegawallet service out of vegacapsule

### DIFF
--- a/.github/actions/setup-vegawallet-docker/action.yml
+++ b/.github/actions/setup-vegawallet-docker/action.yml
@@ -1,0 +1,25 @@
+inputs:
+  passphrase:
+    description: 'Wallet password'
+runs:
+  using: 'composite'
+  steps:
+    - name: Create passphrase
+      shell: bash
+      run: echo "${{ inputs.passphrase }}" > ./passphrase
+
+    - name: Initialize wallet
+      shell: bash
+      run: vega wallet init -f --home ~/.vegacapsule/testnet/wallet
+
+    - name: Import wallet
+      shell: bash
+      run: vega wallet import -w capsule_wallet --recovery-phrase-file ./frontend-monorepo/vegacapsule/recovery -p ./passphrase --home ~/.vegacapsule/testnet/wallet
+
+    - name: Import network
+      shell: bash
+      run: vega wallet network import --force --from-file ./frontend-monorepo/vegacapsule/wallet-config.toml --home ~/.vegacapsule/testnet/wallet
+
+    - name: Start service using capsule network
+      shell: bash
+      run: vegawallet-dummy service run --network DV --wallet capsule_wallet --passphrase-file ./passphrase --home ~/.vegacapsule/testnet/wallet &

--- a/.github/actions/setup-vegawallet/action.yml
+++ b/.github/actions/setup-vegawallet/action.yml
@@ -3,9 +3,6 @@ inputs:
     description: 'Recovery phrase'
   passphrase:
     description: 'Wallet password'
-  capsule:
-    description: 'Is Capsule network used'
-    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -23,25 +20,16 @@ runs:
 
     - name: Import wallet
       shell: bash
-      if: ${{ inputs.capsule=='false' }}
       run: vega wallet import -w UI_Trading_Test --recovery-phrase-file ./recovery -p ./passphrase --home ~/.vegacapsule/testnet/wallet
 
     - name: Create public key 2
       shell: bash
-      if: ${{ inputs.capsule=='false' }}
       run: vega wallet key generate -w UI_Trading_Test -p ./passphrase --home ~/.vegacapsule/testnet/wallet
 
     - name: Import network
       shell: bash
-      if: ${{ inputs.capsule=='false' }}
       run: vega wallet network import --from-url="https://raw.githubusercontent.com/vegaprotocol/networks-internal/master/stagnet3/stagnet3.toml" --force --home ~/.vegacapsule/testnet/wallet
 
-    - name: Start service using fairground network
+    - name: Start service using stagnet3 network
       shell: bash
-      if: ${{ inputs.capsule=='false' }}
       run: vegawallet-dummy service run --network stagnet3 --wallet UI_Trading_Test --passphrase-file ./passphrase --home ~/.vegacapsule/testnet/wallet &
-
-    - name: Start service using capsule network
-      shell: bash
-      if: ${{ inputs.capsule=='true' }}
-      run: vegawallet-dummy service run --network DV --wallet capsule_wallet --passphrase-file ./passphrase --home ~/.vegacapsule/testnet/wallet &

--- a/.github/workflows/cypress-console-lite-e2e.yml
+++ b/.github/workflows/cypress-console-lite-e2e.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
           passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
-          capsule: false
 
       # To make sure that all Cypress binaries are installed properly
       - name: Install cypress bins

--- a/.github/workflows/cypress-explorer-e2e.yml
+++ b/.github/workflows/cypress-explorer-e2e.yml
@@ -79,12 +79,10 @@ jobs:
       ## Setup a Vega wallet for our user
       ######
 
-      - name: Set up Vegawallet
-        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+      - name: Set up Vegawallet for docker
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet-docker
         with:
-          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
           passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
-          capsule: true
 
       ######
       ## Run some tests

--- a/.github/workflows/cypress-token-e2e.yml
+++ b/.github/workflows/cypress-token-e2e.yml
@@ -75,12 +75,10 @@ jobs:
       ## Setup a Vega wallet for our user
       ######
 
-      - name: Set up Vegawallet
-        uses: ./frontend-monorepo/.github/actions/setup-vegawallet
+      - name: Set up Vegawallet for docker
+        uses: ./frontend-monorepo/.github/actions/setup-vegawallet-docker
         with:
-          recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
           passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
-          capsule: true
 
       ######
       ## Run some tests

--- a/.github/workflows/cypress-trading-e2e.yml
+++ b/.github/workflows/cypress-trading-e2e.yml
@@ -71,7 +71,6 @@ jobs:
         with:
           recovery: ${{ secrets.TRADING_TEST_VEGA_WALLET_RECOVERY }}
           passphrase: ${{ secrets.CYPRESS_TRADING_TEST_VEGA_WALLET_PASSPHRASE }}
-          capsule: false
 
       # To make sure that all Cypress binaries are installed properly
       - name: Install cypress bins

--- a/vegacapsule/config.hcl
+++ b/vegacapsule/config.hcl
@@ -17,21 +17,6 @@ network "testnet" {
 EOT
   }
 
-  wallet "wallet-1" {
-    template = <<-EOT
-Name = "DV"
-Level = "info"
-TokenExpiry = "168h0m0s"
-Port = 1789
-Host = "0.0.0.0"
-
-[API]
-  [API.GRPC]
-    Hosts = [{{range $i, $v := .Validators}}{{if ne $i 0}},{{end}}"127.0.0.1:30{{$i}}2"{{end}}]
-    Retries = 5
-EOT
-  }
-
   pre_start {
     docker_service "ganache-1" {
       image = "vegaprotocol/ganache:latest"

--- a/vegacapsule/recovery
+++ b/vegacapsule/recovery
@@ -1,0 +1,1 @@
+ozone access unlock valid olympic save include omit supply green clown session

--- a/vegacapsule/wallet-config.toml
+++ b/vegacapsule/wallet-config.toml
@@ -1,0 +1,12 @@
+Name = "DV"
+LogLevel = "info"
+TokenExpiry = "168h0m0s"
+Port = 1789
+Host = "0.0.0.0"
+
+[API]
+  [API.GRPC]
+    Hosts = ["127.0.0.1:3002", "127.0.0.1:3012", "127.0.0.1:3022", "127.0.0.1:3032"]
+    Retries = 5
+  [API.REST]
+  [API.GraphQL]


### PR DESCRIPTION
# Description ℹ️

Vegawallet needs to be started separately, not in vegacapsule network bootstrap process, in order to use dummy wallet correctly.