### PR TITLE
fix(#2200): handle NotFound GraphQL errors in async renderer

### DIFF
--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -64,7 +64,7 @@ export function createClient(base?: string, cacheConfig?: InMemoryCacheConfig) {
     : httpLink;
 
   const errorLink = onError(({ graphQLErrors, networkError }) => {
-    if (graphQLErrors && hasNotFoundGraphQLErrors(graphQLErrors)) {
+    if (graphQLErrors && !hasNotFoundGraphQLErrors(graphQLErrors)) {
       console.log(graphQLErrors);
     }
     if (networkError) {

--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -85,7 +85,7 @@ const isApolloGraphQLError = (
 };
 
 const hasNotFoundGraphQLErrors = (errors: GraphQLErrors) => {
-  return errors.some((e) => e.extensions?.type === NOT_FOUND);
+  return errors.some((e) => e.extensions && e.extensions['type'] === NOT_FOUND);
 };
 
 export const isNotFoundGraphQLError = (

--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -78,12 +78,14 @@ export function createClient(base?: string, cacheConfig?: InMemoryCacheConfig) {
 }
 
 export const isApolloGraphQLError = (
-  error: ApolloError | Error
+  error: ApolloError | Error | undefined
 ): error is ApolloError => {
-  return error && !!(error as ApolloError).graphQLErrors;
+  return !!error && !!(error as ApolloError).graphQLErrors;
 };
 
-export const isNotFoundGraphQLError = (error: Error | ApolloError) => {
+export const isNotFoundGraphQLError = (
+  error: Error | ApolloError | undefined
+) => {
   return (
     isApolloGraphQLError(error) &&
     error.graphQLErrors.some((e) => e.extensions?.type === NOT_FOUND)

--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -64,8 +64,12 @@ export function createClient(base?: string, cacheConfig?: InMemoryCacheConfig) {
     : httpLink;
 
   const errorLink = onError(({ graphQLErrors, networkError }) => {
-    if (graphQLErrors && !hasNotFoundGraphQLErrors(graphQLErrors)) {
-      console.log(graphQLErrors);
+    if (graphQLErrors) {
+      graphQLErrors.forEach((e) => {
+        if (e.extensions && e.extensions['type'] !== NOT_FOUND) {
+          console.log(e);
+        }
+      });
     }
     if (networkError) {
       console.log(networkError);

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-market-amount.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-market-amount.tsx
@@ -46,7 +46,7 @@ export const DealTicketMarketAmount = ({
       <div className="flex items-end gap-4 mb-2">
         <div className="flex-1 text-sm">Size</div>
         <div />
-        <div className="flex-1 text-sm text-right">
+        <div className="flex-2 text-sm text-right">
           {isMarketInAuction(market) && (
             <Tooltip
               description={t(

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -29,7 +29,12 @@ export const FillsManager = ({ partyId }: FillsManagerProps) => {
   };
 
   return (
-    <AsyncRenderer loading={loading} error={error} data={data}>
+    <AsyncRenderer
+      loading={loading}
+      error={error}
+      data={data}
+      noDataCondition={() => false}
+    >
       <FillsTable
         ref={gridRef}
         partyId={partyId}

--- a/libs/positions/src/lib/positions-manager.tsx
+++ b/libs/positions/src/lib/positions-manager.tsx
@@ -25,7 +25,13 @@ export const PositionsManager = ({ partyId }: PositionsManagerProps) => {
 
   return (
     <>
-      <AsyncRenderer loading={loading} error={error} data={data}>
+      <AsyncRenderer
+        loading={loading}
+        error={error}
+        data={data}
+        noDataMessage={t('No positions')}
+        noDataCondition={(data) => !(data && data.length)}
+      >
         <PositionsTable
           ref={gridRef}
           rowData={data}

--- a/libs/react-helpers/src/hooks/use-data-provider.ts
+++ b/libs/react-helpers/src/hooks/use-data-provider.ts
@@ -7,6 +7,7 @@ import type {
   Load,
   UpdateCallback,
 } from '../lib/generic-data-provider';
+import { isNotFoundGraphQLError } from '@vegaprotocol/apollo-client';
 
 export interface useDataProviderParams<
   Data,
@@ -136,7 +137,15 @@ export const useDataProvider = <
       return unsubscribe();
     };
   }, [client, initialized, dataProvider, callback, variables, skip, update]);
-  return { data, loading, error, flush, reload, load, totalCount };
+  return {
+    data,
+    loading,
+    error: isNotFoundGraphQLError(error) ? null : error,
+    flush,
+    reload,
+    load,
+    totalCount,
+  };
 };
 
 export const useThrottledDataProvider = <Data, Delta>(

--- a/libs/react-helpers/src/hooks/use-data-provider.ts
+++ b/libs/react-helpers/src/hooks/use-data-provider.ts
@@ -7,7 +7,6 @@ import type {
   Load,
   UpdateCallback,
 } from '../lib/generic-data-provider';
-import { isNotFoundGraphQLError } from '@vegaprotocol/apollo-client';
 
 export interface useDataProviderParams<
   Data,

--- a/libs/react-helpers/src/hooks/use-data-provider.ts
+++ b/libs/react-helpers/src/hooks/use-data-provider.ts
@@ -86,7 +86,7 @@ export const useDataProvider = <
         isInsert,
         isUpdate,
       } = args;
-      setError(error);
+      setError(isNotFoundGraphQLError(error) ? undefined : error);
       setLoading(loading);
       // if update or insert function returns true it means that component handles updates
       // component can use flush() which will call callback without delta and cause data state update
@@ -140,7 +140,7 @@ export const useDataProvider = <
   return {
     data,
     loading,
-    error: isNotFoundGraphQLError(error) ? null : error,
+    error,
     flush,
     reload,
     load,

--- a/libs/react-helpers/src/hooks/use-data-provider.ts
+++ b/libs/react-helpers/src/hooks/use-data-provider.ts
@@ -86,7 +86,7 @@ export const useDataProvider = <
         isInsert,
         isUpdate,
       } = args;
-      setError(isNotFoundGraphQLError(error) ? undefined : error);
+      setError(error);
       setLoading(loading);
       // if update or insert function returns true it means that component handles updates
       // component can use flush() which will call callback without delta and cause data state update

--- a/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
+++ b/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
@@ -1,6 +1,7 @@
 import { Splash } from '../splash';
 import type { ReactNode } from 'react';
 import { t } from '@vegaprotocol/react-helpers';
+import { isNotFoundGraphQLError } from '@vegaprotocol/apollo-client';
 
 interface AsyncRendererProps<T> {
   loading: boolean;
@@ -25,7 +26,7 @@ export function AsyncRenderer<T = object>({
   children,
   render,
 }: AsyncRendererProps<T>) {
-  if (error) {
+  if (error && !isNotFoundGraphQLError(error)) {
     return (
       <Splash>
         {errorMessage

--- a/libs/ui-toolkit/src/components/splash/splash.tsx
+++ b/libs/ui-toolkit/src/components/splash/splash.tsx
@@ -7,7 +7,7 @@ export interface SplashProps {
 
 export const Splash = ({ children }: SplashProps) => {
   const splashClasses = classNames(
-    'w-full h-full',
+    'w-full h-full text-xs text-center text-gray-200',
     'flex items-center justify-center'
   );
   return <div className={splashClasses}>{children}</div>;


### PR DESCRIPTION
# Related issues 🔗

Closes #2200 

# Description ℹ️ &  Technical 👨‍🔧

- [x] handle NotFound GraphQL errors in the async renderer
- [x] handle NotFound GraphQL errors in certain queries / data providers
- [x] add method in apollo-client to spot NotFound errors but not filter them

# Demo 📺

Handles this issue observed in empty stagnet3: 

<img width="959" alt="Screenshot 2022-11-22 at 10 02 00" src="https://user-images.githubusercontent.com/16125548/203577564-0c4948cb-214c-4c51-8e5e-fc949d69f585.png">

<img width="808" alt="Screenshot 2022-11-23 at 08 26 22" src="https://user-images.githubusercontent.com/16125548/203577679-7de5f24d-fa4e-441e-b26e-e5e429387c79.png">


