### PR TITLE
feat: add seperate transaction toast for completed eth transaction

### DIFF
--- a/libs/deposits/src/lib/use-deposits.ts
+++ b/libs/deposits/src/lib/use-deposits.ts
@@ -70,7 +70,6 @@ const updateQuery: UpdateQueryFn<
     subscriptionData.data.busEvents
   );
 
-  console.log({ subscriptionData, time: new Date() });
   const deposits = uniqBy([...incoming, ...curr], 'id');
 
   if (!prev.party) {

--- a/libs/deposits/src/lib/use-deposits.ts
+++ b/libs/deposits/src/lib/use-deposits.ts
@@ -70,6 +70,7 @@ const updateQuery: UpdateQueryFn<
     subscriptionData.data.busEvents
   );
 
+  console.log({ subscriptionData, time: new Date() });
   const deposits = uniqBy([...incoming, ...curr], 'id');
 
   if (!prev.party) {

--- a/libs/ui-toolkit/src/components/toast/toast.tsx
+++ b/libs/ui-toolkit/src/components/toast/toast.tsx
@@ -115,6 +115,7 @@ export const Toast = ({
     >
       <div className="flex relative">
         <button
+          type="button"
           data-testid="toast-close"
           onClick={closeToast}
           className="absolute p-2 top-0 right-0"

--- a/libs/web3/src/lib/use-ethereum-transaction-store.tsx
+++ b/libs/web3/src/lib/use-ethereum-transaction-store.tsx
@@ -120,9 +120,7 @@ export const useEthTransactionStore = create<EthTransactionStore>(
         produce((state: EthTransactionStore) => {
           const transaction = state.transactions.find(
             (transaction) =>
-              transaction &&
-              transaction.status === EthTxStatus.Pending &&
-              deposit.txHash === transaction.txHash
+              transaction && deposit.txHash === transaction.txHash
           );
           if (!transaction) {
             return;


### PR DESCRIPTION
# Related issues 🔗

Closes #[Issue number here]

# Description ℹ️

Distinct Complete and Confirmed status of eth transaction in toast notification. 
Deposit transaction requires final confirmation by change in status of deposit from 'open' to 'finalized'. This change delays "Transaction confirmed" toast and displays "Processing deposit" toast until deposit will be finalized

# Demo 📺

![image](https://user-images.githubusercontent.com/1754247/214613375-4f33a537-126f-40bd-84d2-fd05a2a0f5db.png)


