### PR TITLE
fix(explorer): fix various small lp tx view bugs

### DIFF
--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/Explorer-settlement-asset.graphql
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/Explorer-settlement-asset.graphql
@@ -2,16 +2,5 @@ query ExplorerSettlementAssetForMarket($id: ID!) {
   market(id: $id) {
     id
     decimalPlaces
-    tradableInstrument {
-      instrument {
-        product {
-          ... on Future {
-            settlementAsset {
-              decimals
-            }
-          }
-        }
-      }
-    }
   }
 }

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/__generated__/Explorer-settlement-asset.ts
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/__generated__/Explorer-settlement-asset.ts
@@ -8,7 +8,7 @@ export type ExplorerSettlementAssetForMarketQueryVariables = Types.Exact<{
 }>;
 
 
-export type ExplorerSettlementAssetForMarketQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', product: { __typename?: 'Future', settlementAsset: { __typename?: 'Asset', decimals: number } } } } } | null };
+export type ExplorerSettlementAssetForMarketQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number } | null };
 
 
 export const ExplorerSettlementAssetForMarketDocument = gql`
@@ -16,17 +16,6 @@ export const ExplorerSettlementAssetForMarketDocument = gql`
   market(id: $id) {
     id
     decimalPlaces
-    tradableInstrument {
-      instrument {
-        product {
-          ... on Future {
-            settlementAsset {
-              decimals
-            }
-          }
-        }
-      }
-    }
   }
 }
     `;

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-details-row.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-details-row.spec.tsx
@@ -91,7 +91,7 @@ describe('LiquidityProvisionDetails component', () => {
     expect(res.getByTestId('SIDE_SELL-40-1')).toBeInTheDocument();
     expect(res.getByText('-1')).toBeInTheDocument();
     expect(res.getByText('Best Bid')).toBeInTheDocument();
-    expect(res.getByText('40% (normalised from: 20%)')).toBeInTheDocument();
+    expect(res.getByText('40%')).toBeInTheDocument();
   });
 
   it('handles a missing offset gracefully (should not happen)', () => {
@@ -125,7 +125,7 @@ describe('LiquidityProvisionDetails component', () => {
     );
     // Row test ids and keys are based on the side, reference and proportion - and that proportion is scaled
     expect(res.getByTestId('SIDE_SELL-40-1')).toBeInTheDocument();
-    expect(res.getByText('40% (normalised from: 20%)')).toBeInTheDocument();
+    expect(res.getByText('40%')).toBeInTheDocument();
     expect(res.getByText('-')).toBeInTheDocument();
   });
 });

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-details-row.tsx
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-details-row.tsx
@@ -67,11 +67,7 @@ export function LiquidityProvisionDetailsRow({
       <td className="text-center">
         {order.reference ? LiquidityReferenceLabel[order.reference] : '-'}
       </td>
-      <td className="text-center">
-        {proportion === order.proportion
-          ? `${proportion}%`
-          : `${proportion}% (normalised from: ${order.proportion}%)`}{' '}
-      </td>
+      <td className="text-center">{proportion}%</td>
     </TableRow>
   );
 }

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-offset.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-offset.spec.tsx
@@ -13,15 +13,6 @@ const decimalsMock: ExplorerSettlementAssetForMarketQuery = {
     id: '123',
     __typename: 'Market',
     decimalPlaces: 5,
-    tradableInstrument: {
-      instrument: {
-        product: {
-          settlementAsset: {
-            decimals: 5,
-          },
-        },
-      },
-    },
   },
 };
 

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-offset.tsx
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/components/liquidity-provision-offset.tsx
@@ -36,7 +36,7 @@ export function LiquidityProvisionOffset({
 }
 
 /**
- * Does the work of formatting the number now we have the settlement decimal places.
+ * Does the work of formatting the number now we have the market decimal places.
  * If no market data is assigned (i.e. during loading, or if the market doesn't exist)
  * this function will return the unformatted number
  *
@@ -49,9 +49,7 @@ export function getFormattedOffset(
   offset: string,
   data?: ExplorerSettlementAssetForMarketQuery
 ) {
-  const decimals =
-    data?.market?.tradableInstrument.instrument.product.settlementAsset
-      .decimals;
+  const decimals = data?.market?.decimalPlaces;
 
   if (!decimals) {
     return offset;

--- a/apps/explorer/src/app/components/txs/details/liquidity-provision/liquidity-provision-details.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/liquidity-provision/liquidity-provision-details.spec.tsx
@@ -203,7 +203,7 @@ describe('LiquidityProvisionDetails component', () => {
     };
 
     const res = renderComponent(mock);
-    expect(res.getByText('45% (normalised from: 25%)')).toBeInTheDocument();
-    expect(res.getByText('55% (normalised from: 30%)')).toBeInTheDocument();
+    expect(res.getByText('45%')).toBeInTheDocument();
+    expect(res.getByText('55%')).toBeInTheDocument();
   });
 });

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-cancel.tsx
@@ -27,7 +27,7 @@ export const TxDetailsLiquidityCancellation = ({
   pubKey,
   blockData,
 }: TxDetailsLiquidityCancellationProps) => {
-  if (!txData || !txData.command.liquidityProvisionAmendment) {
+  if (!txData || !txData.command.liquidityProvisionCancellation) {
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
 


### PR DESCRIPTION
# Related issues 🔗

Closes #2737

# Description ℹ️

- Fixes a bug that meant LP Cancellations never displayed
- Fixed decimal places in LP offsets - it now uses market DPs
- Remove 'normalised from' text on normalised proportions

