### PR TITLE
fix(2590): download JSON for some proposal types not working if propo…

### DIFF
--- a/apps/token/src/routes/proposals/propose/new-asset/propose-new-asset.tsx
+++ b/apps/token/src/routes/proposals/propose/new-asset/propose-new-asset.tsx
@@ -95,9 +95,9 @@ export const ProposeNewAsset = () => {
         description: fields.proposalDescription,
       },
       terms: {
-        newAsset: {
-          ...JSON.parse(fields.proposalTerms),
-        },
+        newAsset: fields.proposalTerms
+          ? { ...JSON.parse(fields.proposalTerms) }
+          : {},
         closingTimestamp: getClosingTimestamp(
           fields.proposalVoteDeadline,
           isVoteDeadlineAtMinimum,

--- a/apps/token/src/routes/proposals/propose/new-market/propose-new-market.tsx
+++ b/apps/token/src/routes/proposals/propose/new-market/propose-new-market.tsx
@@ -89,9 +89,9 @@ export const ProposeNewMarket = () => {
         description: fields.proposalDescription,
       },
       terms: {
-        newMarket: {
-          ...JSON.parse(fields.proposalTerms),
-        },
+        newMarket: fields.proposalTerms
+          ? { ...JSON.parse(fields.proposalTerms) }
+          : {},
         closingTimestamp: getClosingTimestamp(
           fields.proposalVoteDeadline,
           isVoteDeadlineAtMinimum,

--- a/apps/token/src/routes/proposals/propose/update-asset/propose-update-asset.tsx
+++ b/apps/token/src/routes/proposals/propose/update-asset/propose-update-asset.tsx
@@ -89,9 +89,9 @@ export const ProposeUpdateAsset = () => {
         description: fields.proposalDescription,
       },
       terms: {
-        updateAsset: {
-          ...JSON.parse(fields.proposalTerms),
-        },
+        updateAsset: fields.proposalTerms
+          ? { ...JSON.parse(fields.proposalTerms) }
+          : {},
         closingTimestamp: getClosingTimestamp(
           fields.proposalVoteDeadline,
           isVoteDeadlineAtMinimum,

--- a/apps/token/src/routes/proposals/propose/update-market/propose-update-market.tsx
+++ b/apps/token/src/routes/proposals/propose/update-market/propose-update-market.tsx
@@ -132,9 +132,9 @@ export const ProposeUpdateMarket = () => {
       terms: {
         updateMarket: {
           marketId: fields.proposalMarketId,
-          changes: {
-            ...JSON.parse(fields.proposalTerms),
-          },
+          changes: fields.proposalTerms
+            ? { ...JSON.parse(fields.proposalTerms) }
+            : {},
         },
         closingTimestamp: getClosingTimestamp(
           fields.proposalVoteDeadline,


### PR DESCRIPTION
…sal terms is empty

# Related issues 🔗

Closes #2590

# Description ℹ️

Some proposal downloads were failing due to a json parsing error if their terms data was an empty string. Added a little conditional logic to avoid this problem.
