### PR TITLE
feat: add market duration/age to market list page

### DIFF
--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -29,6 +29,7 @@ import { Grid } from '../../grid';
 import { HealthBar } from '../../health-bar';
 import { HealthDialog } from '../../health-dialog';
 import { Status } from '../../status';
+import { formatDistanceToNow } from 'date-fns';
 
 export const MarketList = () => {
   const { data, error, loading } = useMarketsLiquidity();
@@ -284,6 +285,16 @@ export const MarketList = () => {
             )}
             sortable={false}
             cellStyle={{ overflow: 'unset' }}
+          />
+          <AgGridColumn
+            headerName={t('Age')}
+            field="marketTimestamps.open"
+            headerTooltip={t('Age of the market')}
+            valueFormatter={({
+              value,
+            }: VegaValueFormatterParams<Market, 'marketTimestamps.open'>) => {
+              return value ? formatDistanceToNow(new Date(value)) : '-';
+            }}
           />
         </Grid>
 


### PR DESCRIPTION
# Related issues 🔗

Part of #2216 

# Description ℹ️

Add's a column to the lp-dashboard market list page for market age.

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Don't think there's anything of note, but please do shout if we've got date/time convensions that I've not adhered to!
