### PR TITLE
fix: blank page if startup subscription fails

### DIFF
--- a/apps/trading/components/app-loader/index.tsx
+++ b/apps/trading/components/app-loader/index.tsx
@@ -8,7 +8,8 @@ import {
   Web3Provider as Web3ProviderInternal,
   useWeb3ConnectStore,
 } from '@vegaprotocol/web3';
-import { AsyncRenderer } from '@vegaprotocol/ui-toolkit';
+import { AsyncRenderer, Splash } from '@vegaprotocol/ui-toolkit';
+import { t } from '@vegaprotocol/react-helpers';
 
 interface AppLoaderProps {
   children: ReactNode;
@@ -19,7 +20,14 @@ interface AppLoaderProps {
  * that must happen for it can be used
  */
 export function AppLoader({ children }: AppLoaderProps) {
-  return <NetworkLoader cache={cacheConfig}>{children}</NetworkLoader>;
+  return (
+    <NetworkLoader
+      skeleton={<Splash>{t('Loading...')}</Splash>}
+      cache={cacheConfig}
+    >
+      {children}
+    </NetworkLoader>
+  );
 }
 
 export const Web3Provider = ({ children }: { children: ReactNode }) => {


### PR DESCRIPTION
# Description ℹ️

On console a blank page gets rendered if the start up subscription to determine node suitability never receives a message. This is fixed by ensuring the node switcher dialog is opened if the initial subscription takes longer than 3 seconds. 

# Technical 👨‍🔧

- Added setTimeout in requestNode
- Added a "Loading..." message as some fallback UI for the NetworkLoader
