### PR TITLE
fix(trading): update async renderer on error

### DIFF
--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.spec.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.spec.tsx
@@ -19,56 +19,58 @@ const generateJsx = () => {
   );
 };
 
-it('Renders a loading state while awaiting orders', async () => {
-  jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
-    data: [],
-    loading: true,
-    error: undefined,
-    flush: jest.fn(),
-    reload: jest.fn(),
-    load: jest.fn(),
-    totalCount: 0,
+describe('OrderListManager', () => {
+  it('should render a loading state while awaiting orders', async () => {
+    jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
+      data: [],
+      loading: true,
+      error: undefined,
+      flush: jest.fn(),
+      reload: jest.fn(),
+      load: jest.fn(),
+      totalCount: 0,
+    });
+    await act(async () => {
+      render(generateJsx());
+    });
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
-  await act(async () => {
-    render(generateJsx());
-  });
-  expect(screen.getByText('Loading...')).toBeInTheDocument();
-});
 
-it('Renders an error state', async () => {
-  const errorMsg = 'Oops! An Error';
-  jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
-    data: [],
-    loading: false,
-    error: new Error(errorMsg),
-    flush: jest.fn(),
-    reload: jest.fn(),
-    load: jest.fn(),
-    totalCount: undefined,
+  it('should render an error state', async () => {
+    const errorMsg = 'Oops! An Error';
+    jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
+      data: null,
+      loading: false,
+      error: new Error(errorMsg),
+      flush: jest.fn(),
+      reload: jest.fn(),
+      load: jest.fn(),
+      totalCount: undefined,
+    });
+    await act(async () => {
+      render(generateJsx());
+    });
+    expect(
+      screen.getByText(`Something went wrong: ${errorMsg}`)
+    ).toBeInTheDocument();
   });
-  await act(async () => {
-    render(generateJsx());
-  });
-  expect(
-    screen.getByText(`Something went wrong: ${errorMsg}`)
-  ).toBeInTheDocument();
-});
 
-it('Renders the order list if orders provided', async () => {
-  // @ts-ignore Orderlist is read only but we need to override with the forwardref to
-  // avoid warnings about padding refs
-  orderListMock.OrderListTable = forwardRef(() => <div>OrderList</div>);
-  jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
-    data: [{ id: '1' } as OrderFieldsFragment],
-    loading: false,
-    error: undefined,
-    flush: jest.fn(),
-    reload: jest.fn(),
-    load: jest.fn(),
-    totalCount: undefined,
+  it('should render the order list if orders provided', async () => {
+    // @ts-ignore OrderList is read only but we need to override with the forwardRef to
+    // avoid warnings about padding refs
+    orderListMock.OrderListTable = forwardRef(() => <div>OrderList</div>);
+    jest.spyOn(useDataProviderHook, 'useDataProvider').mockReturnValue({
+      data: [{ id: '1' } as OrderFieldsFragment],
+      loading: false,
+      error: undefined,
+      flush: jest.fn(),
+      reload: jest.fn(),
+      load: jest.fn(),
+      totalCount: undefined,
+    });
+    await act(async () => {
+      render(generateJsx());
+    });
+    expect(await screen.findByText('OrderList')).toBeInTheDocument();
   });
-  await act(async () => {
-    render(generateJsx());
-  });
-  expect(await screen.findByText('OrderList')).toBeInTheDocument();
 });

--- a/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
+++ b/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
@@ -1,6 +1,7 @@
 import { Splash } from '../splash';
 import type { ReactNode } from 'react';
 import { t } from '@vegaprotocol/react-helpers';
+import * as Sentry from '@sentry/react';
 
 interface AsyncRendererProps<T> {
   loading: boolean;
@@ -26,13 +27,16 @@ export function AsyncRenderer<T = object>({
   render,
 }: AsyncRendererProps<T>) {
   if (error) {
-    return (
-      <Splash>
-        {errorMessage
-          ? errorMessage
-          : t(`Something went wrong: ${error.message}`)}
-      </Splash>
-    );
+    Sentry.captureException(`Error rendering data: ${error.message}`);
+    if (!data) {
+      return (
+        <Splash>
+          {errorMessage
+            ? errorMessage
+            : t(`Something went wrong: ${error.message}`)}
+        </Splash>
+      );
+    }
   }
 
   if (loading) {


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️
 Update `AsyncRenderer` on error


# Demo 📺

<img width="1679" alt="Screenshot 2023-02-03 at 15 00 35" src="https://user-images.githubusercontent.com/16125548/216640051-023191ff-b706-4f0e-92e2-46afae74d7f1.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
