### PR TITLE
fix(explorer): add workaround for v53 misreporting total node count

### DIFF
--- a/apps/explorer/.env.mainnet
+++ b/apps/explorer/.env.mainnet
@@ -8,3 +8,6 @@ NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https:
 NX_VEGA_ENV=MAINNET
 NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
 NX_BLOCK_EXPLORER=https://be.explorer.vega.xyz/rest/
+
+# 0.53.0 misreports total nodes, including ex-validators
+NX_HACK_53_TOTAL_NODES=2

--- a/libs/network-stats/src/config/stats-fields.ts
+++ b/libs/network-stats/src/config/stats-fields.ts
@@ -39,6 +39,14 @@ export const statsFields: { [key in keyof Stats]: StatFields[] } = {
   totalNodes: [
     {
       title: t('Total nodes'),
+      formatter: (nodes: number) => {
+        // Hack: 0.53.0 misreports node count, included departed validators. This hack fixes that by changing the number
+        // Should be removed when anything later than 0.53.0
+        const hackReduceNodesBy = process.env.NX_HACK_53_TOTAL_NODES
+          ? parseInt(process.env.NX_HACK_53_TOTAL_NODES)
+          : 0;
+        return nodes - hackReduceNodesBy;
+      },
       promoted: true,
       description: t('The total number of nodes registered on the network'),
     },


### PR DESCRIPTION
# Related issues 🔗

Closes #2453

# Description ℹ️

Adds a new environment variable that is used to fix the number of total nodes reported on explorer when it is connected to older networks.

