### PR TITLE
feat(governance): body can scroll again after clicking 'back to staking'

### DIFF
--- a/apps/token/src/routes/staking/node/stake-success.tsx
+++ b/apps/token/src/routes/staking/node/stake-success.tsx
@@ -1,5 +1,7 @@
 import { Dialog, Icon, Intent } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+import Routes from '../../routes';
 import type { StakeAction } from './staking-form';
 import { Actions, RemoveType } from './staking-form';
 
@@ -21,6 +23,7 @@ export const StakeSuccess = ({
   toggleDialog,
 }: StakeSuccessProps) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const isAdd = action === Actions.Add;
   const title = isAdd
     ? t('stakeAddSuccessTitle', { amount })
@@ -41,6 +44,21 @@ export const StakeSuccess = ({
     >
       <div>
         <p>{message}</p>
+        <p>
+          <Link
+            className="underline"
+            to={Routes.VALIDATORS}
+            onClick={(event) => {
+              event.preventDefault();
+              // Because the dialog is not closed when the user clicks on the link,
+              // we need to remove the overflow-hidden class from the body.
+              document.body.classList.remove('overflow-hidden');
+              navigate(Routes.VALIDATORS);
+            }}
+          >
+            {t('backToStaking')}
+          </Link>
+        </p>
       </div>
     </Dialog>
   );

--- a/apps/token/src/routes/staking/node/stake-success.tsx
+++ b/apps/token/src/routes/staking/node/stake-success.tsx
@@ -1,7 +1,5 @@
 import { Dialog, Icon, Intent } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
-import Routes from '../../routes';
 import type { StakeAction } from './staking-form';
 import { Actions, RemoveType } from './staking-form';
 
@@ -43,11 +41,6 @@ export const StakeSuccess = ({
     >
       <div>
         <p>{message}</p>
-        <p>
-          <Link className="underline" to={Routes.VALIDATORS}>
-            {t('backToStaking')}
-          </Link>
-        </p>
       </div>
     </Dialog>
   );

--- a/apps/token/src/routes/staking/node/stake-success.tsx
+++ b/apps/token/src/routes/staking/node/stake-success.tsx
@@ -50,10 +50,8 @@ export const StakeSuccess = ({
             to={Routes.VALIDATORS}
             onClick={(event) => {
               event.preventDefault();
-              // Because the dialog is not closed when the user clicks on the link,
-              // we need to remove the overflow-hidden class from the body.
-              document.body.classList.remove('overflow-hidden');
-              navigate(Routes.VALIDATORS);
+              toggleDialog();
+              setTimeout(() => navigate(Routes.VALIDATORS), 0);
             }}
           >
             {t('backToStaking')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19190,9 +19190,9 @@ react-refresh@^0.11.0:
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 react-remove-scroll-bar@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz#e291f71b1bb30f5f67f023765b7435f4b2b2cd94"
-  integrity sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
   dependencies:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"


### PR DESCRIPTION
# Related issues 🔗

Closes #2431

# Description ℹ️

When the 'back to staking' link was clicked from within the staking success modal, the modal would not close properly and the body tag would continue to have its overflow css property locked. This is now fixed.
