### PR TITLE
fix(#2283): use correct GQL document for withdrawal event subscription

### DIFF
--- a/libs/withdraws/src/lib/use-create-withdraw.spec.tsx
+++ b/libs/withdraws/src/lib/use-create-withdraw.spec.tsx
@@ -18,7 +18,7 @@ import type {
   WithdrawalEventSubscription,
   WithdrawalFieldsFragment,
 } from './__generated__/Withdrawal';
-import { WithdrawalsDocument } from './__generated__/Withdrawal';
+import { WithdrawalEventDocument } from './__generated__/Withdrawal';
 import { Schema } from '@vegaprotocol/types';
 
 function setup(
@@ -116,7 +116,7 @@ beforeEach(() => {
   };
   mockWithdrawalEvent = {
     request: {
-      query: WithdrawalsDocument,
+      query: WithdrawalEventDocument,
       variables: { partyId: pubKey },
     },
     result: {

--- a/libs/withdraws/src/lib/use-withdrawal-event.ts
+++ b/libs/withdraws/src/lib/use-withdrawal-event.ts
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import type { VegaTxState } from '@vegaprotocol/wallet';
 import { useCallback, useEffect, useRef } from 'react';
 import type { Subscription } from 'zen-observable-ts';
-import { WithdrawalsDocument } from './__generated__/Withdrawal';
+import { WithdrawalEventDocument } from './__generated__/Withdrawal';
 import type {
   WithdrawalEventSubscription,
   WithdrawalEventSubscriptionVariables,
@@ -20,13 +20,13 @@ export const useWithdrawalEvent = (transaction: VegaTxState) => {
 
   const waitForWithdrawalEvent = useCallback<WaitForWithdrawalEvent>(
     (id, partyId) => {
-      return new Promise((resolve) => {
+      return new Promise<WithdrawalFieldsFragment>((resolve) => {
         subRef.current = client
           .subscribe<
             WithdrawalEventSubscription,
             WithdrawalEventSubscriptionVariables
           >({
-            query: WithdrawalsDocument,
+            query: WithdrawalEventDocument,
             variables: { partyId },
           })
           .subscribe(({ data }) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #2283 

# Description ℹ️

Changes to use the correct graphql document for the withdrawal event subscription