### PR TITLE
chore: 0 decimal places for % target stake column

### DIFF
--- a/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
+++ b/apps/liquidity-provision-dashboard/src/app/components/dashboard/market-list/market-list.tsx
@@ -215,7 +215,7 @@ export const MarketList = () => {
                   ) * 100;
                 const display = Number.isNaN(roundedPercentage)
                   ? 'N/A'
-                  : formatNumberPercentage(toBigNum(roundedPercentage, 2));
+                  : formatNumberPercentage(toBigNum(roundedPercentage, 0), 0);
                 return display;
               } else return '-';
             }}


### PR DESCRIPTION
# Related issues 🔗

Part of #2168 

# Description ℹ️

Don't show decimal places for `% target stake met` column on the lp-dashboard
