### PR TITLE
chore: skip flow test

### DIFF
--- a/apps/token-e2e/src/integration/flow/governance-flow.cy.js
+++ b/apps/token-e2e/src/integration/flow/governance-flow.cy.js
@@ -728,7 +728,7 @@ context(
       });
 
       // 1005-PROP-009
-      it(
+      it.skip(
         'Unable to vote on a freeform proposal - when some but not enough vega associated',
         { tags: '@smoke' },
         function () {


### PR DESCRIPTION
# Related issues 🔗

This PR skips one token flow test that has been flakey and blocking PR builds getting merged.

The issue is capsule related and tracked in the ticket here: 
https://github.com/vegaprotocol/vegacapsule/issues/362

Once the issue is resolved the test can be un-skipped.
