### PR TITLE
chore: pull capsule from v0.2.3

### DIFF
--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vegaprotocol/vegacapsule
-          ref: main
+          ref: v0.2.3
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
           path: './capsule'
 


### PR DESCRIPTION
# Related issues 🔗

E2E tests that use capsule in CI are erroring on main branch because it is pulling from latest main branch. 

Change workflow to pull from compatible version of capsule against Vega v0.54.0

Closes #2519 
