### PR TITLE
feat: add market close datetime to lp dashboard

### DIFF
--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -10,6 +10,7 @@ import {
   formatNumberPercentage,
   t,
   toBigNum,
+  getDateTimeFormat,
 } from '@vegaprotocol/react-helpers';
 import type { VegaValueFormatterParams } from '@vegaprotocol/ui-toolkit';
 import type * as Schema from '@vegaprotocol/types';
@@ -294,6 +295,21 @@ export const MarketList = () => {
               value,
             }: VegaValueFormatterParams<Market, 'marketTimestamps.open'>) => {
               return value ? formatDistanceToNow(new Date(value)) : '-';
+            }}
+          />
+          <AgGridColumn
+            headerName={t('Closing Time')}
+            field="proposal.terms.closingDatetime"
+            headerTooltip={t('Closing time of the market')}
+            valueFormatter={({
+              value,
+            }: VegaValueFormatterParams<
+              Market,
+              'proposal.terms.closingDatetime'
+            >) => {
+              return value
+                ? getDateTimeFormat().format(new Date(value).getTime())
+                : '-';
             }}
           />
         </Grid>


### PR DESCRIPTION
# Related issues 🔗

Closes #2216 

# Description ℹ️

Adds a 'closing time' column to the lp-dashboard, populated from the `terms.closingDateTime` field on the governance proposal API.


