### PR TITLE
feat(#2560): show market code and name in the trading header

### DIFF
--- a/apps/trading/client-pages/liquidity/liquidity.tsx
+++ b/apps/trading/client-pages/liquidity/liquidity.tsx
@@ -226,7 +226,7 @@ export const LiquidityViewContainer = ({
             market?.tradableInstrument.instrument.name &&
             marketId && (
               <Link to={Links[Routes.MARKET](marketId)}>
-                <UiToolkitLink className="sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+                <UiToolkitLink className="sm:text-sm md:text-md lg:text-lg flex items-center gap-2 whitespace-nowrap">
                   {`${market?.tradableInstrument.instrument.name} ${t(
                     'liquidity provision'
                   )}`}

--- a/apps/trading/client-pages/market/trade-market-header.tsx
+++ b/apps/trading/client-pages/market/trade-market-header.tsx
@@ -44,6 +44,7 @@ export const TradeMarketHeader = ({
     <Header
       title={
         <SelectMarketPopover
+          marketCode={market?.tradableInstrument.instrument.code || NO_MARKET}
           marketName={market?.tradableInstrument.instrument.name || NO_MARKET}
           onSelect={onSelect}
           onCellClick={onCellClick}

--- a/apps/trading/components/header/header.tsx
+++ b/apps/trading/components/header/header.tsx
@@ -10,8 +10,8 @@ interface TradeMarketHeaderProps {
 
 export const Header = ({ title, children }: TradeMarketHeaderProps) => {
   return (
-    <header className="w-screen xl:px-4 pt-3 border-b border-default">
-      <div className="xl:flex xl:gap-4  items-start">
+    <header className="w-screen xl:px-4 pt-2 border-b border-default">
+      <div className="xl:flex xl:gap-4 items-center">
         <div className="mb-4 xl:mb-0 px-4 xl:px-0">{title}</div>
         <div
           data-testid="header-summary"

--- a/apps/trading/components/select-market/select-market.tsx
+++ b/apps/trading/components/select-market/select-market.tsx
@@ -91,16 +91,16 @@ export const SelectAllMarketsTableBody = ({
 };
 
 export const SelectMarketPopover = ({
+  marketCode,
   marketName,
   onSelect,
   onCellClick,
 }: {
+  marketCode: string;
   marketName: string;
   onSelect: (id: string) => void;
   onCellClick: OnCellClickHandler;
 }) => {
-  const triggerClasses =
-    'sm:text-lg md:text-xl lg:text-2xl flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300 mt-1';
   const { pubKey } = useVegaWallet();
   const [open, setOpen] = useState(false);
   const inViewRoot = useRef<HTMLDivElement>(null);
@@ -150,8 +150,16 @@ export const SelectMarketPopover = ({
       open={open}
       onChange={setOpen}
       trigger={
-        <span className={triggerClasses}>
-          {marketName}
+        <span className="flex items-center gap-2">
+          <span>
+            <span className="sm:text-sm md:text-md lg:text-lg flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+              {marketCode}
+            </span>
+            <span className="sm:text-xs text-sm flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300 pb-2">
+              {marketName}
+            </span>
+          </span>
+
           <Icon name="chevron-down" className={iconClass} size={6} />
         </span>
       }

--- a/apps/trading/components/select-market/select-market.tsx
+++ b/apps/trading/components/select-market/select-market.tsx
@@ -152,10 +152,10 @@ export const SelectMarketPopover = ({
       trigger={
         <span className="flex items-center gap-2">
           <span>
-            <span className="sm:text-sm md:text-md lg:text-lg flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300">
+            <span className="sm:text-sm md:text-md lg:text-lg flex items-center gap-2 whitespace-nowrap">
               {marketCode}
             </span>
-            <span className="sm:text-xs text-sm flex items-center gap-2 whitespace-nowrap hover:text-neutral-500 dark:hover:text-neutral-300 pb-2">
+            <span className="sm:text-xs text-sm flex items-center gap-2 whitespace-nowrap text-neutral-500 dark:text-neutral-400 pb-2">
               {marketName}
             </span>
           </span>

--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
@@ -70,7 +70,7 @@ const MobileWalletButton = ({
     [selectPubKey]
   );
   return (
-    <div className="md:hidden overflow-hidden flex" ref={setContainer}>
+    <div className="lg:hidden overflow-hidden flex" ref={setContainer}>
       <Drawer
         dataTestId="wallets-drawer"
         open={drawerOpen}
@@ -141,7 +141,7 @@ export const VegaWalletConnectButton = () => {
   if (isConnected && pubKeys) {
     return (
       <>
-        <div className="hidden md:block">
+        <div className="hidden lg:block">
           <DropdownMenu open={dropdownOpen}>
             <DropdownMenuTrigger
               data-testid="manage-vega-wallet"
@@ -183,7 +183,7 @@ export const VegaWalletConnectButton = () => {
         data-testid="connect-vega-wallet"
         onClick={openVegaWalletDialog}
         size="sm"
-        className="hidden md:block"
+        className="hidden lg:block"
       >
         <span className="whitespace-nowrap">{t('Connect Vega wallet')}</span>
       </Button>


### PR DESCRIPTION
# Related issues 🔗

Closes #2560 

# Description ℹ️

Show the market code and name in the trading header.

# Demo 📺

<img width="1680" alt="Screenshot 2023-01-18 at 12 37 21" src="https://user-images.githubusercontent.com/16125548/213173850-7a69c79e-36bc-4386-884d-e8fa7929d956.png">

# Technical 👨‍🔧

+ Fix navbar wrapping

<img width="870" alt="image" src="https://user-images.githubusercontent.com/16125548/213174085-17c8e676-fd3a-4502-b2d1-8c870defe8fa.png">
<img width="960" alt="Screenshot 2023-01-18 at 12 40 51" src="https://user-images.githubusercontent.com/16125548/213174118-c9b10631-bdbb-4c14-889b-21b19b856d7f.png">

