### PR TITLE
fix(explorer): tx viewer dropdown did not correctly represent state

### DIFF
--- a/apps/explorer/src/app/components/txs/tx-data-view.tsx
+++ b/apps/explorer/src/app/components/txs/tx-data-view.tsx
@@ -63,7 +63,7 @@ export const TxDataView = ({ txData, blockData }: TxDataViewProps) => {
           <Select
             placeholder="View as..."
             onChange={(v) => setShowTxData(v.target.value as ShowTxDataType)}
-            value={'JSON'}
+            value={showTxData}
           >
             <option value={'JSON'}>JSON</option>
             <option value={'base64'}>Base64</option>


### PR DESCRIPTION
# Related issues 🔗

Closes #2777

# Description ℹ️

The TX viewer introduced in #2765 did not correctly change when the user switched from JSON to base64. Now it does!

