### PR TITLE
fix: allow error message data from wallet to be displayed

### DIFF
--- a/libs/wallet/src/vega-transaction-dialog/vega-transaction-dialog.tsx
+++ b/libs/wallet/src/vega-transaction-dialog/vega-transaction-dialog.tsx
@@ -108,9 +108,10 @@ export const VegaDialog = ({ transaction }: VegaDialogProps) => {
   if (transaction.status === VegaTxStatus.Error) {
     content = (
       <div data-testid={transaction.status}>
-        <p>{transaction.error && transaction.error.message}</p>
-        {transaction.error && transaction.error.data && (
-          <p>{transaction.error.data}</p>
+        {transaction.error && (
+          <p>
+            {transaction.error.message}: {transaction.error.data}
+          </p>
         )}
       </div>
     );


### PR DESCRIPTION
# Description ℹ️

Allows an error returned by the wallet to be render to the UI, rather than just showing 'Something went wrong'

# Demo 📺

![Screen Shot 2022-11-17 at 13 55 57](https://user-images.githubusercontent.com/6803987/202568492-9330c279-a0fb-456f-9a77-41699a6538fa.jpg)
