### PR TITLE
chore: add package json to hash

### DIFF
--- a/.github/workflows/capsule-cypress.yml
+++ b/.github/workflows/capsule-cypress.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             frontend-monorepo/node_modules
             /home/runner/.cache/Cypress
-          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock', 'frontend-monorepo/package.json') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/cypress-console-lite-e2e.yml
+++ b/.github/workflows/cypress-console-lite-e2e.yml
@@ -36,7 +36,7 @@ jobs:
           path: |
             frontend-monorepo/node_modules
             /home/runner/.cache/Cypress
-          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock', 'frontend-monorepo/package.json') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/cypress-explorer-e2e.yml
+++ b/.github/workflows/cypress-explorer-e2e.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             frontend-monorepo/node_modules
             /home/runner/.cache/Cypress
-          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock', 'frontend-monorepo/package.json') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/cypress-token-e2e.yml
+++ b/.github/workflows/cypress-token-e2e.yml
@@ -40,7 +40,7 @@ jobs:
           path: |
             frontend-monorepo/node_modules
             /home/runner/.cache/Cypress
-          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock', 'frontend-monorepo/package.json') }}
 
       # Install frontend dependencies
       - name: Install root dependencies

--- a/.github/workflows/cypress-trading-e2e.yml
+++ b/.github/workflows/cypress-trading-e2e.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             frontend-monorepo/node_modules
             /home/runner/.cache/Cypress
-          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock') }}
+          key: node_modules_cypress-${{ hashFiles('frontend-monorepo/yarn.lock', 'frontend-monorepo/package.json') }}
 
       # Install frontend dependencies
       - name: Install root dependencies


### PR DESCRIPTION
Resolves the issue when package.json change does not trigger yarn.lock change, but cache is created incorrectly and installs everything at each job.