### PR TITLE
chore: remove unnecessary import vega wallet

### DIFF
--- a/apps/explorer-e2e/.cypress-cucumber-preprocessorrc
+++ b/apps/explorer-e2e/.cypress-cucumber-preprocessorrc
@@ -1,3 +1,0 @@
-{
-    "stepDefinitions": "src/support/step_definitions"
-}

--- a/apps/explorer-e2e/src/integration/parties.cy.js
+++ b/apps/explorer-e2e/src/integration/parties.cy.js
@@ -16,7 +16,6 @@ const assetsInTest = Object.keys(assetData);
 
 context('Parties page', { tags: '@regression' }, function () {
   before('send-faucet assets to connected vega wallet', function () {
-    cy.vega_wallet_import();
     assetsInTest.forEach((asset) => {
       cy.vega_wallet_receive_fauceted_asset(
         assetData[asset].name,


### PR DESCRIPTION
# Related issues 🔗

Closes #2060 

# Description ℹ️

Import is being done before the tests starts in workflow. It's not needed to be run in the test itself anymore.