### PR TITLE
chore: rename candles tab to chart

### DIFF
--- a/apps/trading/client-pages/market/trade-grid.tsx
+++ b/apps/trading/client-pages/market/trade-grid.tsx
@@ -83,7 +83,7 @@ const MainGrid = ({
           >
             <TradeGridChild>
               <Tabs>
-                <Tab id="candles" name={t('Candles')}>
+                <Tab id="chart" name={t('Chart')}>
                   <TradingViews.Candles marketId={marketId} />
                 </Tab>
                 <Tab id="depth" name={t('Depth')}>


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Rename 'Candles' tab to 'Chart'