### PR TITLE
fix(explorer): correct calculation for whether party txs list has more txs

### DIFF
--- a/apps/explorer/src/app/hooks/use-txs-data.ts
+++ b/apps/explorer/src/app/hooks/use-txs-data.ts
@@ -5,6 +5,7 @@ import type {
   BlockExplorerTransactions,
 } from '../routes/types/block-explorer-response';
 import { DATA_SOURCES } from '../config';
+import isNumber from 'lodash/isNumber';
 
 export interface TxsStateProps {
   txsData: BlockExplorerTransactionResult[];
@@ -54,15 +55,15 @@ export const useTxsData = ({ limit, filters }: IUseTxsData) => {
   } = useFetch<BlockExplorerTransactions>(url, {}, false);
 
   useEffect(() => {
-    if (data?.transactions?.length) {
+    if (data && isNumber(data?.transactions?.length)) {
       setTxsState((prev) => ({
         txsData: [...prev.txsData, ...data.transactions],
-        hasMoreTxs: true,
+        hasMoreTxs: data.transactions.length > 0,
         lastCursor:
-          data.transactions[data.transactions.length - 1].cursor || '',
+          data.transactions[data.transactions.length - 1]?.cursor || '',
       }));
     }
-  }, [setTxsState, data?.transactions]);
+  }, [setTxsState, data]);
 
   const loadTxs = useCallback(() => {
     return refetch({


### PR DESCRIPTION
# Related issues 🔗

Closes #2719

# Description ℹ️

The infinite scroll fetcher for party transactions always returned `true` for `hasMoreTransactions`, which resulted in the loader always showing. Now it calculates it based on the number of transactions.

