### PR TITLE
feat(#2307): make liquidity provision table more prominent

### DIFF
--- a/apps/trading/client-pages/liquidity/liquidity.tsx
+++ b/apps/trading/client-pages/liquidity/liquidity.tsx
@@ -30,11 +30,19 @@ import { Link, useParams } from 'react-router-dom';
 
 export const Liquidity = () => {
   const params = useParams();
+  const marketId = params.marketId;
+  return <LiquidityContainer marketId={marketId} showTitle={true} />;
+};
+
+export const LiquidityContainer = ({
+  marketId,
+  showTitle = false,
+}: {
+  marketId: string | undefined;
+  showTitle?: boolean;
+}) => {
   const { pubKey } = useVegaWallet();
   const gridRef = useRef<AgGridReact | null>(null);
-
-  const marketId = params.marketId;
-
   const { data: marketProvision } = useDataProvider({
     dataProvider: marketLiquidityDataProvider,
     skipUpdates: true,
@@ -133,13 +141,15 @@ export const Liquidity = () => {
       <div className="h-full grid grid-rows-[min-content_1fr]">
         <Header
           title={
-            <Link to={`/markets/${marketId}`}>
-              <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
-                {`${
-                  marketProvision?.market?.tradableInstrument.instrument.name
-                } ${t('liquidity provision')}`}
-              </UiToolkitLink>
-            </Link>
+            showTitle && (
+              <Link to={`/markets/${marketId}`}>
+                <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+                  {`${
+                    marketProvision?.market?.tradableInstrument.instrument.name
+                  } ${t('liquidity provision')}`}
+                </UiToolkitLink>
+              </Link>
+            )
           }
         >
           <HeaderStat

--- a/apps/trading/client-pages/liquidity/liquidity.tsx
+++ b/apps/trading/client-pages/liquidity/liquidity.tsx
@@ -31,7 +31,7 @@ import { Link, useParams } from 'react-router-dom';
 export const Liquidity = () => {
   const params = useParams();
   const marketId = params.marketId;
-  return <LiquidityViewContainer marketId={marketId} showTitle={true} />;
+  return <LiquidityViewContainer marketId={marketId} />;
 };
 
 export const LiquidityContainer = ({
@@ -122,10 +122,8 @@ export const LiquidityContainer = ({
 
 export const LiquidityViewContainer = ({
   marketId,
-  showTitle = false,
 }: {
   marketId: string | undefined;
-  showTitle?: boolean;
 }) => {
   const { pubKey } = useVegaWallet();
   const gridRef = useRef<AgGridReact | null>(null);
@@ -227,15 +225,13 @@ export const LiquidityViewContainer = ({
       <div className="h-full grid grid-rows-[min-content_1fr]">
         <Header
           title={
-            showTitle && (
-              <Link to={`/markets/${marketId}`}>
-                <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
-                  {`${
-                    marketProvision?.market?.tradableInstrument.instrument.name
-                  } ${t('liquidity provision')}`}
-                </UiToolkitLink>
-              </Link>
-            )
+            <Link to={`/markets/${marketId}`}>
+              <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+                {`${
+                  marketProvision?.market?.tradableInstrument.instrument.name
+                } ${t('liquidity provision')}`}
+              </UiToolkitLink>
+            </Link>
           }
         >
           <HeaderStat

--- a/apps/trading/client-pages/liquidity/liquidity.tsx
+++ b/apps/trading/client-pages/liquidity/liquidity.tsx
@@ -225,13 +225,16 @@ export const LiquidityViewContainer = ({
       <div className="h-full grid grid-rows-[min-content_1fr]">
         <Header
           title={
-            <Link to={`/markets/${marketId}`}>
-              <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
-                {`${
-                  marketProvision?.market?.tradableInstrument.instrument.name
-                } ${t('liquidity provision')}`}
-              </UiToolkitLink>
-            </Link>
+            marketProvision?.market?.tradableInstrument.instrument.name &&
+            marketId && (
+              <Link to={`/markets/${marketId}`}>
+                <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+                  {`${
+                    marketProvision?.market?.tradableInstrument.instrument.name
+                  } ${t('liquidity provision')}`}
+                </UiToolkitLink>
+              </Link>
+            )
           }
         >
           <HeaderStat

--- a/apps/trading/client-pages/market/trade-grid.tsx
+++ b/apps/trading/client-pages/market/trade-grid.tsx
@@ -25,6 +25,7 @@ import type { SingleMarketFieldsFragment } from '@vegaprotocol/market-list';
 import { VegaWalletContainer } from '../../components/vega-wallet-container';
 import { TradeMarketHeader } from './trade-market-header';
 import { NO_MARKET } from './constants';
+import { LiquidityContainer } from '../liquidity/liquidity';
 
 type MarketDependantView =
   | typeof CandlesChartContainer
@@ -46,6 +47,7 @@ const requiresMarket = (View: MarketDependantView) => {
 const TradingViews = {
   Candles: requiresMarket(CandlesChartContainer),
   Depth: requiresMarket(DepthChartContainer),
+  Liquidity: requiresMarket(LiquidityContainer),
   Ticket: requiresMarket(DealTicketContainer),
   Info: requiresMarket(MarketInfoContainer),
   Orderbook: requiresMarket(OrderbookContainer),
@@ -85,6 +87,9 @@ const MainGrid = ({
               </Tab>
               <Tab id="depth" name={t('Depth')}>
                 <TradingViews.Depth marketId={marketId} />
+              </Tab>
+              <Tab id="liquidity" name={t('Liquidity')}>
+                <TradingViews.Liquidity marketId={marketId} />
               </Tab>
             </Tabs>
           </TradeGridChild>

--- a/apps/trading/components/header/header.tsx
+++ b/apps/trading/components/header/header.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from '@vegaprotocol/ui-toolkit';
-import classNames from 'classnames';
 import type { ReactElement, ReactNode } from 'react';
 import { Children } from 'react';
 import { cloneElement } from 'react';
@@ -11,16 +10,12 @@ interface TradeMarketHeaderProps {
 
 export const Header = ({ title, children }: TradeMarketHeaderProps) => {
   return (
-    <header
-      className={classNames('xl:px-4 pt-3 border-b border-default', {
-        'w-screen': !!title,
-      })}
-    >
+    <header className="w-screen xl:px-4 pt-3 border-b border-default">
       <div className="xl:flex xl:gap-4  items-start">
-        {!!title && <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>}
+        <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>
         <div
           data-testid="header-summary"
-          className="flex flex-nowrap items-start xl:flex-1 w-full overflow-x-auto text-xs first:border-0"
+          className="flex flex-nowrap items-start xl:flex-1 w-full overflow-x-auto text-xs"
         >
           {Children.map(children, (child, index) => {
             if (!child) return null;

--- a/apps/trading/components/header/header.tsx
+++ b/apps/trading/components/header/header.tsx
@@ -13,14 +13,14 @@ export const Header = ({ title, children }: TradeMarketHeaderProps) => {
   return (
     <header
       className={classNames('xl:px-4 pt-3 border-b border-default', {
-        'w-screen': Boolean(title),
+        'w-screen': !!title,
       })}
     >
       <div className="xl:flex xl:gap-4  items-start">
-        <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>
+        {!!title && <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>}
         <div
           data-testid="header-summary"
-          className="flex flex-nowrap items-start xl:flex-1 w-full overflow-x-auto text-xs "
+          className="flex flex-nowrap items-start xl:flex-1 w-full overflow-x-auto text-xs first:border-0"
         >
           {Children.map(children, (child, index) => {
             if (!child) return null;

--- a/apps/trading/components/header/header.tsx
+++ b/apps/trading/components/header/header.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from '@vegaprotocol/ui-toolkit';
+import classNames from 'classnames';
 import type { ReactElement, ReactNode } from 'react';
 import { Children } from 'react';
 import { cloneElement } from 'react';
@@ -10,7 +11,11 @@ interface TradeMarketHeaderProps {
 
 export const Header = ({ title, children }: TradeMarketHeaderProps) => {
   return (
-    <header className="w-screen xl:px-4 pt-3 border-b border-default">
+    <header
+      className={classNames('xl:px-4 pt-3 border-b border-default', {
+        'w-screen': Boolean(title),
+      })}
+    >
       <div className="xl:flex xl:gap-4  items-start">
         <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>
         <div


### PR DESCRIPTION
# Related issues 🔗

Closes #2307 

# Description ℹ️

Make the liquidity provision table more prominent (add another tab)

# Demo 📺

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/16125548/206746691-dad1dd60-015a-41bf-9bb9-cbdfd0d4bc17.png">

