### PR TITLE
fix: text color of no data message, add connect buttons to trade grid

### DIFF
--- a/apps/trading/client-pages/market/trade-grid.tsx
+++ b/apps/trading/client-pages/market/trade-grid.tsx
@@ -37,6 +37,7 @@ import { MarketMarkPrice } from '../../components/market-mark-price';
 import { MarketTradingModeComponent } from '../../components/market-trading-mode';
 import { Last24hVolume } from '../../components/last-24h-volume';
 import { MarketProposalNotification } from '@vegaprotocol/governance';
+import { VegaWalletContainer } from '../../components/vega-wallet-container';
 
 const NO_MARKET = t('No market');
 
@@ -261,16 +262,24 @@ const MainGrid = ({
       <TradeGridChild>
         <Tabs>
           <Tab id="positions" name={t('Positions')}>
-            <TradingViews.Positions />
+            <VegaWalletContainer>
+              <TradingViews.Positions />
+            </VegaWalletContainer>
           </Tab>
           <Tab id="orders" name={t('Orders')}>
-            <TradingViews.Orders />
+            <VegaWalletContainer>
+              <TradingViews.Orders />
+            </VegaWalletContainer>
           </Tab>
           <Tab id="fills" name={t('Fills')}>
-            <TradingViews.Fills />
+            <VegaWalletContainer>
+              <TradingViews.Fills />
+            </VegaWalletContainer>
           </Tab>
           <Tab id="accounts" name={t('Collateral')}>
-            <TradingViews.Collateral />
+            <VegaWalletContainer>
+              <TradingViews.Collateral />
+            </VegaWalletContainer>
           </Tab>
         </Tabs>
       </TradeGridChild>

--- a/libs/ui-toolkit/src/components/splash/splash.tsx
+++ b/libs/ui-toolkit/src/components/splash/splash.tsx
@@ -7,7 +7,7 @@ export interface SplashProps {
 
 export const Splash = ({ children }: SplashProps) => {
   const splashClasses = classNames(
-    'w-full h-full text-xs text-center text-gray-200',
+    'w-full h-full text-xs text-center text-gray-800 dark:text-gray-200',
     'flex items-center justify-center'
   );
   return <div className={splashClasses}>{children}</div>;


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

- Fix color of no data message when in light theme
- Add connect button for vega wallet

# Demo 📺

Before:

![Screenshot 2022-11-28 at 12 32 02](https://user-images.githubusercontent.com/6803987/204376848-96179f95-f622-4b83-8774-5c039eff265a.jpg)

After:

![Screenshot 2022-11-28 at 12 42 31](https://user-images.githubusercontent.com/6803987/204376871-d6b5437f-3f92-4c1b-aae6-f5de00dfe489.jpg)