### PR TITLE
fix(explorer): avoid caching block list, cache block by id

### DIFF
--- a/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
@@ -26,7 +26,8 @@ export const TxDetailsWrapper = ({
   const {
     state: { data: blockData },
   } = useFetch<TendermintBlocksResponse>(
-    `${DATA_SOURCES.tendermintUrl}/block?height=${height}`
+    `${DATA_SOURCES.tendermintUrl}/block?height=${height}`,
+    { cache: 'force-cache' }
   );
 
   const child = useMemo(() => getTransactionComponent(txData), [txData]);

--- a/apps/explorer/src/app/routes/blocks/home/index.tsx
+++ b/apps/explorer/src/app/routes/blocks/home/index.tsx
@@ -44,7 +44,7 @@ const Blocks = () => {
     refetch,
   } = useFetch<TendermintBlockchainResponse>(
     `${DATA_SOURCES.tendermintUrl}/blockchain`,
-    undefined,
+    { cache: 'no-cache' },
     false
   );
 

--- a/apps/explorer/src/app/routes/blocks/id/block.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.tsx
@@ -23,7 +23,8 @@ const Block = () => {
   const {
     state: { data: blockData, loading, error },
   } = useFetch<TendermintBlocksResponse>(
-    `${DATA_SOURCES.tendermintUrl}/block?height=${block}`
+    `${DATA_SOURCES.tendermintUrl}/block?height=${block}`,
+    { cache: 'force-cache' }
   );
 
   return (


### PR DESCRIPTION
# Related issues 🔗

Closes #2236

# Description ℹ️

Forces no caching of list of blocks (which was preventing some envs from updating the block list page), and forces
caching of block by ID to avoid refetches.
