### PR TITLE
feat(#2239): add decimal places in key details in market info

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -55,6 +55,9 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       'Trading Mode',
       MarketTradingModeMapping.TRADING_MODE_CONTINUOUS
     );
+    validateMarketDataRow(3, 'Market Decimal Places', '5');
+    validateMarketDataRow(4, 'Position Decimal Places', '0');
+    validateMarketDataRow(5, 'Settlement Asset Decimal Places', '5');
   });
 
   it('instrument displayed', () => {

--- a/libs/market-info/src/components/market-info/info-market.tsx
+++ b/libs/market-info/src/components/market-info/info-market.tsx
@@ -197,6 +197,11 @@ export const Info = ({ market, onSelect }: InfoProps) => {
             tradingMode:
               keyDetails.tradingMode &&
               MarketTradingModeMapping[keyDetails.tradingMode],
+            marketDecimalPlaces: market.decimalPlaces,
+            positionDecimalPlaces: market.positionDecimalPlaces,
+            settlementAssetDecimalPlaces:
+              market.tradableInstrument.instrument.product.settlementAsset
+                .decimals,
           }}
         />
       ),

--- a/libs/market-info/src/components/market-info/tooltip-mapping.tsx
+++ b/libs/market-info/src/components/market-info/tooltip-mapping.tsx
@@ -34,7 +34,7 @@ export const tooltipMapping: Record<string, ReactNode> = {
   bestStaticOfferVolume: t(
     'The aggregated volume being offered at the best static offer price on the market.'
   ),
-
+  marketDecimalPlaces: t('The smallest price increment on the book.'),
   decimalPlaces: t('The smallest price increment on the book.'),
   positionDecimalPlaces: t(
     'How big the smallest order / position on the market can be.'


### PR DESCRIPTION
# Related issues 🔗

Closes #2239 

# Description ℹ️

Add decimal places in key details in market info

# Demo 📺

<img width="325" alt="Screenshot 2022-11-29 at 18 03 14" src="https://user-images.githubusercontent.com/16125548/204668162-e858bd27-912e-41ac-b21b-622618f11b24.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
