### PR TITLE
chore: allow jsx in trading-e2e

### DIFF
--- a/apps/trading-e2e/cypress.config.js
+++ b/apps/trading-e2e/cypress.config.js
@@ -1,19 +1,6 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  component: {
-    baseUrl: 'http://localhost:4200',
-    fileServerFolder: '.',
-    fixturesFolder: false,
-    specPattern: '**/*.cy.{js,jsx,ts,tsx}',
-    supportFile: './src/support/index.js',
-    video: false,
-    videosFolder: '../../dist/cypress/apps/trading-e2e/videos',
-    screenshotsFolder: '../../dist/cypress/apps/trading-e2e/screenshots',
-    chromeWebSecurity: false,
-    projectId: 'et4snf',
-    defaultCommandTimeout: 10000,
-  },
   e2e: {
     setupNodeEvents(on, config) {
       require('@cypress/grep/src/plugin')(config);

--- a/apps/trading-e2e/tsconfig.json
+++ b/apps/trading-e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
     "allowJs": true,


### PR DESCRIPTION
# Description ℹ️

Allows jsx to be imported into trading-e2e test files for easier sharing of code. Also deletes the unused cypress component testing configuration