### PR TITLE
fix(2380): fixed block duration field to account for the new api format

### DIFF
--- a/apps/stats/.env.stagnet3
+++ b/apps/stats/.env.stagnet3
@@ -1,3 +1,3 @@
 # App configuration variables
 NX_VEGA_URL=https://api.stagnet3.vega.xyz/graphql
-NX_VEGA_ENV=STAGNET3;
+NX_VEGA_ENV=STAGNET3

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -6,7 +6,6 @@ import {
   t,
 } from '@vegaprotocol/react-helpers';
 import type { Stats, StatFields } from './types';
-import BigNumber from 'bignumber.js';
 
 // Stats fields config. Keys will correspond to graphql queries when used, and values
 // contain the associated data and methods we need to render. A single query

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -111,16 +111,28 @@ export const statsFields: { [key in keyof Stats]: StatFields[] } = {
     {
       title: t('Block time'),
       formatter: (duration: string) => {
+        const dp = 3;
         if (duration?.includes('ms')) {
-          return (parseFloat(duration) / 1000).toFixed(2).toString();
+          return (parseFloat(duration) / 1000).toFixed(dp).toString();
         } else if (duration?.includes('s')) {
-          return parseFloat(duration).toFixed(2).toString();
+          return parseFloat(duration).toFixed(dp).toString();
         }
-        return undefined;
+        return duration
+          ? (Number(duration) / 1000000000).toFixed(dp)
+          : undefined;
       },
-      goodThreshold: (blockDuration: string) =>
-        blockDuration?.includes('ms') ||
-        (blockDuration.includes('s') && parseFloat(blockDuration) <= 2),
+      goodThreshold: (blockDuration: string) => {
+        if (blockDuration?.includes('ms')) {
+          // only show ms if less than 1s
+          return true;
+        } else if (blockDuration?.includes('s')) {
+          return parseFloat(blockDuration) <= 2;
+        } else {
+          return (
+            Number(blockDuration) > 0 && Number(blockDuration) <= 2000000000
+          );
+        }
+      },
       description: t('Seconds between the two most recent blocks'),
     },
   ],

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -123,7 +123,8 @@ export const statsFields: { [key in keyof Stats]: StatFields[] } = {
       },
       goodThreshold: (blockDuration: string) => {
         if (blockDuration?.includes('ms')) {
-          // only show ms if less than 1s
+          // we only get ms from the api if duration is less than 1s, so this
+          // automatically passes
           return true;
         } else if (blockDuration?.includes('s')) {
           return parseFloat(blockDuration) <= 2;

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -6,6 +6,7 @@ import {
   t,
 } from '@vegaprotocol/react-helpers';
 import type { Stats, StatFields } from './types';
+import BigNumber from 'bignumber.js';
 
 // Stats fields config. Keys will correspond to graphql queries when used, and values
 // contain the associated data and methods we need to render. A single query
@@ -110,9 +111,17 @@ export const statsFields: { [key in keyof Stats]: StatFields[] } = {
   blockDuration: [
     {
       title: t('Block time'),
-      formatter: (duration: number) => (duration / 1000000000).toFixed(3),
-      goodThreshold: (blockDuration: number) =>
-        blockDuration > 0 && blockDuration <= 2000000000,
+      formatter: (duration: string) => {
+        if (duration?.includes('ms')) {
+          return (parseFloat(duration) / 1000).toFixed(2).toString();
+        } else if (duration?.includes('s')) {
+          return parseFloat(duration).toFixed(2).toString();
+        }
+        return undefined;
+      },
+      goodThreshold: (blockDuration: string) =>
+        blockDuration?.includes('ms') ||
+        (blockDuration.includes('s') && parseFloat(blockDuration) <= 2),
       description: t('Seconds between the two most recent blocks'),
     },
   ],


### PR DESCRIPTION
# Related issues 🔗

Closes #2380

# Description ℹ️

Where previously the API gave the duration between blocks as a duration number, it's now a string and can be in seconds or milliseconds. That stats app now accounts for these possibilities and formats the value into seconds for display.
