### PR TITLE
chore: correct ethereum releated envs in trading-e2e

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -68,7 +68,6 @@ jobs:
         working-directory: frontend-monorepo
         env:
           CYPRESS_SLACK_WEBHOOK: ${{ secrets.CYPRESS_SLACK_WEBHOOK }}
-          CYPRESS_ETH_WALLET_MNEMONIC: ${{ secrets.CYPRESS_ETH_WALLET_MNEMONIC }}
           CYPRESS_VEGA_WALLET_API_TOKEN: ${{ steps.setup-vega.outputs.token }}
           CYPRESS_grepTags: ${{ inputs.tags }}
 

--- a/apps/trading-e2e/.env
+++ b/apps/trading-e2e/.env
@@ -14,6 +14,7 @@ NX_ETH_WALLET_MNEMONIC="ozone access unlock valid olympic save include omit supp
 
 # Expose some env vars to cypress environment for market setup
 CYPRESS_ETH_WALLET_MNEMONIC=ozone access unlock valid olympic save include omit supply green clown session
+CYPRESS_ETHEREUM_WALLET_ADDRESS=0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F
 CYPRESS_ETHEREUM_PROVIDER_URL=http://localhost:8545
 CYPRESS_EXPLORER_URL=https://explorer.fairground.wtf
 CYPRESS_FAUCET_URL=http://localhost:1790/api/v1/mint

--- a/apps/trading-e2e/.env.capsule
+++ b/apps/trading-e2e/.env.capsule
@@ -14,6 +14,7 @@ NX_ETH_WALLET_MNEMONIC="ozone access unlock valid olympic save include omit supp
 
 # Expose some env vars to cypress environment for market setup
 CYPRESS_ETH_WALLET_MNEMONIC=ozone access unlock valid olympic save include omit supply green clown session
+CYPRESS_ETHEREUM_WALLET_ADDRESS=0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F
 CYPRESS_ETHEREUM_PROVIDER_URL=http://localhost:8545
 CYPRESS_EXPLORER_URL=https://explorer.fairground.wtf
 CYPRESS_FAUCET_URL=http://localhost:1790/api/v1/mint

--- a/apps/trading-e2e/.env.stagnet3
+++ b/apps/trading-e2e/.env.stagnet3
@@ -10,7 +10,9 @@ NX_VEGA_TOKEN_URL=https://stagnet3.token.vega.xyz
 NX_VEGA_URL=https://api.stagnet3.vega.xyz/graphql
 NX_VEGA_WALLET_URL=http://localhost:1789
 
-CYPRESS_ETH_WALLET_MNEMONIC=ugly gallery notice network true range brave clarify flat logic someone chunk
+CYPRESS_ETH_WALLET_MNEMONIC=
+CYPRESS_ETHEREUM_WALLET_ADDRESS=0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F
+CYPRESS_ETHEREUM_PROVIDER_URL=https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
 CYPRESS_EXPLORER_URL=https://stagnet3.explorer.vega.xyz
 CYPRESS_TRUNCATED_VEGA_PUBLIC_KEY=1a18cd…0cf2e4
 CYPRESS_TRUNCATED_VEGA_PUBLIC_KEY2=47836c…c7d278

--- a/apps/trading-e2e/cypress.config.js
+++ b/apps/trading-e2e/cypress.config.js
@@ -24,19 +24,8 @@ module.exports = defineConfig({
     requestTimeout: 20000,
   },
   env: {
-    VEGA_PUBLIC_KEY:
-      '47836c253520d2661bf5bed6339c0de08fd02cf5d4db0efee3b4373f20c7d278',
-    VEGA_PUBLIC_KEY2:
-      '1a18cdcaaa4f44a57b35a4e9b77e0701c17a476f2b407620f8c17371740cf2e4',
-    TRUNCATED_VEGA_PUBLIC_KEY: '47836c…c7d278',
-    TRUNCATED_VEGA_PUBLIC_KEY2: '1a18cd…0cf2e4',
-    ETHEREUM_PROVIDER_URL:
-      'https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8',
-    ETHEREUM_WALLET_ADDRESS: '0x265Cc6d39a1B53d0d92068443009eE7410807158',
     ETHERSCAN_URL: 'https://sepolia.etherscan.io',
     ETHEREUM_CHAIN_ID: 11155111,
-    ETH_WALLET_MNEMONIC:
-      'ugly gallery notice network true range brave clarify flat logic someone chunk',
     TRADING_MODE_LINK:
       'https://docs.vega.xyz/testnet/concepts/trading-on-vega/trading-modes#auction-type-liquidity-monitoring',
     grepTags: '@regression @smoke @slow',


### PR DESCRIPTION
There was some mess with `ETH_WALLET_MNEMONIC` and `ETHEREUM_WALLET_ADDRESS`, that needed clean up. Mnemonic for stagnet3 can be found in 1password, to avoid exposure.