### PR TITLE
fix: show correct asset in rewards table

### DIFF
--- a/apps/token/src/routes/rewards/home/reward-info.tsx
+++ b/apps/token/src/routes/rewards/home/reward-info.tsx
@@ -108,7 +108,8 @@ export const RewardTable = ({ reward, delegations }: RewardTableProps) => {
         <KeyValueTableRow>
           {t('reward')}
           <span>
-            {formatNumber(toBigNum(reward.amount, decimals))} {t('VEGA')}
+            {formatNumber(toBigNum(reward.amount, decimals))}{' '}
+            {reward.asset.symbol}
           </span>
         </KeyValueTableRow>
         <KeyValueTableRow>


### PR DESCRIPTION
# Related issues 🔗

Closes #2293

# Description ℹ️

Was always showing Vega as the reward paid out when in fact it could be any currency.
