### PR TITLE
feat: add more data columns to lp dashboard

### DIFF
--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -1,34 +1,35 @@
-import { useCallback, useState } from 'react';
-import { AgGridColumn } from 'ag-grid-react';
+import { DApp, useLinks } from '@vegaprotocol/environment';
+import type { Market } from '@vegaprotocol/liquidity';
+import {
+  displayChange,
+  formatWithAsset,
+  useMarketsLiquidity,
+} from '@vegaprotocol/liquidity';
+import {
+  addDecimalsFormatNumber,
+  formatNumberPercentage,
+  t,
+  toBigNum,
+} from '@vegaprotocol/react-helpers';
+import type { Schema } from '@vegaprotocol/types';
+import {
+  AsyncRenderer,
+  Icon,
+  PriceCellChange,
+  TooltipCellComponent,
+} from '@vegaprotocol/ui-toolkit';
 import type {
-  ValueFormatterParams,
   GetRowIdParams,
   RowClickedEvent,
+  ValueFormatterParams,
 } from 'ag-grid-community';
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-alpine.css';
-import {
-  t,
-  addDecimalsFormatNumber,
-  formatNumberPercentage,
-  toBigNum,
-} from '@vegaprotocol/react-helpers';
-import {
-  Icon,
-  AsyncRenderer,
-  TooltipCellComponent,
-} from '@vegaprotocol/ui-toolkit';
-import type { Market } from '@vegaprotocol/liquidity';
-import {
-  useMarketsLiquidity,
-  formatWithAsset,
-  displayChange,
-} from '@vegaprotocol/liquidity';
-import type { Schema } from '@vegaprotocol/types';
-import { DApp, useLinks } from '@vegaprotocol/environment';
+import { AgGridColumn } from 'ag-grid-react';
+import { useCallback, useState } from 'react';
 
-import { HealthBar } from '../../health-bar';
 import { Grid } from '../../grid';
+import { HealthBar } from '../../health-bar';
 import { HealthDialog } from '../../health-dialog';
 import { Status } from '../../status';
 

--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -110,7 +110,7 @@ export const MarketList = () => {
           />
 
           <AgGridColumn
-            headerName={t('Committed bond')}
+            headerName={t('Total staked by LPs')}
             field="liquidityCommitted"
             valueFormatter={({ value, data }: ValueFormatterParams) =>
               formatWithAsset(

--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -98,6 +98,14 @@ export const MarketList = () => {
           />
 
           <AgGridColumn
+            headerName={t('Market Code')}
+            headerTooltip={t(
+              'The market code is a unique identifier for this market'
+            )}
+            field="tradableInstrument.instrument.code"
+          />
+
+          <AgGridColumn
             headerName={t('Type')}
             headerTooltip={t('Type')}
             field="tradableInstrument.instrument.product.__typename"

--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -98,6 +98,12 @@ export const MarketList = () => {
           />
 
           <AgGridColumn
+            headerName={t('Type')}
+            headerTooltip={t('Type')}
+            field="tradableInstrument.instrument.product.__typename"
+          />
+
+          <AgGridColumn
             headerName={t('Last Price')}
             headerTooltip={t('Latest price for this market')}
             field="data.markPrice"

--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -98,6 +98,18 @@ export const MarketList = () => {
           />
 
           <AgGridColumn
+            headerName={t('Last Price')}
+            headerTooltip={t('Latest price for this market')}
+            field="data.markPrice"
+            valueFormatter={({ value, data }: ValueFormatterParams) =>
+              formatWithAsset(
+                value,
+                data.tradableInstrument.instrument.product.settlementAsset
+              )
+            }
+          />
+
+          <AgGridColumn
             headerName={t('Volume (24h)')}
             field="dayVolume"
             valueFormatter={({ value, data }: ValueFormatterParams) =>

--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -110,6 +110,22 @@ export const MarketList = () => {
           />
 
           <AgGridColumn
+            headerName={t('Change (24h)')}
+            headerTooltip={t('Change in price over the last 24h')}
+            cellRenderer={({ data }: { data: Market }) => {
+              if (data.candles) {
+                const prices = data.candles.map((candle) => candle.close);
+                return (
+                  <PriceCellChange
+                    candles={prices}
+                    decimalPlaces={data?.decimalPlaces}
+                  />
+                );
+              } else return <div>{t('No data')}</div>;
+            }}
+          />
+
+          <AgGridColumn
             headerName={t('Volume (24h)')}
             field="dayVolume"
             valueFormatter={({ value, data }: ValueFormatterParams) =>


### PR DESCRIPTION
# Related issues 🔗

Part of #2206 

# Description ℹ️

Adds some more data columns to the LP dashboard:
* last/mark price
* 24h price change
* market type
* market code

Changed the title for liquidity committed from 'committed bond' to 'Total staked by LPs'

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Re-using `<PriceCellChange>` for the 24h price change
