### PR TITLE
fix: don't show `my markets` if there are no markets & reset deal ticket price validation before setting price 

### DIFF
--- a/apps/trading/components/select-market/select-market.tsx
+++ b/apps/trading/components/select-market/select-market.tsx
@@ -170,7 +170,7 @@ export const SelectMarketPopover = ({
           </div>
         ) : (
           <table className="relative text-sm w-full whitespace-nowrap">
-            {pubKey && (positions?.length ?? 0) > 0 ? (
+            {pubKey && (positions?.length ?? 0) && (markets?.length ?? 0) ? (
               <>
                 <TableTitle>{t('My markets')}</TableTitle>
                 <SelectAllMarketsTableBody

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -74,6 +74,7 @@ export const DealTicket = ({ market, submit }: DealTicketProps) => {
 
   usePersistedOrderStoreSubscription(market.id, (storedOrder) => {
     if (order.price !== storedOrder.price) {
+      clearErrors('price');
       setValue('price', storedOrder.price);
     }
   });


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

- [x] clear up price errors before setting value
- [x] don't show "My markets" if there are no markets


