### PR TITLE
feat(explorer): batch market instructions

### DIFF
--- a/apps/explorer/src/app/app.tsx
+++ b/apps/explorer/src/app/app.tsx
@@ -19,28 +19,10 @@ function App() {
   }, [location]);
 
   const cacheConfig: InMemoryCacheConfig = {
-    // True is default
-    addTypename: true,
-    // These feel redundant
     typePolicies: {
       statistics: {
         keyFields: false,
       },
-      Asset: {
-        keyFields: ['id'],
-      },
-      Market: {
-        keyFields: ['id'],
-      },
-      Order: {
-        keyFields: ['id'],
-      },
-      Party: {
-        keyFields: ['id'],
-      },
-    },
-    possibleTypes: {
-      Order: ['Order', 'order', 'orderById', 'OrderById'],
     },
   };
 

--- a/apps/explorer/src/app/app.tsx
+++ b/apps/explorer/src/app/app.tsx
@@ -1,23 +1,15 @@
 import classnames from 'classnames';
 import { useState, useEffect } from 'react';
-import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
 import { useLocation } from 'react-router-dom';
-import {
-  EnvironmentProvider,
-  NetworkLoader,
-  useEnvironment,
-} from '@vegaprotocol/environment';
+import { EnvironmentProvider, NetworkLoader } from '@vegaprotocol/environment';
 import { NetworkInfo } from '@vegaprotocol/network-info';
 import { Nav } from './components/nav';
 import { Header } from './components/header';
 import { Main } from './components/main';
 import { TendermintWebsocketProvider } from './contexts/websocket/tendermint-websocket-provider';
-import { ENV } from './config/env';
 import type { InMemoryCacheConfig } from '@apollo/client';
 
 function App() {
-  const { VEGA_ENV } = useEnvironment();
   const [menuOpen, setMenuOpen] = useState(false);
 
   const location = useLocation();
@@ -26,17 +18,30 @@ function App() {
     setMenuOpen(false);
   }, [location]);
 
-  useEffect(() => {
-    Sentry.init({
-      dsn: ENV.dsn,
-      integrations: [new BrowserTracing()],
-      tracesSampleRate: 1,
-      environment: VEGA_ENV,
-    });
-  }, [VEGA_ENV]);
-
   const cacheConfig: InMemoryCacheConfig = {
-    canonizeResults: true,
+    // True is default
+    addTypename: true,
+    // These feel redundant
+    typePolicies: {
+      statistics: {
+        keyFields: false,
+      },
+      Asset: {
+        keyFields: ['id'],
+      },
+      Market: {
+        keyFields: ['id'],
+      },
+      Order: {
+        keyFields: ['id'],
+      },
+      Party: {
+        keyFields: ['id'],
+      },
+    },
+    possibleTypes: {
+      Order: ['Order', 'order', 'orderById', 'OrderById'],
+    },
   };
 
   const layoutClasses = classnames(

--- a/apps/explorer/src/app/app.tsx
+++ b/apps/explorer/src/app/app.tsx
@@ -36,11 +36,7 @@ function App() {
   }, [VEGA_ENV]);
 
   const cacheConfig: InMemoryCacheConfig = {
-    typePolicies: {
-      Node: {
-        keyFields: false,
-      },
-    },
+    canonizeResults: true,
   };
 
   const layoutClasses = classnames(

--- a/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
+++ b/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
@@ -18,7 +18,6 @@ const AssetBalance = ({
   showAssetLink = true,
 }: AssetBalanceProps) => {
   const { data } = useExplorerAssetQuery({
-    fetchPolicy: 'cache-first',
     variables: { id: assetId },
   });
 

--- a/apps/explorer/src/app/components/links/asset-link/asset-link.tsx
+++ b/apps/explorer/src/app/components/links/asset-link/asset-link.tsx
@@ -16,7 +16,6 @@ export type AssetLinkProps = Partial<ComponentProps<typeof Link>> & {
  */
 const AssetLink = ({ id, ...props }: AssetLinkProps) => {
   const { data } = useExplorerAssetQuery({
-    fetchPolicy: 'cache-first',
     variables: { id },
   });
 

--- a/apps/explorer/src/app/components/links/market-link/market-link.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.tsx
@@ -18,6 +18,7 @@ export type MarketLinkProps = Partial<ComponentProps<typeof Link>> & {
 const MarketLink = ({ id, ...props }: MarketLinkProps) => {
   const { data, error, loading } = useExplorerMarketQuery({
     variables: { id },
+    fetchPolicy: 'cache-first',
   });
 
   let label = <span>{id}</span>;

--- a/apps/explorer/src/app/components/links/market-link/market-link.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.tsx
@@ -18,7 +18,6 @@ export type MarketLinkProps = Partial<ComponentProps<typeof Link>> & {
 const MarketLink = ({ id, ...props }: MarketLinkProps) => {
   const { data, error, loading } = useExplorerMarketQuery({
     variables: { id },
-    fetchPolicy: 'cache-first',
   });
 
   let label = <span>{id}</span>;
@@ -30,7 +29,7 @@ const MarketLink = ({ id, ...props }: MarketLinkProps) => {
       label = (
         <div title={t('Unknown market')}>
           <span role="img" aria-label="Unknown market" className="img">
-            ⚠️
+            ⚠️&nbsp;{t('Invalid market')}
           </span>
           &nbsp;{id}
         </div>

--- a/apps/explorer/src/app/components/order-details/Order.graphql
+++ b/apps/explorer/src/app/components/order-details/Order.graphql
@@ -22,8 +22,14 @@ fragment ExplorerDeterministicOrderFields on Order {
     tradableInstrument {
       instrument {
         name
+        product {
+          ... on Future {
+            quoteName
+          }
+        }
       }
     }
+    state
   }
 }
 

--- a/apps/explorer/src/app/components/order-details/__generated__/Order.ts
+++ b/apps/explorer/src/app/components/order-details/__generated__/Order.ts
@@ -3,7 +3,7 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ExplorerDeterministicOrderFieldsFragment = { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string } } } };
+export type ExplorerDeterministicOrderFieldsFragment = { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } };
 
 export type ExplorerDeterministicOrderQueryVariables = Types.Exact<{
   orderId: Types.Scalars['ID'];
@@ -11,7 +11,7 @@ export type ExplorerDeterministicOrderQueryVariables = Types.Exact<{
 }>;
 
 
-export type ExplorerDeterministicOrderQuery = { __typename?: 'Query', orderByID: { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string } } } } };
+export type ExplorerDeterministicOrderQuery = { __typename?: 'Query', orderByID: { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } } };
 
 export const ExplorerDeterministicOrderFieldsFragmentDoc = gql`
     fragment ExplorerDeterministicOrderFields on Order {
@@ -38,8 +38,14 @@ export const ExplorerDeterministicOrderFieldsFragmentDoc = gql`
     tradableInstrument {
       instrument {
         name
+        product {
+          ... on Future {
+            quoteName
+          }
+        }
       }
     }
+    state
   }
 }
     `;

--- a/apps/explorer/src/app/components/order-details/lib/order-labels.tsx
+++ b/apps/explorer/src/app/components/order-details/lib/order-labels.tsx
@@ -1,5 +1,6 @@
 import { t } from '@vegaprotocol/react-helpers';
 import type * as Schema from '@vegaprotocol/types';
+import type { components } from '../../../../types/explorer';
 
 export interface DeterministicOrderDetailsProps {
   id: string;
@@ -19,7 +20,8 @@ export const statusText: Record<Schema.OrderStatus, string> = {
   STATUS_STOPPED: t('Stopped'),
 };
 
-export const sideText: Record<Schema.Side, string> = {
+export const sideText: Record<components['schemas']['vegaSide'], string> = {
+  SIDE_UNSPECIFIED: t('Buy'),
   SIDE_BUY: t('Buy'),
   SIDE_SELL: t('Sell'),
 };

--- a/apps/explorer/src/app/components/order-details/lib/order-labels.tsx
+++ b/apps/explorer/src/app/components/order-details/lib/order-labels.tsx
@@ -21,7 +21,7 @@ export const statusText: Record<Schema.OrderStatus, string> = {
 };
 
 export const sideText: Record<components['schemas']['vegaSide'], string> = {
-  SIDE_UNSPECIFIED: t('Buy'),
+  SIDE_UNSPECIFIED: t('Unspecified'),
   SIDE_BUY: t('Buy'),
   SIDE_SELL: t('Sell'),
 };

--- a/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
@@ -1,0 +1,119 @@
+import type { MockedResponse } from '@apollo/client/testing';
+import type { components } from '../../../types/explorer';
+import type { UnknownObject } from '../nested-data-list';
+
+import { MockedProvider } from '@apollo/client/testing';
+import OrderSummary from './order-summary';
+import { render } from '@testing-library/react';
+import { ExplorerMarketDocument } from '../links/market-link/__generated__/Market';
+
+type Order = components['schemas']['v1OrderSubmission'];
+
+function renderComponent(order: Order, mocks?: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <OrderSummary order={order} />
+    </MockedProvider>
+  );
+}
+describe('Order Summary component', () => {
+  it('Renders nothing if the order passed is somehow null', () => {
+    const res = renderComponent({} as UnknownObject as Order);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order passed lacks a side', () => {
+    const o: Order = {
+      marketId: '123',
+      price: '100',
+      type: 'TYPE_LIMIT',
+      size: '10',
+    };
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order passed lacks a price', () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+    };
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order has an unspecified side', () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_UNSPECIFIED',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '10',
+    };
+
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order has an unspecified market', () => {
+    const o: Order = {
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '10',
+    };
+
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('side, size and price in market if all details are present', async () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '333',
+    };
+
+    const mock = {
+      request: {
+        query: ExplorerMarketDocument,
+        variables: {
+          id: '123',
+        },
+      },
+      result: {
+        data: {
+          market: {
+            id: '123',
+            decimalPlaces: 2,
+            state: 'irrelevant-test-data',
+            tradableInstrument: {
+              instrument: {
+                name: 'TEST',
+                product: {
+                  __typename: 'Future',
+                  quoteName: 'TEST',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const res = renderComponent(o, [mock]);
+    expect(res.queryByTestId('order-summary')).toBeInTheDocument();
+    expect(res.getByText('Buy')).toBeInTheDocument();
+    expect(res.getByText('10')).toBeInTheDocument();
+
+    // Initially renders price alone
+    expect(res.getByText('333')).toBeInTheDocument();
+
+    // After fetch renders formatted price and asset quotename
+    expect(await res.findByText('3.33')).toBeInTheDocument();
+    expect(await res.findByText('TEST')).toBeInTheDocument();
+  });
+});

--- a/apps/explorer/src/app/components/order-summary/order-summary.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.tsx
@@ -1,0 +1,32 @@
+import type { components } from '../../../types/explorer';
+
+import PriceInMarket from '../price-in-market/price-in-market';
+import { sideText } from '../order-details/lib/order-labels';
+
+export type OrderSummaryProps = {
+  order: components['schemas']['v1OrderSubmission'];
+};
+
+/**
+ * Given a market ID, it will fetch the market name and show that,
+ * with a link to the markets list. If the name does not come back
+ * it will use the ID instead
+ */
+const OrderSummary = ({ order }: OrderSummaryProps) => {
+  if (!order || !order.marketId || !order.price || !order.side) {
+    return null;
+  }
+
+  return (
+    <span>
+      {sideText[order.side]}&nbsp;
+      {order.size}&nbsp;<i className="text-xs">@</i>&nbsp;
+      <PriceInMarket
+        marketId={order.marketId}
+        price={order.price}
+      ></PriceInMarket>
+    </span>
+  );
+};
+
+export default OrderSummary;

--- a/apps/explorer/src/app/components/order-summary/order-summary.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.tsx
@@ -8,24 +8,33 @@ export type OrderSummaryProps = {
 };
 
 /**
- * Given a market ID, it will fetch the market name and show that,
- * with a link to the markets list. If the name does not come back
- * it will use the ID instead
+ * Shows a brief, relatively plaintext summary of an order transaction
+ * showing the price, correctly formatted. Created for the Batch Submission
+ * list, should be kept compact.
+ *
+ * Market name is expected to be listed elsewhere, so is not included
  */
 const OrderSummary = ({ order }: OrderSummaryProps) => {
-  if (!order || !order.marketId || !order.price || !order.side) {
+  // Render nothing if the Order Submission doesn't look right
+  if (
+    !order ||
+    !order.marketId ||
+    !order.price ||
+    !order.side ||
+    order.side === 'SIDE_UNSPECIFIED'
+  ) {
     return null;
   }
 
   return (
-    <span>
-      {sideText[order.side]}&nbsp;
-      {order.size}&nbsp;<i className="text-xs">@</i>&nbsp;
+    <div data-testid="order-summary">
+      <span>{sideText[order.side]}</span>&nbsp;
+      <span>{order.size}</span>&nbsp;<i className="text-xs">@</i>&nbsp;
       <PriceInMarket
         marketId={order.marketId}
         price={order.price}
       ></PriceInMarket>
-    </span>
+    </div>
   );
 };
 

--- a/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
@@ -1,0 +1,119 @@
+import type { MockedResponse } from '@apollo/client/testing';
+import type { components } from '../../../types/explorer';
+import type { UnknownObject } from '../nested-data-list';
+
+import { MockedProvider } from '@apollo/client/testing';
+import OrderTxSummary from './order-tx-summary';
+import { render } from '@testing-library/react';
+import { ExplorerMarketDocument } from '../links/market-link/__generated__/Market';
+
+type Order = components['schemas']['v1OrderSubmission'];
+
+function renderComponent(order: Order, mocks?: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <OrderTxSummary order={order} />
+    </MockedProvider>
+  );
+}
+describe('Order TX Summary component', () => {
+  it('Renders nothing if the order passed is somehow null', () => {
+    const res = renderComponent({} as UnknownObject as Order);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order passed lacks a side', () => {
+    const o: Order = {
+      marketId: '123',
+      price: '100',
+      type: 'TYPE_LIMIT',
+      size: '10',
+    };
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order passed lacks a price', () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+    };
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order has an unspecified side', () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_UNSPECIFIED',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '10',
+    };
+
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('Renders nothing if the order has an unspecified market', () => {
+    const o: Order = {
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '10',
+    };
+
+    const res = renderComponent(o);
+    expect(res.queryByTestId('order-summary')).not.toBeInTheDocument();
+  });
+
+  it('side, size and price in market if all details are present', async () => {
+    const o: Order = {
+      marketId: '123',
+      side: 'SIDE_BUY',
+      type: 'TYPE_LIMIT',
+      size: '10',
+      price: '333',
+    };
+
+    const mock = {
+      request: {
+        query: ExplorerMarketDocument,
+        variables: {
+          id: '123',
+        },
+      },
+      result: {
+        data: {
+          market: {
+            id: '123',
+            decimalPlaces: 2,
+            state: 'irrelevant-test-data',
+            tradableInstrument: {
+              instrument: {
+                name: 'TEST',
+                product: {
+                  __typename: 'Future',
+                  quoteName: 'TEST',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const res = renderComponent(o, [mock]);
+    expect(res.queryByTestId('order-summary')).toBeInTheDocument();
+    expect(res.getByText('Buy')).toBeInTheDocument();
+    expect(res.getByText('10')).toBeInTheDocument();
+
+    // Initially renders price alone
+    expect(res.getByText('333')).toBeInTheDocument();
+
+    // After fetch renders formatted price and asset quotename
+    expect(await res.findByText('3.33')).toBeInTheDocument();
+    expect(await res.findByText('TEST')).toBeInTheDocument();
+  });
+});

--- a/apps/explorer/src/app/components/order-summary/order-tx-summary.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-tx-summary.tsx
@@ -1,0 +1,41 @@
+import type { components } from '../../../types/explorer';
+
+import PriceInMarket from '../price-in-market/price-in-market';
+import { sideText } from '../order-details/lib/order-labels';
+
+export type OrderSummaryProps = {
+  order: components['schemas']['v1OrderSubmission'];
+};
+
+/**
+ * Shows a brief, relatively plaintext summary of an order transaction
+ * showing the price, correctly formatted. Created for the Batch Submission
+ * list, should be kept compact.
+ *
+ * Market name is expected to be listed elsewhere, so is not included
+ */
+const OrderTxSummary = ({ order }: OrderSummaryProps) => {
+  // Render nothing if the Order Submission doesn't look right
+  if (
+    !order ||
+    !order.marketId ||
+    !order.price ||
+    !order.side ||
+    order.side === 'SIDE_UNSPECIFIED'
+  ) {
+    return null;
+  }
+
+  return (
+    <div data-testid="order-summary">
+      <span>{sideText[order.side]}</span>&nbsp;
+      <span>{order.size}</span>&nbsp;<i className="text-xs">@</i>&nbsp;
+      <PriceInMarket
+        marketId={order.marketId}
+        price={order.price}
+      ></PriceInMarket>
+    </div>
+  );
+};
+
+export default OrderTxSummary;

--- a/apps/explorer/src/app/components/price-in-market/price-in-market.tsx
+++ b/apps/explorer/src/app/components/price-in-market/price-in-market.tsx
@@ -15,6 +15,7 @@ export type PriceInMarketProps = {
 const PriceInMarket = ({ marketId, price }: PriceInMarketProps) => {
   const { data } = useExplorerMarketQuery({
     variables: { id: marketId },
+    fetchPolicy: 'cache-first',
   });
 
   let label = price;
@@ -37,9 +38,9 @@ const PriceInMarket = ({ marketId, price }: PriceInMarketProps) => {
     );
   } else {
     return (
-      <div className="inline-block">
+      <label>
         <span>{label}</span> <span>{suffix}</span>
-      </div>
+      </label>
     );
   }
 };

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
@@ -1,7 +1,7 @@
 import type { BatchInstruction } from '../../../../routes/types/block-explorer-response';
 import { TxOrderType } from '../../tx-order-type';
-import { TruncateInline } from '../../../truncate/truncate';
 import { MarketLink } from '../../../links';
+import OrderSummary from '../../../order-summary/order-summary';
 
 interface BatchAmendProps {
   index: number;
@@ -16,10 +16,10 @@ export const BatchAmend = ({ index, submission }: BatchAmendProps) => {
     <tr>
       <td>{index}</td>
       <td>
-        <TxOrderType orderType={'OrderCancellation'} />
+        <TxOrderType orderType={'OrderAmendment'} />
       </td>
       <td>
-        <TruncateInline text={submission.orderId} />
+        <OrderSummary id={submission.orderId} modifier="edited" />
       </td>
       <td>
         <MarketLink id={submission.marketId} />

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
@@ -1,0 +1,29 @@
+import type { BatchInstruction } from '../../../../routes/types/block-explorer-response';
+import { TxOrderType } from '../../tx-order-type';
+import { TruncateInline } from '../../../truncate/truncate';
+import { MarketLink } from '../../../links';
+
+interface BatchAmendProps {
+  index: number;
+  submission: BatchInstruction;
+}
+
+/**
+ * Table row for a single amendment in a batch submission
+ */
+export const BatchAmend = ({ index, submission }: BatchAmendProps) => {
+  return (
+    <tr>
+      <td>{index}</td>
+      <td>
+        <TxOrderType orderType={'OrderCancellation'} />
+      </td>
+      <td>
+        <TruncateInline text={submission.orderId} />
+      </td>
+      <td>
+        <MarketLink id={submission.marketId} />
+      </td>
+    </tr>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-amend.tsx
@@ -13,7 +13,7 @@ interface BatchAmendProps {
  */
 export const BatchAmend = ({ index, submission }: BatchAmendProps) => {
   return (
-    <tr>
+    <tr key={`amend-${index}`}>
       <td>{index}</td>
       <td>
         <TxOrderType orderType={'OrderAmendment'} />

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
@@ -1,7 +1,7 @@
 import type { BatchCancellationInstruction } from '../../../../routes/types/block-explorer-response';
 import { TxOrderType } from '../../tx-order-type';
-import { TruncateInline } from '../../../truncate/truncate';
 import { MarketLink } from '../../../links';
+import OrderSummary from '../../../order-summary/order-summary';
 
 interface BatchCancelProps {
   index: number;
@@ -19,7 +19,7 @@ export const BatchCancel = ({ index, submission }: BatchCancelProps) => {
         <TxOrderType orderType={'OrderCancellation'} />
       </td>
       <td>
-        <TruncateInline text={submission.orderId} />
+        <OrderSummary id={submission.orderId} modifier="cancelled" />
       </td>
       <td>
         <MarketLink id={submission.marketId} />

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
@@ -1,0 +1,29 @@
+import type { BatchCancellationInstruction } from '../../../../routes/types/block-explorer-response';
+import { TxOrderType } from '../../tx-order-type';
+import { TruncateInline } from '../../../truncate/truncate';
+import { MarketLink } from '../../../links';
+
+interface BatchCancelProps {
+  index: number;
+  submission: BatchCancellationInstruction;
+}
+
+/**
+ * Table row for a single cancellation in a batch submission
+ */
+export const BatchCancel = ({ index, submission }: BatchCancelProps) => {
+  return (
+    <tr>
+      <td>{index}</td>
+      <td>
+        <TxOrderType orderType={'OrderCancellation'} />
+      </td>
+      <td>
+        <TruncateInline text={submission.orderId} />
+      </td>
+      <td>
+        <MarketLink id={submission.marketId} />
+      </td>
+    </tr>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
@@ -13,7 +13,7 @@ interface BatchOrderProps {
  */
 export const BatchOrder = ({ index, submission }: BatchOrderProps) => {
   return (
-    <tr>
+    <tr key={`batch-${index}`}>
       <td>{index}</td>
       <td>
         <TxOrderType orderType={'OrderSubmission'} />

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
@@ -1,0 +1,29 @@
+import type { BatchInstruction } from '../../../../routes/types/block-explorer-response';
+import { TxOrderType } from '../../tx-order-type';
+import { MarketLink } from '../../../links';
+import OrderSummary from '../../../order-summary/order-summary';
+
+interface BatchOrderProps {
+  index: number;
+  submission: BatchInstruction;
+}
+
+/**
+ * Table row for a single order in a batch submission
+ */
+export const BatchOrder = ({ index, submission }: BatchOrderProps) => {
+  return (
+    <tr>
+      <td>{index}</td>
+      <td>
+        <TxOrderType orderType={'OrderCancellation'} />
+      </td>
+      <td>
+        <OrderSummary order={submission} />
+      </td>
+      <td>
+        <MarketLink id={submission.marketId} />
+      </td>
+    </tr>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-order.tsx
@@ -1,7 +1,7 @@
 import type { BatchInstruction } from '../../../../routes/types/block-explorer-response';
 import { TxOrderType } from '../../tx-order-type';
 import { MarketLink } from '../../../links';
-import OrderSummary from '../../../order-summary/order-summary';
+import OrderTxSummary from '../../../order-summary/order-tx-summary';
 
 interface BatchOrderProps {
   index: number;
@@ -16,10 +16,10 @@ export const BatchOrder = ({ index, submission }: BatchOrderProps) => {
     <tr>
       <td>{index}</td>
       <td>
-        <TxOrderType orderType={'OrderCancellation'} />
+        <TxOrderType orderType={'OrderSubmission'} />
       </td>
       <td>
-        <OrderSummary order={submission} />
+        <OrderTxSummary order={submission} />
       </td>
       <td>
         <MarketLink id={submission.marketId} />

--- a/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
@@ -31,6 +31,10 @@ export const ChainResponseCode = ({
   const icon = isSuccess ? '✅' : '❌';
   const label = ErrorCodes.get(code) || 'Unknown response code';
 
+  // Hack for batches with many errors - see https://github.com/vegaprotocol/vega/issues/7245
+  const displayError =
+    error && error.length > 100 ? error.replace(/,/g, ',\r\n') : error;
+
   return (
     <div title={`Response code: ${code} - ${label}`}>
       <span
@@ -41,8 +45,8 @@ export const ChainResponseCode = ({
         {icon}
       </span>
       {hideLabel ? null : <span>{label}</span>}
-      {!hideLabel && !!error ? (
-        <span className="ml-1">&mdash;&nbsp;{error}</span>
+      {!hideLabel && !!displayError ? (
+        <span className="ml-1 whitespace-pre">&mdash;&nbsp;{displayError}</span>
       ) : null}
     </div>
   );

--- a/apps/explorer/src/app/components/txs/details/shared/tx-details-shared.tsx
+++ b/apps/explorer/src/app/components/txs/details/shared/tx-details-shared.tsx
@@ -14,6 +14,12 @@ interface TxDetailsSharedProps {
   blockData: TendermintBlocksResponse | undefined;
 }
 
+// Applied to all header cells
+const sharedHeaderProps = {
+  // Ensures that multi line contents still have the header aligned to the first line
+  className: 'align-top',
+};
+
 /**
  * These rows are shown for every transaction type, providing a consistent set of rows for the top
  * of a transaction details row. The order is relatively arbitrary but felt right - it might need to
@@ -34,27 +40,27 @@ export const TxDetailsShared = ({
   return (
     <>
       <TableRow modifier="bordered">
-        <TableCell>{t('Type')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Type')}</TableCell>
         <TableCell>{txData.type}</TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>{t('Hash')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Hash')}</TableCell>
         <TableCell>
           <code>{txData.hash}</code>
         </TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>{t('Submitter')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Submitter')}</TableCell>
         <TableCell>{pubKey ? <PartyLink id={pubKey} /> : '-'}</TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>{t('Block')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Block')}</TableCell>
         <TableCell>
           <BlockLink height={height} />
         </TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>{t('Time')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Time')}</TableCell>
         <TableCell>
           {time ? (
             <div>
@@ -71,7 +77,7 @@ export const TxDetailsShared = ({
         </TableCell>
       </TableRow>
       <TableRow modifier="bordered">
-        <TableCell>{t('Response code')}</TableCell>
+        <TableCell {...sharedHeaderProps}>{t('Response code')}</TableCell>
         <TableCell>
           <ChainResponseCode code={txData.code} error={txData.error} />
         </TableCell>

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -51,7 +51,7 @@ export const TxDetailsBatch = ({
     txData.command.batchMarketInstructions.cancellations;
   const countCancellations = cancellations.length || 0;
   const countTotal = countSubmissions + countAmendments + countCancellations;
-
+  let index = 0;
   return (
     <div>
       <TableWithTbody className="mb-8">
@@ -95,10 +95,10 @@ export const TxDetailsBatch = ({
       <Table className="max-w-5xl min-w-fit">
         <thead>
           <TableRow modifier="bordered" className="font-mono">
-            <th align="left">{t('Type Index')}</th>
+            <th align="left">{t('#')}</th>
             <th align="left">{t('Type')}</th>
-            <th align="left">{t('Market')}</th>
             <th align="left">{t('Order')}</th>
+            <th align="left">{t('Market')}</th>
           </TableRow>
         </thead>
         <tbody>
@@ -106,15 +106,15 @@ export const TxDetailsBatch = ({
             ? cancellations.map((c, i) => {
                 return (
                   <tr>
-                    <td>{i}</td>
+                    <td>{index++}</td>
                     <td>
                       <TxOrderType orderType={'OrderCancellation'} />
                     </td>
                     <td>
-                      <MarketLink id={c.marketId} />
+                      <TruncateInline text={c.orderId} />
                     </td>
                     <td>
-                      <TruncateInline text={c.orderId} />
+                      <MarketLink id={c.marketId} />
                     </td>
                   </tr>
                 );
@@ -124,15 +124,15 @@ export const TxDetailsBatch = ({
             ? amendments.map((a, i) => {
                 return (
                   <tr>
-                    <td>{i}</td>
+                    <td>{index++}</td>
                     <td>
                       <TxOrderType orderType={'OrderAmendment'} />
                     </td>
                     <td>
-                      <MarketLink id={a.marketId} />
+                      <TruncateInline text={a.orderId} />
                     </td>
                     <td>
-                      <TruncateInline text={a.orderId} />
+                      <MarketLink id={a.marketId} />
                     </td>
                   </tr>
                 );
@@ -142,15 +142,15 @@ export const TxDetailsBatch = ({
             ? submissions.map((s, i) => {
                 return (
                   <tr>
-                    <td>{i}</td>
+                    <td>{index++}</td>
                     <td>
                       <TxOrderType orderType={'OrderSubmission'} />
                     </td>
                     <td>
-                      <MarketLink id={s.marketId} />
+                      <OrderSummary order={s} />
                     </td>
                     <td>
-                      <OrderSummary order={s} />
+                      <MarketLink id={s.marketId} />
                     </td>
                   </tr>
                 );

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -52,7 +52,7 @@ export const TxDetailsBatch = ({
   const countTotal = countSubmissions + countAmendments + countCancellations;
   let index = 0;
   return (
-    <div>
+    <div key={`tx-${index}`}>
       <TableWithTbody className="mb-8">
         <TxDetailsShared
           txData={txData}
@@ -102,13 +102,13 @@ export const TxDetailsBatch = ({
         </thead>
         <tbody>
           {cancellations.map((c) => (
-            <BatchCancel submission={c} index={index++} />
+            <BatchCancel key={`bc-${index}`} submission={c} index={index++} />
           ))}
           {amendments.map((a) => (
-            <BatchAmend submission={a} index={index++} />
+            <BatchAmend key={`ba-${index}`} submission={a} index={index++} />
           ))}
           {submissions.map((s) => (
-            <BatchOrder submission={s} index={index++} />
+            <BatchOrder key={`bo-${index}`} submission={s} index={index++} />
           ))}
         </tbody>
       </Table>

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -1,8 +1,14 @@
 import { t } from '@vegaprotocol/react-helpers';
-import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
+import type {
+  BatchCancellationInstruction,
+  BatchInstruction,
+  BlockExplorerTransactionResult,
+} from '../../../routes/types/block-explorer-response';
 import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
 import { TxDetailsShared } from './shared/tx-details-shared';
-import { TableWithTbody, TableRow, TableCell } from '../../table';
+import { TableWithTbody, TableRow, TableCell, Table } from '../../table';
+import { TxOrderType } from '../tx-order-type';
+import { TruncateInline } from '../../truncate/truncate';
 
 interface TxDetailsBatchProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -16,6 +22,11 @@ interface TxDetailsBatchProps {
  *
  * Design considerations for batch:
  * - So far it's very basic details about the size of the batch
+ *
+ * Batches are processed in the following order:
+ * - Cancellations
+ * - Amends
+ * - Submissions
  */
 export const TxDetailsBatch = ({
   txData,
@@ -26,47 +37,118 @@ export const TxDetailsBatch = ({
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
 
-  const countSubmissions =
-    txData.command.batchMarketInstructions.submissions?.length || 0;
-  const countAmendments =
-    txData.command.batchMarketInstructions.amendments?.length || 0;
-  const countCancellations =
-    txData.command.batchMarketInstructions.cancellations?.length || 0;
+  const submissions: BatchInstruction[] =
+    txData.command.batchMarketInstructions.submissions;
+  const countSubmissions = submissions?.length || 0;
+
+  const amendments: BatchInstruction[] =
+    txData.command.batchMarketInstructions.amendments;
+  const countAmendments = amendments?.length || 0;
+
+  const cancellations: BatchCancellationInstruction[] =
+    txData.command.batchMarketInstructions.cancellations;
+  const countCancellations = cancellations.length || 0;
   const countTotal = countSubmissions + countAmendments + countCancellations;
 
   return (
-    <TableWithTbody className="mb-8">
-      <TxDetailsShared txData={txData} pubKey={pubKey} blockData={blockData} />
-      <TableRow modifier="bordered">
-        <TableCell>{t('Batch size')}</TableCell>
-        <TableCell>
-          <span>{countTotal}</span>
-        </TableCell>
-      </TableRow>
-      <TableRow modifier="bordered">
-        <TableCell>
-          <span className="ml-5">{t('Submissions')}</span>
-        </TableCell>
-        <TableCell>
-          <span>{countSubmissions}</span>
-        </TableCell>
-      </TableRow>
-      <TableRow modifier="bordered">
-        <TableCell>
-          <span className="ml-5">{t('Amendments')}</span>
-        </TableCell>
-        <TableCell>
-          <span>{countAmendments}</span>
-        </TableCell>
-      </TableRow>
-      <TableRow modifier="bordered">
-        <TableCell>
-          <span className="ml-5">{t('Cancellations')}</span>
-        </TableCell>
-        <TableCell>
-          <span>{countCancellations}</span>
-        </TableCell>
-      </TableRow>
-    </TableWithTbody>
+    <div>
+      <TableWithTbody className="mb-8">
+        <TxDetailsShared
+          txData={txData}
+          pubKey={pubKey}
+          blockData={blockData}
+        />
+        <TableRow modifier="bordered">
+          <TableCell>{t('Batch size')}</TableCell>
+          <TableCell>
+            <span>{countTotal}</span>
+          </TableCell>
+        </TableRow>
+        <TableRow modifier="bordered">
+          <TableCell>
+            <span className="ml-5">{t('Cancellations')}</span>
+          </TableCell>
+          <TableCell>
+            <span>{countCancellations}</span>
+          </TableCell>
+        </TableRow>
+        <TableRow modifier="bordered">
+          <TableCell>
+            <span className="ml-5">{t('Amendments')}</span>
+          </TableCell>
+          <TableCell>
+            <span>{countAmendments}</span>
+          </TableCell>
+        </TableRow>
+        <TableRow modifier="bordered">
+          <TableCell>
+            <span className="ml-5">{t('Submissions')}</span>
+          </TableCell>
+          <TableCell>
+            <span>{countSubmissions}</span>
+          </TableCell>
+        </TableRow>
+      </TableWithTbody>
+
+      <Table className="max-w-5xl min-w-fit">
+        <thead>
+          <TableRow modifier="bordered" className="font-mono">
+            <th>{t('Type')}</th>
+            <th>{t('Market')}</th>
+            <th>{t('Order')}</th>
+          </TableRow>
+        </thead>
+        <tbody>
+          {cancellations.length > 0
+            ? cancellations.map((c) => {
+                return (
+                  <tr>
+                    <td>
+                      <TxOrderType orderType={'OrderCancellation'} />
+                    </td>
+                    <td>
+                      <TruncateInline text={c.marketId} />
+                    </td>
+                    <td>
+                      <TruncateInline text={c.orderId} />
+                    </td>
+                  </tr>
+                );
+              })
+            : null}
+          {amendments.length > 0
+            ? amendments.map((a) => {
+                return (
+                  <tr>
+                    <td>
+                      <TxOrderType orderType={'OrderAmendment'} />
+                    </td>
+                    <td>
+                      <TruncateInline text={a.marketId} />
+                    </td>
+                    <td>
+                      <TruncateInline text={a.orderId} />
+                    </td>
+                  </tr>
+                );
+              })
+            : null}
+          {submissions.length > 0
+            ? submissions.map((s) => {
+                return (
+                  <tr>
+                    <td>
+                      <TxOrderType orderType={'OrderSubmission'} />
+                    </td>
+                    <td>
+                      <TruncateInline text={s.marketId} />
+                    </td>
+                  </tr>
+                );
+              })
+            : null}
+        </tbody>
+      </Table>
+    </div>
   );
 };

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -8,9 +8,11 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableWithTbody, TableRow, TableCell, Table } from '../../table';
 import { TxOrderType } from '../tx-order-type';
-import { TruncateInline } from '../../truncate/truncate';
 import { MarketLink } from '../../links';
 import OrderSummary from '../../order-summary/order-summary';
+import { BatchCancel } from './batch-submission/batch-cancel';
+import { BatchAmend } from './batch-submission/batch-amend';
+import { BatchOrder } from './batch-submission/batch-order';
 
 interface TxDetailsBatchProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -102,60 +104,15 @@ export const TxDetailsBatch = ({
           </TableRow>
         </thead>
         <tbody>
-          {cancellations.length > 0
-            ? cancellations.map((c, i) => {
-                return (
-                  <tr>
-                    <td>{index++}</td>
-                    <td>
-                      <TxOrderType orderType={'OrderCancellation'} />
-                    </td>
-                    <td>
-                      <TruncateInline text={c.orderId} />
-                    </td>
-                    <td>
-                      <MarketLink id={c.marketId} />
-                    </td>
-                  </tr>
-                );
-              })
-            : null}
-          {amendments.length > 0
-            ? amendments.map((a, i) => {
-                return (
-                  <tr>
-                    <td>{index++}</td>
-                    <td>
-                      <TxOrderType orderType={'OrderAmendment'} />
-                    </td>
-                    <td>
-                      <TruncateInline text={a.orderId} />
-                    </td>
-                    <td>
-                      <MarketLink id={a.marketId} />
-                    </td>
-                  </tr>
-                );
-              })
-            : null}
-          {submissions.length > 0
-            ? submissions.map((s, i) => {
-                return (
-                  <tr>
-                    <td>{index++}</td>
-                    <td>
-                      <TxOrderType orderType={'OrderSubmission'} />
-                    </td>
-                    <td>
-                      <OrderSummary order={s} />
-                    </td>
-                    <td>
-                      <MarketLink id={s.marketId} />
-                    </td>
-                  </tr>
-                );
-              })
-            : null}
+          {cancellations.map((c) => (
+            <BatchCancel submission={c} index={index++} />
+          ))}
+          {amendments.map((a) => (
+            <BatchAmend submission={a} index={index++} />
+          ))}
+          {submissions.map((s) => (
+            <BatchOrder submission={s} index={index++} />
+          ))}
         </tbody>
       </Table>
     </div>

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -9,6 +9,8 @@ import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableWithTbody, TableRow, TableCell, Table } from '../../table';
 import { TxOrderType } from '../tx-order-type';
 import { TruncateInline } from '../../truncate/truncate';
+import { MarketLink } from '../../links';
+import OrderSummary from '../../order-summary/order-summary';
 
 interface TxDetailsBatchProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -93,21 +95,23 @@ export const TxDetailsBatch = ({
       <Table className="max-w-5xl min-w-fit">
         <thead>
           <TableRow modifier="bordered" className="font-mono">
-            <th>{t('Type')}</th>
-            <th>{t('Market')}</th>
-            <th>{t('Order')}</th>
+            <th align="left">{t('Type Index')}</th>
+            <th align="left">{t('Type')}</th>
+            <th align="left">{t('Market')}</th>
+            <th align="left">{t('Order')}</th>
           </TableRow>
         </thead>
         <tbody>
           {cancellations.length > 0
-            ? cancellations.map((c) => {
+            ? cancellations.map((c, i) => {
                 return (
                   <tr>
+                    <td>{i}</td>
                     <td>
                       <TxOrderType orderType={'OrderCancellation'} />
                     </td>
                     <td>
-                      <TruncateInline text={c.marketId} />
+                      <MarketLink id={c.marketId} />
                     </td>
                     <td>
                       <TruncateInline text={c.orderId} />
@@ -117,14 +121,15 @@ export const TxDetailsBatch = ({
               })
             : null}
           {amendments.length > 0
-            ? amendments.map((a) => {
+            ? amendments.map((a, i) => {
                 return (
                   <tr>
+                    <td>{i}</td>
                     <td>
                       <TxOrderType orderType={'OrderAmendment'} />
                     </td>
                     <td>
-                      <TruncateInline text={a.marketId} />
+                      <MarketLink id={a.marketId} />
                     </td>
                     <td>
                       <TruncateInline text={a.orderId} />
@@ -134,14 +139,18 @@ export const TxDetailsBatch = ({
               })
             : null}
           {submissions.length > 0
-            ? submissions.map((s) => {
+            ? submissions.map((s, i) => {
                 return (
                   <tr>
+                    <td>{i}</td>
                     <td>
                       <TxOrderType orderType={'OrderSubmission'} />
                     </td>
                     <td>
-                      <TruncateInline text={s.marketId} />
+                      <MarketLink id={s.marketId} />
+                    </td>
+                    <td>
+                      <OrderSummary order={s} />
                     </td>
                   </tr>
                 );

--- a/apps/explorer/src/app/components/txs/details/tx-batch.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-batch.tsx
@@ -7,9 +7,6 @@ import type {
 import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableWithTbody, TableRow, TableCell, Table } from '../../table';
-import { TxOrderType } from '../tx-order-type';
-import { MarketLink } from '../../links';
-import OrderSummary from '../../order-summary/order-summary';
 import { BatchCancel } from './batch-submission/batch-cancel';
 import { BatchAmend } from './batch-submission/batch-amend';
 import { BatchOrder } from './batch-submission/batch-order';

--- a/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
@@ -45,7 +45,7 @@ export const TxDetailsWrapper = ({
   const raw = get(blockData, `result.block.data.txs[${txData.index}]`);
 
   return (
-    <>
+    <div key={`txd-${txData.hash}`}>
       <section>{child({ txData, pubKey, blockData })}</section>
 
       <details title={t('Decoded transaction')} className="mt-3">
@@ -59,7 +59,7 @@ export const TxDetailsWrapper = ({
           <code className="break-all font-mono text-xs">{raw}</code>
         </details>
       ) : null}
-    </>
+    </div>
   );
 };
 

--- a/apps/explorer/src/app/routes/parties/id/Party-assets.graphql
+++ b/apps/explorer/src/app/routes/parties/id/Party-assets.graphql
@@ -15,9 +15,15 @@ fragment ExplorerPartyAssetsAccounts on AccountBalance {
   balance
   market {
     id
+    decimalPlaces
     tradableInstrument {
       instrument {
         name
+        product {
+          ... on Future {
+            quoteName
+          }
+        }
       }
     }
   }

--- a/apps/explorer/src/app/routes/parties/id/__generated__/Party-assets.ts
+++ b/apps/explorer/src/app/routes/parties/id/__generated__/Party-assets.ts
@@ -3,14 +3,14 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ExplorerPartyAssetsAccountsFragment = { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string } }, market?: { __typename?: 'Market', id: string, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string } } } | null };
+export type ExplorerPartyAssetsAccountsFragment = { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string } }, market?: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } | null };
 
 export type ExplorerPartyAssetsQueryVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
 
 
-export type ExplorerPartyAssetsQuery = { __typename?: 'Query', partiesConnection?: { __typename?: 'PartyConnection', edges: Array<{ __typename?: 'PartyEdge', node: { __typename?: 'Party', id: string, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number, node: { __typename?: 'Node', id: string, name: string } } } | null> | null } | null, stakingSummary: { __typename?: 'StakingSummary', currentStakeAvailable: string }, accountsConnection?: { __typename?: 'AccountsConnection', edges?: Array<{ __typename?: 'AccountEdge', node: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string } }, market?: { __typename?: 'Market', id: string, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string } } } | null } } | null> | null } | null } }> } | null };
+export type ExplorerPartyAssetsQuery = { __typename?: 'Query', partiesConnection?: { __typename?: 'PartyConnection', edges: Array<{ __typename?: 'PartyEdge', node: { __typename?: 'Party', id: string, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number, node: { __typename?: 'Node', id: string, name: string } } } | null> | null } | null, stakingSummary: { __typename?: 'StakingSummary', currentStakeAvailable: string }, accountsConnection?: { __typename?: 'AccountsConnection', edges?: Array<{ __typename?: 'AccountEdge', node: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string } }, market?: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } | null } } | null> | null } | null } }> } | null };
 
 export const ExplorerPartyAssetsAccountsFragmentDoc = gql`
     fragment ExplorerPartyAssetsAccounts on AccountBalance {
@@ -30,9 +30,15 @@ export const ExplorerPartyAssetsAccountsFragmentDoc = gql`
   balance
   market {
     id
+    decimalPlaces
     tradableInstrument {
       instrument {
         name
+        product {
+          ... on Future {
+            quoteName
+          }
+        }
       }
     }
   }

--- a/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
+++ b/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
@@ -51,6 +51,7 @@ export const PartyAccounts = ({ accounts }: PartyAccountsProps) => {
 
           return (
             <TableRow
+              key={`pa-${account.asset.id}-${account.type}`}
               title={account.asset.name}
               id={`${accountTypeString[account.type]} ${m ? ` - ${m}` : ''}`}
             >

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -51,12 +51,12 @@ const Party = () => {
   const staking = (
     <section>
       {p?.stakingSummary?.currentStakeAvailable ? (
-        <p className="mt-4 leading-3">
+        <div className="mt-4 leading-3">
           <strong className="font-semibold">{t('Staking Balance: ')}</strong>
           <GovernanceAssetBalance
             price={p.stakingSummary.currentStakeAvailable}
           />
-        </p>
+        </div>
       ) : null}
     </section>
   );

--- a/apps/explorer/src/app/routes/txs/id/tx-details.tsx
+++ b/apps/explorer/src/app/routes/txs/id/tx-details.tsx
@@ -15,7 +15,7 @@ export const TxDetails = ({ txData, pubKey, className }: TxDetailsProps) => {
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
   return (
-    <section className="mb-10">
+    <section className="mb-10" key={txData.hash}>
       <TxDetailsWrapper height={txData.block} txData={txData} pubKey={pubKey} />
     </section>
   );


### PR DESCRIPTION
- feat(explorer): add basic table for all types in a batch
- feat(explorer): use marketlink for market ids in batch
- feat(explorer): break long batch errors and fix header alignment
- test(explorer): add tests for order summary component
- feat(explorer): split out batch rows for tests
- feat(explorer): add ordersummary
- feat(explorer): improve caching with some slight overfetching and cache config

# Related issues 🔗

Closes #2121

# Description ℹ️

Adds a Batch Market Instruction view

# Demo 📺
![TX 0x5FB18D2A613CC0BA431BC64FA1912DF425BC7A6920168AB2F1F90D51E9CB14B2 | Transactions | VEGA explorer](https://user-images.githubusercontent.com/6678/212671871-ae0ff329-8847-4bff-b8af-93feb3153b06.png)
![TX 0x68567E52CA9E44CA552A378758F2B554738344B133E38E84B153BE2EB2AA9EF3 | Transactions | VEGA explorer](https://user-images.githubusercontent.com/6678/212671887-b20b61a9-6728-4055-a816-8033bf0a7d2f.png)


