### PR TITLE
chore(#2151): rename market valuation entry and change tooltips on LP table

### DIFF
--- a/libs/liquidity/src/lib/liquidity-table.spec.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.spec.tsx
@@ -43,7 +43,7 @@ describe('LiquidityTable', () => {
       'Commitment ()',
       'Share',
       'Proposed fee',
-      'Average entry valuation',
+      'Market valuation at entry',
       'Obligation',
       'Supplied',
       'Status',

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -94,7 +94,7 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
           field="equityLikeShare"
           type="rightAligned"
           headerTooltip={t(
-            'The equity-like share of liquidity of the market, specific to each liquidity provider.'
+            'The equity-like share of liquidity of the market used to determine allocation of LP fees. Calculated based on share of total liquidity, with a premium added for length of commitment.'
           )}
           valueFormatter={percentageFormatter}
         />
@@ -108,11 +108,11 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
           valueFormatter={percentageFormatter}
         />
         <AgGridColumn
-          headerName={t('Average entry valuation')}
+          headerName={t('Market Valuation at Entry')}
           field="averageEntryValuation"
           type="rightAligned"
           headerTooltip={t(
-            'The average entry valuation of this liquidity provision for the market.'
+            'The valuation of the market at the time the liquidity commitment was made. Commitments made at a lower valuation earlier in the lifetime of the market would be expected to have a higher equity-like share if the market has grown. If a commitment is amended, value will reflect the average of the market valuations across the lifetime of the commitment.'
           )}
           minWidth={160}
           valueFormatter={assetDecimalsFormatter}
@@ -122,14 +122,14 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
           field="commitmentAmount"
           type="rightAligned"
           headerTooltip={t(
-            'The liquidity provider’s obligation to the market, calculated as the liquidity commitment amount multiplied by the value of the stake_to_ccy_siskas network parameter.'
+            `The liquidity provider's obligation to the market, calculated as the liquidity commitment amount multiplied by the value of the stake_to_ccy_siskas network parameter to convert into units of liquidity volume. The obligation can be met by a combination of LP orders and limit orders on the order book.`
           )}
           valueFormatter={stakeToCcySiskasFormatter}
         />
         <AgGridColumn
           headerName={t('Supplied')}
           headerTooltip={t(
-            'The amount of the settlement asset supplied for liquidity by this provider, calculated as the bond account balance multiplied by the value of the stake_to_ccy_siskas network parameter.'
+            `The amount of liquidity volume supplied by the LP order in order to meet the obligation. If the obligation is already met in full by other limit orders from the same Vega key the LP order is not required and this value will be zero. Also note if the target stake for the market is less than the obligation the full value of the obligation may not be required.`
           )}
           field="balance"
           type="rightAligned"

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -108,7 +108,7 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
           valueFormatter={percentageFormatter}
         />
         <AgGridColumn
-          headerName={t('Market Valuation at Entry')}
+          headerName={t('Market valuation at entry')}
           field="averageEntryValuation"
           type="rightAligned"
           headerTooltip={t(


### PR DESCRIPTION
# Related issues 🔗

Closes #2151 

# Description ℹ️

Update tooltips on LP table and rename market valuation entry.

# Demo 📺

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/16125548/202782825-8b54a3a9-8ae7-4acd-8ce8-2c9285d8ae22.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
