### PR TITLE
feat(#1791): block height check

### DIFF
--- a/apps/trading/components/footer/footer.spec.tsx
+++ b/apps/trading/components/footer/footer.spec.tsx
@@ -1,26 +1,59 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Footer } from './footer';
-import { useEnvironment } from '@vegaprotocol/environment';
+import { Footer, NodeHealth } from './footer';
+import type { NodeHealth as HealthType } from '@vegaprotocol/environment';
+import { Health, useEnvironment } from '@vegaprotocol/environment';
 
 jest.mock('@vegaprotocol/environment');
 
 describe('Footer', () => {
-  it('renders a button to open node switcher', () => {
+  it('can open node switcher by clicking the node url', () => {
     const mockOpenNodeSwitcher = jest.fn();
     const node = 'n99.somenetwork.vega.xyz';
-    const nodeUrl = `https://${node}`;
 
     // @ts-ignore mock env hook
     useEnvironment.mockImplementation(() => ({
       VEGA_URL: `https://api.${node}/graphql`,
+      nodeHealth: Health.Good,
       setNodeSwitcherOpen: mockOpenNodeSwitcher,
     }));
 
     render(<Footer />);
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText(node));
     expect(mockOpenNodeSwitcher).toHaveBeenCalled();
-    const link = screen.getByText(node);
-    expect(link).toHaveAttribute('href', nodeUrl);
   });
+
+  it('can open node switcher by clicking health', () => {
+    const mockOpenNodeSwitcher = jest.fn();
+    const node = 'n99.somenetwork.vega.xyz';
+
+    // @ts-ignore mock env hook
+    useEnvironment.mockImplementation(() => ({
+      VEGA_URL: `https://api.${node}/graphql`,
+      nodeHealth: Health.Good,
+      setNodeSwitcherOpen: mockOpenNodeSwitcher,
+    }));
+
+    render(<Footer />);
+
+    fireEvent.click(screen.getByText(Health.Good));
+    expect(mockOpenNodeSwitcher).toHaveBeenCalled();
+  });
+});
+
+describe('NodeHealth', () => {
+  const classmap: {
+    [H in HealthType]: string;
+  } = {
+    [Health.Good]: 'bg-success',
+    [Health.Bad]: 'bg-warning',
+    [Health.Critical]: 'bg-danger',
+  };
+  it.each(Object.keys(Health))(
+    'renders an indicator color for %s health',
+    (health) => {
+      render(<NodeHealth health={health} openNodeSwitcher={jest.fn()} />);
+      expect(screen.getByTestId('indicator')).toHaveClass(classmap[health]);
+    }
+  );
 });

--- a/apps/trading/components/footer/footer.spec.tsx
+++ b/apps/trading/components/footer/footer.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Footer, NodeHealth } from './footer';
-import type { NodeHealth as HealthType } from '@vegaprotocol/environment';
-import { Health, useEnvironment } from '@vegaprotocol/environment';
+import { useEnvironment } from '@vegaprotocol/environment';
 
 jest.mock('@vegaprotocol/environment');
 
@@ -13,7 +12,7 @@ describe('Footer', () => {
     // @ts-ignore mock env hook
     useEnvironment.mockImplementation(() => ({
       VEGA_URL: `https://api.${node}/graphql`,
-      nodeHealth: Health.Good,
+      blockDifference: 0,
       setNodeSwitcherOpen: mockOpenNodeSwitcher,
     }));
 
@@ -30,31 +29,30 @@ describe('Footer', () => {
     // @ts-ignore mock env hook
     useEnvironment.mockImplementation(() => ({
       VEGA_URL: `https://api.${node}/graphql`,
-      nodeHealth: Health.Good,
+      blockDifference: 0,
       setNodeSwitcherOpen: mockOpenNodeSwitcher,
     }));
 
     render(<Footer />);
 
-    fireEvent.click(screen.getByText(Health.Good));
+    fireEvent.click(screen.getByText('Operational'));
     expect(mockOpenNodeSwitcher).toHaveBeenCalled();
   });
 });
 
 describe('NodeHealth', () => {
-  const classmap: {
-    [H in HealthType]: string;
-  } = {
-    [Health.Good]: 'bg-success',
-    [Health.Bad]: 'bg-warning',
-    [Health.Critical]: 'bg-danger',
-  };
-  it.each(Object.keys(Health))(
-    'renders an indicator color for %s health',
-    (h) => {
-      const health = h as HealthType;
-      render(<NodeHealth health={health} openNodeSwitcher={jest.fn()} />);
-      expect(screen.getByTestId('indicator')).toHaveClass(classmap[health]);
+  const cases = [
+    { diff: 0, classname: 'bg-success', text: 'Operational' },
+    { diff: 5, classname: 'bg-warning', text: '5 Blocks behind' },
+    { diff: -1, classname: 'bg-danger', text: 'Non operational' },
+  ];
+  it.each(cases)(
+    'renders correct text and indicator color for $diff block difference',
+    (elem) => {
+      console.log(elem);
+      render(<NodeHealth blockDiff={elem.diff} openNodeSwitcher={jest.fn()} />);
+      expect(screen.getByTestId('indicator')).toHaveClass(elem.classname);
+      expect(screen.getByText(elem.text)).toBeInTheDocument();
     }
   );
 });

--- a/apps/trading/components/footer/footer.spec.tsx
+++ b/apps/trading/components/footer/footer.spec.tsx
@@ -51,7 +51,8 @@ describe('NodeHealth', () => {
   };
   it.each(Object.keys(Health))(
     'renders an indicator color for %s health',
-    (health) => {
+    (h) => {
+      const health = h as HealthType;
       render(<NodeHealth health={health} openNodeSwitcher={jest.fn()} />);
       expect(screen.getByTestId('indicator')).toHaveClass(classmap[health]);
     }

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,5 +1,5 @@
 import { useEnvironment } from '@vegaprotocol/environment';
-import { t } from '@vegaprotocol/react-helpers';
+import { t, useNavigatorOnline } from '@vegaprotocol/react-helpers';
 import { ButtonLink, Indicator, Intent } from '@vegaprotocol/ui-toolkit';
 
 export const Footer = () => {
@@ -49,10 +49,15 @@ export const NodeHealth = ({
   blockDiff,
   openNodeSwitcher,
 }: NodeHealthProps) => {
+  const online = useNavigatorOnline();
+
   let intent = Intent.Success;
   let text = 'Operational';
 
-  if (blockDiff < 0) {
+  if (!online) {
+    text = t('Offline');
+    intent = Intent.Danger;
+  } else if (blockDiff < 0) {
     // Block height query failed and null was returned
     text = t('Non operational');
     intent = Intent.Danger;

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,9 +1,9 @@
-import type { NodeHealth as NodeHealthType } from '@vegaprotocol/environment';
 import { useEnvironment } from '@vegaprotocol/environment';
+import { t } from '@vegaprotocol/react-helpers';
 import { ButtonLink, Indicator, Intent } from '@vegaprotocol/ui-toolkit';
 
 export const Footer = () => {
-  const { VEGA_URL, nodeHealth, setNodeSwitcherOpen } = useEnvironment();
+  const { VEGA_URL, blockDifference, setNodeSwitcherOpen } = useEnvironment();
   return (
     <footer className="px-4 py-1 text-xs border-t border-default">
       <div className="flex justify-between">
@@ -11,7 +11,7 @@ export const Footer = () => {
           {VEGA_URL && (
             <>
               <NodeHealth
-                health={nodeHealth}
+                blockDiff={blockDifference}
                 openNodeSwitcher={setNodeSwitcherOpen}
               />
               {' | '}
@@ -38,21 +38,33 @@ const NodeUrl = ({ url, openNodeSwitcher }: NodeUrlProps) => {
 
 interface NodeHealthProps {
   openNodeSwitcher: () => void;
-  health: NodeHealthType;
+  blockDiff: number;
 }
 
-export const NodeHealth = ({ health, openNodeSwitcher }: NodeHealthProps) => {
+// How many blocks behind the most advanced block that is
+// deemed acceptable for "Good" status
+const BLOCK_THRESHOLD = 3;
+
+export const NodeHealth = ({
+  blockDiff,
+  openNodeSwitcher,
+}: NodeHealthProps) => {
   let intent = Intent.Success;
-  if (health === 'Critical') {
+  let text = 'Operational';
+
+  if (blockDiff < 0) {
+    // Block height query failed and null was returned
+    text = t('Non operational');
     intent = Intent.Danger;
-  } else if (health === 'Bad') {
+  } else if (blockDiff >= BLOCK_THRESHOLD) {
+    text = t(`${blockDiff} Blocks behind`);
     intent = Intent.Warning;
   }
 
   return (
     <span>
       <Indicator variant={intent} />
-      <ButtonLink onClick={openNodeSwitcher}>{health}</ButtonLink>
+      <ButtonLink onClick={openNodeSwitcher}>{text}</ButtonLink>
     </span>
   );
 };

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,6 +1,5 @@
 import { useEnvironment } from '@vegaprotocol/environment';
-import { t } from '@vegaprotocol/react-helpers';
-import { ButtonLink, Indicator, Intent, Link } from '@vegaprotocol/ui-toolkit';
+import { ButtonLink, Indicator, Intent } from '@vegaprotocol/ui-toolkit';
 
 export const Footer = () => {
   const { VEGA_URL, setNodeSwitcherOpen } = useEnvironment();
@@ -8,27 +7,36 @@ export const Footer = () => {
     <footer className="px-4 py-1 text-xs border-t border-default">
       <div className="flex justify-between">
         <div className="flex gap-2">
-          <NodeHealth />
-          {VEGA_URL && <NodeUrl url={VEGA_URL} />}
-          <ButtonLink onClick={setNodeSwitcherOpen}>{t('Change')}</ButtonLink>
+          {VEGA_URL && (
+            <>
+              <NodeHealth openNodeSwitcher={setNodeSwitcherOpen} />
+              {' | '}
+              <NodeUrl url={VEGA_URL} openNodeSwitcher={setNodeSwitcherOpen} />
+            </>
+          )}
         </div>
       </div>
     </footer>
   );
 };
 
-const NodeUrl = ({ url }: { url: string }) => {
+interface NodeUrlProps {
+  url: string;
+  openNodeSwitcher: () => void;
+}
+
+const NodeUrl = ({ url, openNodeSwitcher }: NodeUrlProps) => {
   // get base url from api url, api sub domain
   const urlObj = new URL(url);
   const nodeUrl = urlObj.origin.replace(/^[^.]+\./g, '');
-  return (
-    <Link href={'https://' + nodeUrl} target="_blank">
-      {nodeUrl}
-    </Link>
-  );
+  return <ButtonLink onClick={openNodeSwitcher}>{nodeUrl}</ButtonLink>;
 };
 
-const NodeHealth = () => {
+interface NodeHealthProps {
+  openNodeSwitcher: () => void;
+}
+
+const NodeHealth = ({ openNodeSwitcher }: NodeHealthProps) => {
   const { nodeHealth } = useEnvironment();
 
   let intent = Intent.Success;
@@ -38,5 +46,10 @@ const NodeHealth = () => {
     intent = Intent.Warning;
   }
 
-  return <Indicator variant={intent} />;
+  return (
+    <span>
+      <Indicator variant={intent} />
+      <ButtonLink onClick={openNodeSwitcher}>{nodeHealth}</ButtonLink>
+    </span>
+  );
 };

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,15 +1,19 @@
+import type { NodeHealthType } from '@vegaprotocol/environment';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { ButtonLink, Indicator, Intent } from '@vegaprotocol/ui-toolkit';
 
 export const Footer = () => {
-  const { VEGA_URL, setNodeSwitcherOpen } = useEnvironment();
+  const { VEGA_URL, nodeHealth, setNodeSwitcherOpen } = useEnvironment();
   return (
     <footer className="px-4 py-1 text-xs border-t border-default">
       <div className="flex justify-between">
         <div className="flex gap-2">
           {VEGA_URL && (
             <>
-              <NodeHealth openNodeSwitcher={setNodeSwitcherOpen} />
+              <NodeHealth
+                health={nodeHealth}
+                openNodeSwitcher={setNodeSwitcherOpen}
+              />
               {' | '}
               <NodeUrl url={VEGA_URL} openNodeSwitcher={setNodeSwitcherOpen} />
             </>
@@ -34,22 +38,21 @@ const NodeUrl = ({ url, openNodeSwitcher }: NodeUrlProps) => {
 
 interface NodeHealthProps {
   openNodeSwitcher: () => void;
+  health: NodeHealthType;
 }
 
-const NodeHealth = ({ openNodeSwitcher }: NodeHealthProps) => {
-  const { nodeHealth } = useEnvironment();
-
+export const NodeHealth = ({ health, openNodeSwitcher }: NodeHealthProps) => {
   let intent = Intent.Success;
-  if (nodeHealth === 'Critical') {
+  if (health === 'Critical') {
     intent = Intent.Danger;
-  } else if (nodeHealth === 'Bad') {
+  } else if (health === 'Bad') {
     intent = Intent.Warning;
   }
 
   return (
     <span>
       <Indicator variant={intent} />
-      <ButtonLink onClick={openNodeSwitcher}>{nodeHealth}</ButtonLink>
+      <ButtonLink onClick={openNodeSwitcher}>{health}</ButtonLink>
     </span>
   );
 };

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import type { NodeHealthType } from '@vegaprotocol/environment';
+import type { NodeHealth as NodeHealthType } from '@vegaprotocol/environment';
 import { useEnvironment } from '@vegaprotocol/environment';
 import { ButtonLink, Indicator, Intent } from '@vegaprotocol/ui-toolkit';
 

--- a/apps/trading/components/footer/footer.tsx
+++ b/apps/trading/components/footer/footer.tsx
@@ -1,6 +1,6 @@
 import { useEnvironment } from '@vegaprotocol/environment';
 import { t } from '@vegaprotocol/react-helpers';
-import { ButtonLink, Link } from '@vegaprotocol/ui-toolkit';
+import { ButtonLink, Indicator, Intent, Link } from '@vegaprotocol/ui-toolkit';
 
 export const Footer = () => {
   const { VEGA_URL, setNodeSwitcherOpen } = useEnvironment();
@@ -8,6 +8,7 @@ export const Footer = () => {
     <footer className="px-4 py-1 text-xs border-t border-default">
       <div className="flex justify-between">
         <div className="flex gap-2">
+          <NodeHealth />
           {VEGA_URL && <NodeUrl url={VEGA_URL} />}
           <ButtonLink onClick={setNodeSwitcherOpen}>{t('Change')}</ButtonLink>
         </div>
@@ -25,4 +26,17 @@ const NodeUrl = ({ url }: { url: string }) => {
       {nodeUrl}
     </Link>
   );
+};
+
+const NodeHealth = () => {
+  const { nodeHealth } = useEnvironment();
+
+  let intent = Intent.Success;
+  if (nodeHealth === 'Critical') {
+    intent = Intent.Danger;
+  } else if (nodeHealth === 'Bad') {
+    intent = Intent.Warning;
+  }
+
+  return <Indicator variant={intent} />;
 };

--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -20,7 +20,11 @@ const isBrowser = typeof window !== 'undefined';
 
 const NOT_FOUND = 'NotFound';
 
-export function createClient(base?: string, cacheConfig?: InMemoryCacheConfig) {
+export function createClient(
+  base?: string,
+  cacheConfig?: InMemoryCacheConfig,
+  connectToDevTools = true
+) {
   if (!base) {
     throw new Error('Base must be passed into createClient!');
   }
@@ -87,6 +91,7 @@ export function createClient(base?: string, cacheConfig?: InMemoryCacheConfig) {
   return new ApolloClient({
     link: from([errorLink, composedTimeoutLink, retryLink, splitLink]),
     cache: new InMemoryCache(cacheConfig),
+    connectToDevTools,
   });
 }
 

--- a/libs/apollo-client/src/lib/apollo-client.ts
+++ b/libs/apollo-client/src/lib/apollo-client.ts
@@ -20,7 +20,7 @@ const isBrowser = typeof window !== 'undefined';
 
 const NOT_FOUND = 'NotFound';
 
-type ClientOptions = {
+export type ClientOptions = {
   url?: string;
   cacheConfig?: InMemoryCacheConfig;
   retry?: boolean;

--- a/libs/environment/src/components/network-loader/network-loader.spec.tsx
+++ b/libs/environment/src/components/network-loader/network-loader.spec.tsx
@@ -46,7 +46,10 @@ describe('Network loader', () => {
     render(
       <NetworkLoader skeleton={SKELETON_TEXT}>{SUCCESS_TEXT}</NetworkLoader>
     );
-    expect(createClient).toHaveBeenCalledWith('http://vega.node', undefined);
+    expect(createClient).toHaveBeenCalledWith({
+      url: 'http://vega.node',
+      cacheConfig: undefined,
+    });
     expect(await screen.findByText(SUCCESS_TEXT)).toBeInTheDocument();
   });
 });

--- a/libs/environment/src/components/network-loader/network-loader.tsx
+++ b/libs/environment/src/components/network-loader/network-loader.tsx
@@ -20,7 +20,10 @@ export function NetworkLoader({
 
   const client = useMemo(() => {
     if (VEGA_URL) {
-      return createClient(VEGA_URL, cache);
+      return createClient({
+        url: VEGA_URL,
+        cacheConfig: cache,
+      });
     }
     return undefined;
   }, [VEGA_URL, cache]);

--- a/libs/environment/src/hooks/index.ts
+++ b/libs/environment/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-environment';
 export * from './use-links';
+export * from './use-node-health';

--- a/libs/environment/src/hooks/use-config.tsx
+++ b/libs/environment/src/hooks/use-config.tsx
@@ -18,6 +18,9 @@ type UseConfigOptions = {
   defaultConfig?: Configuration;
 };
 
+/**
+ * Fetch list of hosts from the VEGA_CONFIG_URL
+ */
 export const useConfig = (
   { environment, defaultConfig }: UseConfigOptions,
   onError: (errorType: ErrorType) => void

--- a/libs/environment/src/hooks/use-environment-errors.spec.tsx
+++ b/libs/environment/src/hooks/use-environment-errors.spec.tsx
@@ -101,6 +101,16 @@ beforeEach(() => {
 });
 
 describe('throws error', () => {
+  const consoleError = console.error;
+
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+
+  afterAll(() => {
+    console.error = consoleError;
+  });
+
   beforeEach(() => {
     // @ts-ignore: typescript doesn't recognize the mock implementation
     global.fetch.mockImplementation(setupFetch());
@@ -127,6 +137,7 @@ describe('throws error', () => {
   });
 
   beforeEach(() => jest.resetModules()); // clears the cache of the modules
+
   it('throws a validation error when NX_ETHERSCAN_URL is not a valid url', () => {
     process.env['NX_ETHERSCAN_URL'] = 'invalid-url';
     const result = () =>

--- a/libs/environment/src/hooks/use-environment.spec.tsx
+++ b/libs/environment/src/hooks/use-environment.spec.tsx
@@ -8,7 +8,6 @@ import { Networks, ErrorType } from '../types';
 import type { MockRequestConfig } from './mocks/apollo-client';
 import createMockClient from './mocks/apollo-client';
 import { getErrorByType } from '../utils/validate-node';
-import { Health } from './use-node-health';
 
 jest.mock('@vegaprotocol/apollo-client');
 
@@ -45,7 +44,7 @@ const mockEnvironmentState = {
   GITHUB_FEEDBACK_URL: 'https://github.com/test/feedback',
   MAINTENANCE_PAGE: false,
   setNodeSwitcherOpen: noop,
-  nodeHealth: Health.Good,
+  blockDifference: 0,
   networkError: undefined,
 };
 

--- a/libs/environment/src/hooks/use-environment.spec.tsx
+++ b/libs/environment/src/hooks/use-environment.spec.tsx
@@ -8,6 +8,7 @@ import { Networks, ErrorType } from '../types';
 import type { MockRequestConfig } from './mocks/apollo-client';
 import createMockClient from './mocks/apollo-client';
 import { getErrorByType } from '../utils/validate-node';
+import { Health } from './use-node-health';
 
 jest.mock('@vegaprotocol/apollo-client');
 
@@ -42,7 +43,9 @@ const mockEnvironmentState = {
   GIT_ORIGIN_URL: 'https://github.com/test/repo',
   GIT_COMMIT_HASH: 'abcde01234',
   GITHUB_FEEDBACK_URL: 'https://github.com/test/feedback',
+  MAINTENANCE_PAGE: false,
   setNodeSwitcherOpen: noop,
+  nodeHealth: Health.Good,
   networkError: undefined,
 };
 
@@ -118,6 +121,7 @@ beforeEach(() => {
   process.env['NX_GIT_COMMIT_HASH'] = mockEnvironmentState.GIT_COMMIT_HASH;
   process.env['NX_GITHUB_FEEDBACK_URL'] =
     mockEnvironmentState.GITHUB_FEEDBACK_URL;
+  process.env['NX_MAINTENANCE_PAGE'] = 'false';
 });
 
 afterAll(() => {

--- a/libs/environment/src/hooks/use-environment.tsx
+++ b/libs/environment/src/hooks/use-environment.tsx
@@ -33,8 +33,17 @@ type EnvironmentProviderProps = {
   children?: ReactNode;
 };
 
+const NodeHealth = {
+  Good: 'Good',
+  Bad: 'Bad',
+  Critical: 'Critical',
+} as const;
+type NodeHealthKeys = keyof typeof NodeHealth;
+type Health = typeof NodeHealth[NodeHealthKeys];
+
 export type EnvironmentState = Environment & {
   networkError?: ErrorType;
+  nodeHealth: keyof typeof NodeHealth;
   setNodeSwitcherOpen: () => void;
 };
 
@@ -57,6 +66,7 @@ export const EnvironmentProvider = ({
 }: EnvironmentProviderProps) => {
   const [vegaUrl, setVegaUrl] = useLocalStorage('vega_url');
   const [networkError, setNetworkError] = useState<undefined | ErrorType>();
+  const [nodeHealth, setNodeHealth] = useState<Health>(NodeHealth.Good);
   const [isNodeSwitcherOpen, setNodeSwitcherIsOpen] = useState(false);
   const [environment, updateEnvironment] = useState<Environment>(
     compileEnvironment(definitions, vegaUrl)
@@ -145,6 +155,7 @@ export const EnvironmentProvider = ({
       value={{
         ...environment,
         networkError,
+        nodeHealth,
         setNodeSwitcherOpen: () => setNodeSwitcherOpen(true),
       }}
     >

--- a/libs/environment/src/hooks/use-environment.tsx
+++ b/libs/environment/src/hooks/use-environment.tsx
@@ -37,6 +37,7 @@ export type EnvironmentState = Environment & {
   configLoading: boolean;
   networkError?: ErrorType;
   blockDifference: number;
+  nodeSwitcherOpen: boolean;
   setNodeSwitcherOpen: () => void;
 };
 
@@ -146,10 +147,11 @@ export const EnvironmentProvider = ({
   return (
     <EnvironmentContext.Provider
       value={{
-        configLoading: loading,
         ...environment,
+        configLoading: loading,
         networkError,
         blockDifference,
+        nodeSwitcherOpen: isNodeSwitcherOpen,
         setNodeSwitcherOpen: () => setNodeSwitcherOpen(true),
       }}
     >

--- a/libs/environment/src/hooks/use-environment.tsx
+++ b/libs/environment/src/hooks/use-environment.tsx
@@ -34,6 +34,7 @@ type EnvironmentProviderProps = {
 };
 
 export type EnvironmentState = Environment & {
+  configLoading: boolean;
   networkError?: ErrorType;
   blockDifference: number;
   setNodeSwitcherOpen: () => void;
@@ -145,6 +146,7 @@ export const EnvironmentProvider = ({
   return (
     <EnvironmentContext.Provider
       value={{
+        configLoading: loading,
         ...environment,
         networkError,
         blockDifference,

--- a/libs/environment/src/hooks/use-environment.tsx
+++ b/libs/environment/src/hooks/use-environment.tsx
@@ -25,7 +25,6 @@ import type {
   NodeData,
   Configuration,
 } from '../types';
-import type { NodeHealth } from './use-node-health';
 import { useNodeHealth } from './use-node-health';
 
 type EnvironmentProviderProps = {
@@ -36,7 +35,7 @@ type EnvironmentProviderProps = {
 
 export type EnvironmentState = Environment & {
   networkError?: ErrorType;
-  nodeHealth: NodeHealth;
+  blockDifference: number;
   setNodeSwitcherOpen: () => void;
 };
 
@@ -85,7 +84,7 @@ export const EnvironmentProvider = ({
     environment.MAINTENANCE_PAGE
   );
 
-  const nodeHealth = useNodeHealth(clients, environment.VEGA_URL);
+  const blockDifference = useNodeHealth(clients, environment.VEGA_URL);
 
   const nodeKeys = Object.keys(nodes);
 
@@ -148,7 +147,7 @@ export const EnvironmentProvider = ({
       value={{
         ...environment,
         networkError,
-        nodeHealth,
+        blockDifference,
         setNodeSwitcherOpen: () => setNodeSwitcherOpen(true),
       }}
     >

--- a/libs/environment/src/hooks/use-environment.tsx
+++ b/libs/environment/src/hooks/use-environment.tsx
@@ -25,8 +25,6 @@ import type {
   NodeData,
   Configuration,
 } from '../types';
-import { useLocalStorage } from '@vegaprotocol/react-helpers';
-import type { createClient } from '@vegaprotocol/apollo-client';
 import type { NodeHealth } from './use-node-health';
 import { useNodeHealth } from './use-node-health';
 
@@ -59,11 +57,10 @@ export const EnvironmentProvider = ({
   definitions,
   children,
 }: EnvironmentProviderProps) => {
-  const [vegaUrl, setVegaUrl] = useLocalStorage('vega_url');
   const [networkError, setNetworkError] = useState<undefined | ErrorType>();
   const [isNodeSwitcherOpen, setNodeSwitcherIsOpen] = useState(false);
   const [environment, updateEnvironment] = useState<Environment>(
-    compileEnvironment(definitions, vegaUrl)
+    compileEnvironment(definitions)
   );
   const setNodeSwitcherOpen = useCallback((isOpen: boolean) => {
     if (!('Cypress' in window)) {
@@ -104,7 +101,6 @@ export const EnvironmentProvider = ({
           ...prevEnvironment,
           VEGA_URL: url,
         }));
-        setVegaUrl(url);
       }
     }
 
@@ -164,7 +160,6 @@ export const EnvironmentProvider = ({
         config={config}
         onConnect={(url) => {
           updateEnvironment((env) => ({ ...env, VEGA_URL: url }));
-          setVegaUrl(url);
         }}
       />
       {children}

--- a/libs/environment/src/hooks/use-node-health.spec.tsx
+++ b/libs/environment/src/hooks/use-node-health.spec.tsx
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
 import { useNodeHealth, Health, INTERVAL_TIME } from './use-node-health';
-import type { StatisticsQuery } from '../utils/__generated__/Node';
 import type { createClient } from '@vegaprotocol/apollo-client';
 import type { ClientCollection } from './use-nodes';
 
@@ -37,7 +36,6 @@ function createErroringClient() {
   } as unknown as ReturnType<typeof createClient>;
 }
 
-const INTERVAL = 1000;
 const CURRENT_URL = 'https://n01.test.com';
 
 describe('useNodeHealth', () => {

--- a/libs/environment/src/hooks/use-node-health.spec.tsx
+++ b/libs/environment/src/hooks/use-node-health.spec.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook } from '@testing-library/react';
+import { useNodeHealth, Health, INTERVAL_TIME } from './use-node-health';
+import type { StatisticsQuery } from '../utils/__generated__/Node';
+import type { createClient } from '@vegaprotocol/apollo-client';
+import type { ClientCollection } from './use-nodes';
+
+function setup(...args: Parameters<typeof useNodeHealth>) {
+  return renderHook(() => useNodeHealth(...args));
+}
+
+function createMockClient(blockHeight: string) {
+  return {
+    query: () =>
+      Promise.resolve({
+        data: {
+          statistics: {
+            chainId: 'chain-id',
+            blockHeight,
+          },
+        },
+      }),
+  } as unknown as ReturnType<typeof createClient>;
+}
+
+function createRejectingClient() {
+  return {
+    query: () => Promise.reject(new Error('request failed')),
+  } as unknown as ReturnType<typeof createClient>;
+}
+
+function createErroringClient() {
+  return {
+    query: () =>
+      Promise.resolve({
+        error: new Error('failed'),
+      }),
+  } as unknown as ReturnType<typeof createClient>;
+}
+
+const INTERVAL = 1000;
+const CURRENT_URL = 'https://n01.test.com';
+
+describe('useNodeHealth', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it('health is good if block height is equal', async () => {
+    const clientCollection: ClientCollection = {
+      [CURRENT_URL]: createMockClient('100'),
+      'https://n02.test.com': createMockClient('100'),
+      'https://n03.test.com': createMockClient('100'),
+    };
+    const { result } = setup(clientCollection, CURRENT_URL);
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL_TIME);
+    });
+    expect(result.current).toBe(Health.Good);
+  });
+
+  it('health is good if block height with three blocks', async () => {
+    const clientCollection: ClientCollection = {
+      [CURRENT_URL]: createMockClient('97'),
+      'https://n02.test.com': createMockClient('98'),
+      'https://n03.test.com': createMockClient('100'),
+    };
+    const { result } = setup(clientCollection, CURRENT_URL);
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL_TIME);
+    });
+    expect(result.current).toBe(Health.Good);
+  });
+
+  it('health is bad if block height behind', async () => {
+    const clientCollection: ClientCollection = {
+      [CURRENT_URL]: createMockClient('100'),
+      'https://n02.test.com': createMockClient('200'),
+      'https://n03.test.com': createMockClient('300'),
+    };
+    const { result } = setup(clientCollection, CURRENT_URL);
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL_TIME);
+    });
+    expect(result.current).toBe(Health.Bad);
+  });
+
+  it('health is critical if query rejects', async () => {
+    const clientCollection: ClientCollection = {
+      [CURRENT_URL]: createRejectingClient(),
+      'https://n02.test.com': createMockClient('200'),
+      'https://n03.test.com': createMockClient('102'),
+    };
+    const { result } = setup(clientCollection, CURRENT_URL);
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL_TIME);
+    });
+    expect(result.current).toBe(Health.Critical);
+  });
+
+  it('health is critical if query returns an error', async () => {
+    const clientCollection: ClientCollection = {
+      [CURRENT_URL]: createErroringClient(),
+      'https://n02.test.com': createMockClient('200'),
+      'https://n03.test.com': createMockClient('102'),
+    };
+    const { result } = setup(clientCollection, CURRENT_URL);
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL_TIME);
+    });
+    expect(result.current).toBe(Health.Critical);
+  });
+});

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -7,7 +7,7 @@ import { StatisticsDocument } from '../utils/__generated__/Node';
 import type { ClientCollection } from './use-nodes';
 
 // How often to query other nodes
-export const INTERVAL_TIME = 15 * 1000;
+export const INTERVAL_TIME = 30 * 1000;
 // How many blocks behind the most advanced block that is
 // deemed acceptable for "Good" status
 const BLOCK_THRESHOLD = 3;
@@ -38,6 +38,7 @@ export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
           query: StatisticsDocument,
           fetchPolicy: 'no-cache', // always fetch and never cache
         });
+        console.log(result);
 
         if (!result) return null;
         if (result.error) return null;

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -15,7 +15,7 @@ export const NODE_SUBSET_COUNT = 5;
 // to calculate and return the difference between the most advanced block
 // and the block height of the current node
 export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
-  const [blockDiff, setBlockDiff] = useState(10);
+  const [blockDiff, setBlockDiff] = useState(0);
 
   useEffect(() => {
     if (!clients || !vegaUrl) return;

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -40,7 +40,7 @@ export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
         });
 
         if (!result) return null;
-        if (!result.error) return null;
+        if (result.error) return null;
         return result;
       } catch {
         return null;
@@ -48,12 +48,16 @@ export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
     };
 
     const getBlockHeights = async () => {
-      const nodes = randomSubset(Object.keys(clients), NODE_SUBSET_COUNT);
+      const nodes = Object.keys(clients).filter((key) => key !== vegaUrl);
+
+      // make sure that your current vega url is always included
+      // so we can compare later
+      const testNodes = [vegaUrl, ...randomSubset(nodes, NODE_SUBSET_COUNT)];
       const result = await Promise.all(
-        nodes.map((node) => fetchBlockHeight(clients[node]))
+        testNodes.map((node) => fetchBlockHeight(clients[node]))
       );
       const blockHeights: { [node: string]: number | null } = {};
-      nodes.forEach((node, i) => {
+      testNodes.forEach((node, i) => {
         const data = result[i];
         const blockHeight = data
           ? Number(data?.data.statistics.blockHeight)

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -38,7 +38,6 @@ export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
           query: StatisticsDocument,
           fetchPolicy: 'no-cache', // always fetch and never cache
         });
-        console.log(result);
 
         if (!result) return null;
         if (result.error) return null;

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -1,0 +1,97 @@
+import compact from 'lodash/compact';
+import shuffle from 'lodash/shuffle';
+import type { createClient } from '@vegaprotocol/apollo-client';
+import { useEffect, useState } from 'react';
+import type { StatisticsQuery } from '../utils/__generated__/Node';
+import { StatisticsDocument } from '../utils/__generated__/Node';
+import type { ClientCollection } from './use-nodes';
+
+// How often to query other nodes
+const INTERVAL_TIME = 15 * 1000;
+// How many blocks behind the most advanced block that is
+// deemed acceptable for "Good" status
+const BLOCK_THRESHOLD = 3;
+// Number of nodes to query against
+const NODE_SUBSET_COUNT = 5;
+
+const Health = {
+  Good: 'Good',
+  Bad: 'Bad',
+  Critical: 'Critical',
+} as const;
+
+export type NodeHealth = keyof typeof Health;
+
+// Queries all nodes from the environment provider via an interval
+// to determine node health
+export const useNodeHealth = (clients: ClientCollection, vegaUrl?: string) => {
+  const [nodeHealth, setNodeHealth] = useState<NodeHealth>(Health.Good);
+
+  useEffect(() => {
+    if (!clients || !vegaUrl) return;
+
+    const fetchBlockHeight = async (
+      client?: ReturnType<typeof createClient>
+    ) => {
+      try {
+        const result = await client?.query<StatisticsQuery>({
+          query: StatisticsDocument,
+          fetchPolicy: 'no-cache', // always fetch and never cache
+        });
+
+        if (!result) return null;
+        if (!result.error) return null;
+        return result;
+      } catch {
+        return null;
+      }
+    };
+
+    const getBlockHeights = async () => {
+      const nodes = randomSubset(Object.keys(clients), NODE_SUBSET_COUNT);
+      const result = await Promise.all(
+        nodes.map((node) => fetchBlockHeight(clients[node]))
+      );
+      const blockHeights: { [node: string]: number | null } = {};
+      nodes.forEach((node, i) => {
+        const data = result[i];
+        const blockHeight = data
+          ? Number(data?.data.statistics.blockHeight)
+          : null;
+        blockHeights[node] = blockHeight;
+      });
+      return blockHeights;
+    };
+
+    // Every INTERVAL_TIME get block heights of a random subset
+    // of nodes and determine if your current node is falling behind
+    const interval = setInterval(async () => {
+      const blockHeights = await getBlockHeights();
+      const highestBlock = Math.max.apply(
+        null,
+        compact(Object.values(blockHeights))
+      );
+      const currNodeBlock = blockHeights[vegaUrl];
+
+      if (!currNodeBlock) {
+        // Block height query failed and null was returned
+        setNodeHealth(Health.Critical);
+      } else if (currNodeBlock >= highestBlock - BLOCK_THRESHOLD) {
+        setNodeHealth(Health.Good);
+      } else {
+        setNodeHealth(Health.Bad);
+      }
+    }, INTERVAL_TIME);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [clients, vegaUrl]);
+
+  return nodeHealth;
+};
+
+const randomSubset = (arr: string[], size: number) => {
+  const shuffled = shuffle(arr);
+  return shuffled.slice(0, size);
+};

--- a/libs/environment/src/hooks/use-node-health.ts
+++ b/libs/environment/src/hooks/use-node-health.ts
@@ -7,14 +7,14 @@ import { StatisticsDocument } from '../utils/__generated__/Node';
 import type { ClientCollection } from './use-nodes';
 
 // How often to query other nodes
-const INTERVAL_TIME = 15 * 1000;
+export const INTERVAL_TIME = 15 * 1000;
 // How many blocks behind the most advanced block that is
 // deemed acceptable for "Good" status
 const BLOCK_THRESHOLD = 3;
 // Number of nodes to query against
 const NODE_SUBSET_COUNT = 5;
 
-const Health = {
+export const Health = {
   Good: 'Good',
   Bad: 'Bad',
   Critical: 'Critical',

--- a/libs/environment/src/hooks/use-nodes.tsx
+++ b/libs/environment/src/hooks/use-nodes.tsx
@@ -178,6 +178,10 @@ const reducer = (state: Record<string, NodeData>, action: Action) => {
   }
 };
 
+/**
+ * Tests each node to see if its suitable for connecting to and returns that data
+ * as a map of node urls to an object of that data
+ */
 export const useNodes = (config?: Configuration, skip?: boolean) => {
   const [clients, setClients] = useState<ClientCollection>({});
   const [state, dispatch] = useReducer(reducer, getInitialState(config));

--- a/libs/environment/src/hooks/use-nodes.tsx
+++ b/libs/environment/src/hooks/use-nodes.tsx
@@ -74,7 +74,7 @@ const getInitialState = (config?: Configuration) =>
     {}
   );
 
-type ClientCollection = Record<
+export type ClientCollection = Record<
   string,
   undefined | ReturnType<typeof createClient>
 >;

--- a/libs/environment/src/utils/compile-environment.ts
+++ b/libs/environment/src/utils/compile-environment.ts
@@ -105,7 +105,8 @@ const getValue = (key: EnvKey, definitions: Partial<RawEnvironment> = {}) => {
 };
 
 export const compileEnvironment = (
-  definitions?: Partial<RawEnvironment>
+  definitions?: Partial<RawEnvironment>,
+  vegaUrl?: string | null
 ): Environment => {
   const environment = ENV_KEYS.reduce((acc, key) => {
     const value = getValue(key, definitions);
@@ -138,5 +139,6 @@ export const compileEnvironment = (
       ...networkOverride,
       ...environment.VEGA_NETWORKS,
     },
+    VEGA_URL: vegaUrl || undefined,
   };
 };

--- a/libs/environment/src/utils/compile-environment.ts
+++ b/libs/environment/src/utils/compile-environment.ts
@@ -83,9 +83,7 @@ const getBundledEnvironmentValue = (key: EnvKey) => {
     case 'ETH_WALLET_MNEMONIC':
       return process.env['NX_ETH_WALLET_MNEMONIC'];
     case 'MAINTENANCE_PAGE':
-      return (
-        process.env['MAINTENANCE_PAGE'] || process.env['NX_MAINTENANCE_PAGE']
-      );
+      return process.env['NX_MAINTENANCE_PAGE'];
   }
 };
 
@@ -105,13 +103,12 @@ const getValue = (key: EnvKey, definitions: Partial<RawEnvironment> = {}) => {
 };
 
 export const compileEnvironment = (
-  definitions?: Partial<RawEnvironment>,
-  vegaUrl?: string | null
+  definitions?: Partial<RawEnvironment>
 ): Environment => {
   const environment = ENV_KEYS.reduce((acc, key) => {
     const value = getValue(key, definitions);
 
-    if (value) {
+    if (value !== undefined && value !== null) {
       return {
         ...acc,
         [key]: value,
@@ -139,6 +136,5 @@ export const compileEnvironment = (
       ...networkOverride,
       ...environment.VEGA_NETWORKS,
     },
-    VEGA_URL: vegaUrl || undefined,
   };
 };

--- a/libs/environment/src/utils/request-node.ts
+++ b/libs/environment/src/utils/request-node.ts
@@ -38,7 +38,11 @@ export const requestNode = (
 
   let subscriptionSucceeded = false;
 
-  const client = createClient(url, undefined, false);
+  const client = createClient({
+    url,
+    retry: false,
+    connectToDevTools: false,
+  });
 
   // make a query for block height
   client

--- a/libs/environment/src/utils/request-node.ts
+++ b/libs/environment/src/utils/request-node.ts
@@ -38,7 +38,7 @@ export const requestNode = (
 
   let subscriptionSucceeded = false;
 
-  const client = createClient(url);
+  const client = createClient(url, undefined, false);
 
   // make a query for block height
   client

--- a/libs/react-helpers/src/hooks/index.ts
+++ b/libs/react-helpers/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './use-data-provider';
 export * from './use-fetch';
 export * from './use-mutation-observer';
 export * from './use-network-params';
+export * from './use-navigator-online';
 export * from './use-outside-click';
 export * from './use-resize-observer';
 export * from './use-resize';

--- a/libs/react-helpers/src/hooks/use-navigator-online.spec.ts
+++ b/libs/react-helpers/src/hooks/use-navigator-online.spec.ts
@@ -1,0 +1,17 @@
+import { fireEvent, renderHook } from '@testing-library/react';
+import { useNavigatorOnline } from './use-navigator-online';
+
+const setup = () => {
+  return renderHook(() => useNavigatorOnline());
+};
+
+describe('useNavigatorOnline', () => {
+  it('returns true if connected and false if not', () => {
+    const { result } = setup();
+    expect(result.current).toBe(true);
+    fireEvent(window, new Event('offline'));
+    expect(result.current).toBe(false);
+    fireEvent(window, new Event('online'));
+    expect(result.current).toBe(true);
+  });
+});

--- a/libs/react-helpers/src/hooks/use-navigator-online.spec.ts
+++ b/libs/react-helpers/src/hooks/use-navigator-online.spec.ts
@@ -1,17 +1,29 @@
-import { fireEvent, renderHook } from '@testing-library/react';
+import { act, fireEvent, renderHook } from '@testing-library/react';
 import { useNavigatorOnline } from './use-navigator-online';
 
 const setup = () => {
   return renderHook(() => useNavigatorOnline());
 };
 
+const turnOn = () => {
+  jest.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true);
+  fireEvent(window, new Event('online'));
+};
+
+const turnOff = () => {
+  jest.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+  fireEvent(window, new Event('offline'));
+};
+
 describe('useNavigatorOnline', () => {
   it('returns true if connected and false if not', () => {
     const { result } = setup();
     expect(result.current).toBe(true);
-    fireEvent(window, new Event('offline'));
+
+    act(turnOff);
     expect(result.current).toBe(false);
-    fireEvent(window, new Event('online'));
+
+    act(turnOn);
     expect(result.current).toBe(true);
   });
 });

--- a/libs/react-helpers/src/hooks/use-navigator-online.ts
+++ b/libs/react-helpers/src/hooks/use-navigator-online.ts
@@ -1,25 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
-export const useNavigatorOnline = () => {
-  const [online, setOnline] = useState(window.navigator.onLine);
-
-  useEffect(() => {
-    function handleOnline(event: Event) {
-      setOnline(true);
-    }
-
-    function handleOffline(event: Event) {
-      setOnline(false);
-    }
-
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-
-    return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
-    };
-  }, []);
-
-  return online;
+const subscribe = (onStoreChange: () => void) => {
+  window.addEventListener('online', onStoreChange);
+  window.addEventListener('offline', onStoreChange);
+  return () => {
+    window.removeEventListener('online', onStoreChange);
+    window.removeEventListener('offline', onStoreChange);
+  };
 };
+export const useNavigatorOnline = () =>
+  useSyncExternalStore(
+    subscribe,
+    () => window.navigator.onLine,
+    () => true
+  );

--- a/libs/react-helpers/src/hooks/use-navigator-online.ts
+++ b/libs/react-helpers/src/hooks/use-navigator-online.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export const useNavigatorOnline = () => {
+  const [online, setOnline] = useState(window.navigator.onLine);
+
+  useEffect(() => {
+    function handleOnline(event: Event) {
+      setOnline(true);
+    }
+
+    function handleOffline(event: Event) {
+      setOnline(false);
+    }
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return online;
+};

--- a/libs/ui-toolkit/src/components/indicator/indicator.tsx
+++ b/libs/ui-toolkit/src/components/indicator/indicator.tsx
@@ -11,5 +11,5 @@ export const Indicator = ({ variant = Intent.None }: IndicatorProps) => {
     'inline-block w-2 h-2 mt-1 mr-2 rounded-full',
     getIntentTextAndBackground(variant)
   );
-  return <div className={names} />;
+  return <div className={names} data-testid="indicator" />;
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #1791 

# Description ℹ️

Checks a random subset of nodes every 30s to see if the your current nodes block height is up to date. This is shown in the UI by an indicator in the footer along with the text Opertaional, Non operational, X blocks behind or Offline

# Demo 📺

<img src="https://user-images.githubusercontent.com/6803987/214731430-ddee0b34-24a5-430d-a853-3dd57e663c50.jpg" alt="drawing" width="200"/>

<img src="https://user-images.githubusercontent.com/6803987/214731461-34770ce8-8777-499b-99c6-b943cd4b6c7b.jpg" alt="drawing" width="200"/>

<img src="https://user-images.githubusercontent.com/6803987/214731496-cb9ddd48-e09c-4ef2-be1e-e421a13d29ed.jpg" alt="drawing" width="200"/>

<img src="https://user-images.githubusercontent.com/6803987/214933764-c0c50d76-2eec-42ca-962e-f3e34e4b0389.jpg" alt="drawing" width="200"/>


# Technical
- Updated to createClient to take a few more options, for retry and connect to dev tools. This tidies up the network quite a bit when attempting connections and also doesn't mess with Apollo dev tools
- Fixed broken/evergreen tests for environment provider. Looks like this has been broken since [this commit](https://github.com/vegaprotocol/frontend-monorepo/commit/71ede25339e7a5cd2c8acd8198d99e72244e9a02#diff-771a20a1909c122b0792e947e22ec89f81061f1b41782d1bf7324536b464d14a)
- Adds useNavigatorOnline hook to detect if browser is connected or not