### PR TITLE
feat(explorer): add protocol upgrade view

### DIFF
--- a/apps/explorer/.env.stagnet3
+++ b/apps/explorer/.env.stagnet3
@@ -6,3 +6,4 @@ NX_VEGA_ENV=STAGNET3
 NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
 NX_BLOCK_EXPLORER=https://be.stagnet3.vega.xyz/rest
 NX_VEGA_GOVERNANCE_URL=https://stagnet3.token.vega.xyz
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega-dev-releases/releases/

--- a/apps/explorer/src/app/components/render-fetched/index.tsx
+++ b/apps/explorer/src/app/components/render-fetched/index.tsx
@@ -1,5 +1,4 @@
 import { t } from '@vegaprotocol/react-helpers';
-import React from 'react';
 import { StatusMessage } from '../status-message';
 
 interface RenderFetchedProps {

--- a/apps/explorer/src/app/components/txs/details/tx-details-protocol-upgrade.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-details-protocol-upgrade.tsx
@@ -1,0 +1,62 @@
+import { t } from '@vegaprotocol/react-helpers';
+import { TxDetailsShared } from './shared/tx-details-shared';
+import { TableCell, TableRow, TableWithTbody } from '../../table';
+import { BlockLink } from '../../links';
+import { StatusMessage } from '../../status-message';
+import { ENV } from '../../../config/env';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
+
+import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
+import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
+import type { components } from '../../../../types/explorer';
+
+interface TxDetailsProtocolUpgradeProps {
+  txData: BlockExplorerTransactionResult | undefined;
+  pubKey: string | undefined;
+  blockData: TendermintBlocksResponse | undefined;
+}
+
+/**
+ * Validator event: Protocol Upgrade proposal
+ */
+export const TxDetailsProtocolUpgrade = ({
+  txData,
+  pubKey,
+  blockData,
+}: TxDetailsProtocolUpgradeProps) => {
+  if (!txData) {
+    return <>{t('Awaiting Block Explorer transaction details')}</>;
+  }
+
+  const upgrade: components['schemas']['v1ProtocolUpgradeProposal'] =
+    txData.command.protocolUpgradeProposal;
+
+  if (!upgrade || !upgrade.upgradeBlockHeight || !upgrade.vegaReleaseTag) {
+    return (
+      <StatusMessage>{t('Invalid upgrade proposal format')}</StatusMessage>
+    );
+  }
+
+  const urlBase = ENV.dataSources.vegaRepoUrl;
+  const release = upgrade.vegaReleaseTag;
+
+  return (
+    <TableWithTbody className="mb-8">
+      <TxDetailsShared txData={txData} pubKey={pubKey} blockData={blockData} />
+      <TableRow modifier="bordered">
+        <TableCell>{t('Upgrade at block')}</TableCell>
+        <TableCell>
+          <BlockLink height={upgrade.upgradeBlockHeight} />
+        </TableCell>
+      </TableRow>
+      <TableRow modifier="bordered">
+        <TableCell>{t('Upgrade to')}</TableCell>
+        <TableCell>
+          <ExternalLink href={`${urlBase}${release}`}>
+            {upgrade.vegaReleaseTag}
+          </ExternalLink>
+        </TableCell>
+      </TableRow>
+    </TableWithTbody>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-details-wrapper.tsx
@@ -19,6 +19,7 @@ import { TxDetailsLiquidityAmendment } from './tx-liquidity-amend';
 import { TxDetailsLiquidityCancellation } from './tx-liquidity-cancel';
 import { TxDetailsDataSubmission } from './tx-data-submission';
 import { TxProposalVote } from './tx-proposal-vote';
+import { TxDetailsProtocolUpgrade } from './tx-details-protocol-upgrade';
 
 interface TxDetailsWrapperProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -70,6 +71,8 @@ function getTransactionComponent(txData?: BlockExplorerTransactionResult) {
       return TxDetailsOrder;
     case 'Submit Oracle Data':
       return TxDetailsDataSubmission;
+    case 'Protocol Upgrade':
+      return TxDetailsProtocolUpgrade;
     case 'Cancel Order':
       return TxDetailsOrderCancel;
     case 'Amend Order':

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-cancel.tsx
@@ -1,10 +1,11 @@
 import { t } from '@vegaprotocol/react-helpers';
-import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
 import { MarketLink } from '../../links';
-import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
+
 import type { components } from '../../../../types/explorer';
+import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
+import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
 
 export type LiquidityCancellation =
   components['schemas']['v1LiquidityProvisionCancellation'];

--- a/apps/explorer/src/app/config/env.ts
+++ b/apps/explorer/src/app/config/env.ts
@@ -10,6 +10,7 @@ const truthy = ['1', 'true'];
 export const ENV = {
   // Data sources
   // Environment
+  env: windowOrDefault('NX_VEGA_ENV'),
   dsn: windowOrDefault('NX_EXPLORER_SENTRY_DSN'),
   dataSources: {
     blockExplorerUrl: windowOrDefault('NX_BLOCK_EXPLORER'),
@@ -17,6 +18,7 @@ export const ENV = {
     tendermintWebsocketUrl: windowOrDefault('NX_TENDERMINT_WEBSOCKET_URL'),
     ethExplorerUrl: windowOrDefault('NX_ETHERSCAN_URL'),
     governanceUrl: windowOrDefault('NX_VEGA_GOVERNANCE_URL'),
+    vegaRepoUrl: windowOrDefault('NX_VEGA_REPO_URL'),
   },
   flags: {
     assets: truthy.includes(windowOrDefault('NX_EXPLORER_ASSETS')),

--- a/apps/trading/.env
+++ b/apps/trading/.env
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases

--- a/apps/trading/.env.capsule
+++ b/apps/trading/.env.capsule
@@ -9,6 +9,7 @@ NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_URL=http://localhost:3028/query
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases
 
 NX_ETH_LOCAL_PROVIDER_URL=http://localhost:8545/
 NX_ETH_WALLET_MNEMONIC="ozone access unlock valid olympic save include omit supply green clown session"

--- a/apps/trading/.env.devnet
+++ b/apps/trading/.env.devnet
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega-dev-releases/releases

--- a/apps/trading/.env.mainnet
+++ b/apps/trading/.env.mainnet
@@ -7,3 +7,4 @@ NX_VEGA_NETWORKS={\"MAINNET\":\"https://alpha.console.vega.xyz\",\"TESTNET\":\"h
 NX_VEGA_TOKEN_URL=https://token.vega.xyz
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases

--- a/apps/trading/.env.mirror
+++ b/apps/trading/.env.mirror
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://mainnet-mirror.token.vega.xyz
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases

--- a/apps/trading/.env.sandbox
+++ b/apps/trading/.env.sandbox
@@ -7,3 +7,4 @@ NX_VEGA_NETWORKS={\"DEVNET\":\"https://dev.token.vega.xyz\",\"STAGNET3\":\"https
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/sandbox-network.json
 NX_VEGA_EXPLORER_URL=https://sandbox.explorer.vega.xyz
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases

--- a/apps/trading/.env.stagnet1
+++ b/apps/trading/.env.stagnet1
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://stagnet1.token.vega.xyz
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases

--- a/apps/trading/.env.stagnet3
+++ b/apps/trading/.env.stagnet3
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega-dev-releases/releases

--- a/apps/trading/.env.testnet
+++ b/apps/trading/.env.testnet
@@ -8,3 +8,4 @@ NX_VEGA_NETWORKS={\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"
 NX_VEGA_TOKEN_URL=https://token.fairground.wtf
 NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases


### PR DESCRIPTION
# Related issues 🔗

Closes #2129

# Description ℹ️

Adds a Protocol Upgrade transaction. These are infrequent, but interesting. We're at that point in the transactions list
I suppose. This *could* be expanded with a block height past/future, but given that is easy to calculate in your head
I have not done this in this PR, in favour of MORE TX VIEWS.

# Demo 📺
Note: it now says 'Upgrade at block' rather than 'Upgrade at'.

<img width="839" alt="Screenshot 2023-01-31 at 15 46 07" src="https://user-images.githubusercontent.com/6678/215816344-e6dfd37d-c13d-4ae5-a5cf-568d77883009.png">

