### PR TITLE
fix: wallet connect save url to config

### DIFF
--- a/libs/wallet/src/connectors/json-rpc-connector.ts
+++ b/libs/wallet/src/connectors/json-rpc-connector.ts
@@ -82,7 +82,7 @@ export class JsonRpcConnector implements VegaConnector {
       setConfig({
         token: result.token,
         connector: 'jsonRpc',
-        url: this.url,
+        url: this._url,
       });
       return result;
     } catch (err) {


### PR DESCRIPTION
Fixes wallet connect, save the url to localstorage so that the connection is not los when the page is refreshed. 