### PR TITLE
chore: remove sentry captureException in marketDepthProvider update

### DIFF
--- a/libs/market-depth/src/lib/market-depth-provider.spec.ts
+++ b/libs/market-depth/src/lib/market-depth-provider.spec.ts
@@ -56,7 +56,6 @@ describe('market depth provider update', () => {
     ];
     expect(update(data, delta.slice(0, 1), reload)).toBe(data);
     expect(update(data, delta.slice(1, 2), reload)).toBe(data);
-    expect(mockCaptureException).toBeCalledTimes(2);
   });
 
   it('restarts and captureException when there is gap in updates', () => {

--- a/libs/market-depth/src/lib/market-depth-provider.ts
+++ b/libs/market-depth/src/lib/market-depth-provider.ts
@@ -24,11 +24,6 @@ export const update: Update<
       continue;
     }
     if (BigInt(delta.sequenceNumber) <= BigInt(data.depth.sequenceNumber)) {
-      captureException(
-        new Error(
-          `Sequence number from delta is lower or equal to last sequenceNumber for ${data.id}, ${delta.sequenceNumber} <= ${data.depth.sequenceNumber}, update skipped`
-        )
-      );
       return data;
     }
     if (delta.previousSequenceNumber !== data.depth.sequenceNumber) {


### PR DESCRIPTION
# Technical 👨‍🔧

This exception occur when subscription is ahead of fetched data. It can happens on data provider initialization and when data is reloaded when there is gap between sequence numbers. It should not be treated as an issue.
