### PR TITLE
feat(2629): validator table - adjust the overstaked amount calculation

### DIFF
--- a/apps/token/src/routes/staking/node/validator-table.tsx
+++ b/apps/token/src/routes/staking/node/validator-table.tsx
@@ -209,7 +209,9 @@ export const ValidatorTable = ({
         <KeyValueTable data-testid="validator-table-penalties">
           <KeyValueTableRow>
             <span>{t('OVERSTAKED AMOUNT')}</span>
-            <span>{overstakedAmount.toString()}</span>
+            <span>
+              {formatNumber(toBigNum(overstakedAmount.toNumber(), decimals))}
+            </span>
           </KeyValueTableRow>
           <KeyValueTableRow>
             <span>{t('OVERSTAKED PENALTY')}</span>
@@ -224,7 +226,7 @@ export const ValidatorTable = ({
             </span>
           </KeyValueTableRow>
           <KeyValueTableRow>
-            <span>{t('PERFORMANCE PENALITY')}</span>
+            <span>{t('PERFORMANCE PENALTY')}</span>
             <span>{getPerformancePenalty(performanceScore)}</span>
           </KeyValueTableRow>
           <KeyValueTableRow noBorder={true}>

--- a/apps/token/src/routes/staking/shared.spec.ts
+++ b/apps/token/src/routes/staking/shared.spec.ts
@@ -91,19 +91,26 @@ describe('getOverstakingPenalty', () => {
 describe('getOverstakedAmount', () => {
   it('should return the overstaked amount', () => {
     expect(
-      getOverstakedAmount('0.21', Number(100).toString(), Number(20).toString())
-    ).toEqual(new BigNumber(1));
+      // If a validator score is 0, any amount staked on the node is considered overstaked
+      getOverstakedAmount('0', Number(100).toString(), Number(20).toString())
+    ).toEqual(new BigNumber(20));
     expect(
-      getOverstakedAmount('0.22', Number(100).toString(), Number(20).toString())
-    ).toEqual(new BigNumber(2));
+      getOverstakedAmount('0.05', Number(100).toString(), Number(20).toString())
+    ).toEqual(new BigNumber(15));
     expect(
-      getOverstakedAmount('0.30', Number(100).toString(), Number(20).toString())
+      getOverstakedAmount('0.1', Number(100).toString(), Number(20).toString())
     ).toEqual(new BigNumber(10));
+    expect(
+      getOverstakedAmount('0.15', Number(100).toString(), Number(20).toString())
+    ).toEqual(new BigNumber(5));
+    expect(
+      getOverstakedAmount('0.2', Number(100).toString(), Number(20).toString())
+    ).toEqual(new BigNumber(0));
   });
 
   it('should return 0 if the overstaked amount is negative', () => {
     expect(
-      getOverstakedAmount('0.19', Number(100).toString(), Number(20).toString())
+      getOverstakedAmount('0.8', Number(100).toString(), Number(20).toString())
     ).toEqual(new BigNumber(0));
   });
 });

--- a/apps/token/src/routes/staking/shared.ts
+++ b/apps/token/src/routes/staking/shared.ts
@@ -47,14 +47,13 @@ export const getOverstakedAmount = (
   totalStake: string,
   stakedOnNode: string
 ) => {
-  const amount = validatorScore
-    ? new BigNumber(validatorScore)
-        .times(new BigNumber(totalStake))
-        .minus(new BigNumber(stakedOnNode))
-        .dp(2)
+  const toReturn = validatorScore
+    ? new BigNumber(stakedOnNode).minus(
+        new BigNumber(validatorScore).times(new BigNumber(totalStake))
+      )
     : new BigNumber(0);
 
-  return amount.isNegative() ? new BigNumber(0) : amount;
+  return toReturn.isNegative() ? new BigNumber(0) : toReturn;
 };
 
 export const getOverstakingPenalty = (


### PR DESCRIPTION
# Related issues 🔗

Closes #2629

# Description ℹ️

Adjusted the logic behind the overstaked amount calculation. Previously, if a validator was overstaked, the calculation would return it as a negative amount, but we had some extra logic to return 0 if it was negative. An adjustment was needed so that the calculated amount being overstaked was positive.

# Demo 📺

<img width="1039" alt="Screenshot 2023-01-16 at 19 21 26" src="https://user-images.githubusercontent.com/2410498/212752581-fb5e8cb5-7060-4c36-94ee-e25e901fee3e.png">

