### PR TITLE
fix(explorer): use getnodes to avoid nesting

### DIFF
--- a/apps/explorer/src/app/routes/assets/__generated__/assets.ts
+++ b/apps/explorer/src/app/routes/assets/__generated__/assets.ts
@@ -3,41 +3,47 @@ import { Schema as Types } from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
+export type AssetsFieldsFragment = { __typename?: 'Asset', id: string, name: string, symbol: string, decimals: number, source: { __typename?: 'BuiltinAsset', maxFaucetAmountMint: string } | { __typename?: 'ERC20', contractAddress: string }, infrastructureFeeAccount?: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, market?: { __typename?: 'Market', id: string } | null } | null };
+
 export type ExplorerAssetsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
 export type ExplorerAssetsQuery = { __typename?: 'Query', assetsConnection?: { __typename?: 'AssetsConnection', edges?: Array<{ __typename?: 'AssetEdge', node: { __typename?: 'Asset', id: string, name: string, symbol: string, decimals: number, source: { __typename?: 'BuiltinAsset', maxFaucetAmountMint: string } | { __typename?: 'ERC20', contractAddress: string }, infrastructureFeeAccount?: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, market?: { __typename?: 'Market', id: string } | null } | null } } | null> | null } | null };
 
-
+export const AssetsFieldsFragmentDoc = gql`
+    fragment AssetsFields on Asset {
+  id
+  name
+  symbol
+  decimals
+  source {
+    ... on ERC20 {
+      contractAddress
+    }
+    ... on BuiltinAsset {
+      maxFaucetAmountMint
+    }
+  }
+  infrastructureFeeAccount {
+    type
+    balance
+    market {
+      id
+    }
+  }
+}
+    `;
 export const ExplorerAssetsDocument = gql`
     query ExplorerAssets {
   assetsConnection {
     edges {
       node {
-        id
-        name
-        symbol
-        decimals
-        source {
-          ... on ERC20 {
-            contractAddress
-          }
-          ... on BuiltinAsset {
-            maxFaucetAmountMint
-          }
-        }
-        infrastructureFeeAccount {
-          type
-          balance
-          market {
-            id
-          }
-        }
+        ...AssetsFields
       }
     }
   }
 }
-    `;
+    ${AssetsFieldsFragmentDoc}`;
 
 /**
  * __useExplorerAssetsQuery__

--- a/apps/explorer/src/app/routes/assets/assets.graphql
+++ b/apps/explorer/src/app/routes/assets/assets.graphql
@@ -1,26 +1,31 @@
+fragment AssetsFields on Asset {
+  id
+  name
+  symbol
+  decimals
+  source {
+    ... on ERC20 {
+      contractAddress
+    }
+    ... on BuiltinAsset {
+      maxFaucetAmountMint
+    }
+  }
+
+  infrastructureFeeAccount {
+    type
+    balance
+    market {
+      id
+    }
+  }
+}
+
 query ExplorerAssets {
   assetsConnection {
     edges {
       node {
-        id
-        name
-        symbol
-        decimals
-        source {
-          ... on ERC20 {
-            contractAddress
-          }
-          ... on BuiltinAsset {
-            maxFaucetAmountMint
-          }
-        }
-        infrastructureFeeAccount {
-          type
-          balance
-          market {
-            id
-          }
-        }
+        ...AssetsFields
       }
     }
   }

--- a/apps/explorer/src/app/routes/assets/index.tsx
+++ b/apps/explorer/src/app/routes/assets/index.tsx
@@ -1,16 +1,15 @@
-import { t } from '@vegaprotocol/react-helpers';
+import { getNodes, t } from '@vegaprotocol/react-helpers';
 import React from 'react';
 import { RouteTitle } from '../../components/route-title';
 import { SubHeading } from '../../components/sub-heading';
 import { SyntaxHighlighter } from '@vegaprotocol/ui-toolkit';
 import { useExplorerAssetsQuery } from './__generated__/assets';
+import type { AssetsFieldsFragment } from './__generated__/assets';
 
 const Assets = () => {
   const { data } = useExplorerAssetsQuery();
 
-  const assets = data?.assetsConnection?.edges?.map((n) => {
-    return n?.node;
-  });
+  const assets = getNodes<AssetsFieldsFragment>(data?.assetsConnection);
 
   if (!assets || assets.length === 0) {
     return <section></section>;


### PR DESCRIPTION
# Related issues 🔗

Closes #2076

# Description ℹ️

Use getNodes helper to avoid having to dig edges { node { out of v2 graphql query
