### PR TITLE
test(token): pending balances

### DIFF
--- a/apps/token-e2e/.env
+++ b/apps/token-e2e/.env
@@ -16,7 +16,6 @@ NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet
 #Test configuration variables
 CYPRESS_FAIRGROUND=false
 CYPRESS_VEGA_URL=http://localhost:3028/query
-CYPRESS_VEGA_WALLET_API_TOKEN=jpeAkxcffzTLCzBX2m5TZIp3hF500YZhHwESwNKOGksdGPXeeIznXypaDfpNe2M9
 CYPRESS_ETH_WALLET_MNEMONIC=ozone access unlock valid olympic save include omit supply green clown session
 CYPRESS_ETHEREUM_PROVIDER_URL=http://localhost:8545
 CYPRESS_EXPLORER_URL=https://explorer.fairground.wtf
@@ -29,3 +28,4 @@ CYPRESS_VEGA_PUBLIC_KEY2=7f9cf07d3a9905b1a61a1069f7a758855da428bc0f4a97de87f4864
 CYPRESS_VEGA_TOKEN_URL=https://token.fairground.wtf
 CYPRESS_VEGA_URL=http://localhost:3028/query
 CYPRESS_VEGA_WALLET_URL=http://localhost:1789
+CYPRESS_VEGA_WALLET_API_TOKEN=

--- a/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
+++ b/apps/token-e2e/src/integration/flow/token-association-flow.cy.js
@@ -37,8 +37,8 @@ context(
         function () {
           cy.reload();
           cy.wait_for_spinner();
-          cy.connectVegaWallet();
           cy.ethereum_wallet_connect();
+          cy.connectVegaWallet();
           cy.vega_wallet_teardown();
           cy.navigate_to('validators');
         }
@@ -57,7 +57,16 @@ context(
         //0005-ETXN-006
         //0005-ETXN-003
         //0005-ETXN-005
-        cy.staking_page_associate_tokens('2');
+        cy.staking_page_associate_tokens('2', { skipConfirmation: true });
+
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '0.00');
+        cy.validate_wallet_currency('Pending association', '2.00');
+        cy.validate_wallet_currency('Total associated after pending', '2.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
 
         // 0005-ETXN-002
         cy.get(ethWalletAssociatedBalances, txTimeout)
@@ -97,6 +106,15 @@ context(
         cy.get('button').contains('Select a validator to nominate').click();
 
         cy.staking_page_disassociate_tokens('2');
+
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '2.00');
+        cy.validate_wallet_currency('Pending association', '2.00');
+        cy.validate_wallet_currency('Total associated after pending', '0.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
 
         cy.get(ethWalletAssociatedBalances, txTimeout).should('not.exist');
 
@@ -194,7 +212,19 @@ context(
         // 1004-ASSO-024
         // 1004-ASSO-023
 
-        cy.staking_page_associate_tokens('2', { type: 'contract' });
+        cy.staking_page_associate_tokens('2', {
+          type: 'contract',
+          skipConfirmation: true,
+        });
+
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '0.00');
+        cy.validate_wallet_currency('Pending association', '2.00');
+        cy.validate_wallet_currency('Total associated after pending', '2.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
@@ -210,7 +240,19 @@ context(
         });
 
         cy.get(vegaWalletUnstakedBalance, txTimeout).should('contain', 2.0);
-        cy.staking_page_disassociate_tokens('1', { type: 'contract' });
+        cy.staking_page_disassociate_tokens('1', {
+          type: 'contract',
+          skipConfirmation: true,
+        });
+
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '2.00');
+        cy.validate_wallet_currency('Pending association', '1.00');
+        cy.validate_wallet_currency('Total associated after pending', '1.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
 
         cy.get(ethWalletAssociatedBalances, txTimeout)
           .contains(vegaWalletPublicKeyShort)
@@ -286,6 +328,35 @@ context(
       });
 
       // 1004-ASSO-004
+
+      it('Pending association outside of app is shown', function () {
+        cy.vega_wallet_associate('2');
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '0.00');
+        cy.validate_wallet_currency('Pending association', '2.00');
+        cy.validate_wallet_currency('Total associated after pending', '2.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
+        cy.validate_wallet_currency('Associated', '2.00');
+      });
+
+      it('Disassociation outside of app is shown', function () {
+        cy.staking_page_associate_tokens('2');
+        cy.validate_wallet_currency('Associated', '2.00');
+        cy.vega_wallet_disassociate('2');
+        cy.getByTestId('currency-title', txTimeout).should(
+          'have.length.above',
+          3
+        );
+        cy.validate_wallet_currency('Associated', '2.00');
+        cy.validate_wallet_currency('Pending association', '2.00');
+        cy.validate_wallet_currency('Total associated after pending', '0.00');
+        cy.getByTestId('currency-title', txTimeout).should('have.length', 3);
+        cy.validate_wallet_currency('Associated', '0.00');
+      });
+
       it('Able to associate tokens to different public key of connected vega wallet', function () {
         cy.get(ethWalletAssociateButton).first().click();
         cy.get(associateWalletRadioButton).click();
@@ -310,6 +381,7 @@ context(
             'vegaWalletPublicKey2Short'
           )} can now participate in governance and nominate a validator with your associated $VEGA.`
         );
+        cy.staking_page_disassociate_all_tokens();
       });
     });
   }

--- a/apps/token-e2e/src/integration/view/wallet-vega.cy.js
+++ b/apps/token-e2e/src/integration/view/wallet-vega.cy.js
@@ -321,6 +321,8 @@ context(
             '200000',
             vegaWalletPublicKey
           );
+          cy.reload();
+          cy.wait_for_spinner();
           cy.connectVegaWallet();
           cy.ethereum_wallet_connect();
         });

--- a/apps/token-e2e/src/support/staking.functions.js
+++ b/apps/token-e2e/src/support/staking.functions.js
@@ -58,6 +58,8 @@ Cypress.Commands.add('staking_validator_page_remove_stake', (stake) => {
 Cypress.Commands.add('staking_page_associate_tokens', (amount, options) => {
   let approve = options && options.approve ? options.approve : false;
   let type = options && options.type ? options.type : 'wallet';
+  let skipConfirmation =
+    options && options.skipConfirmation ? options.skipConfirmation : false;
 
   cy.highlight(`Associating ${amount} tokens from ${type}`);
   cy.get(ethWalletAssociateButton).first().click();
@@ -79,16 +81,19 @@ Cypress.Commands.add('staking_page_associate_tokens', (amount, options) => {
     );
   }
   cy.get(tokenSubmitButton, txTimeout).should('be.enabled').click();
-  cy.contains(
-    `Associating with Vega key. Waiting for ${Cypress.env(
-      'blockConfirmations'
-    )} more confirmations..`,
-    txTimeout
-  ).should('be.visible');
-  cy.contains(
-    'can now participate in governance and nominate a validator',
-    txTimeout
-  ).should('be.visible');
+
+  if (!skipConfirmation) {
+    cy.contains(
+      `Associating with Vega key. Waiting for ${Cypress.env(
+        'blockConfirmations'
+      )} more confirmations..`,
+      txTimeout
+    ).should('be.visible');
+    cy.contains(
+      'can now participate in governance and nominate a validator',
+      txTimeout
+    ).should('be.visible');
+  }
 });
 
 Cypress.Commands.add('staking_page_disassociate_tokens', (amount, options) => {
@@ -216,3 +221,19 @@ Cypress.Commands.add('close_staking_dialog', () => {
     cy.get('a').should('have.text', 'Back to Staking').click();
   });
 });
+
+Cypress.Commands.add(
+  'validate_wallet_currency',
+  (currencyTitle, expectedAmount) => {
+    cy.get("[data-testid='currency-title']")
+      .contains(currencyTitle)
+      .parent()
+      .parent()
+      .within(() => {
+        cy.getByTestId('currency-value', txTimeout).should(
+          'have.text',
+          expectedAmount
+        );
+      });
+  }
+);

--- a/apps/token-e2e/src/support/wallet-teardown.functions.js
+++ b/apps/token-e2e/src/support/wallet-teardown.functions.js
@@ -8,7 +8,6 @@ import {
 import { ethers, Wallet } from 'ethers';
 
 const vegaWalletContainer = '[data-testid="vega-wallet"]';
-const vegaWalletAssociatedBalance = '[data-testid="currency-value"]';
 const vegaWalletMnemonic = Cypress.env('vegaWalletMnemonic');
 const vegaWalletPubKey = Cypress.env('vegaWalletPublicKey');
 const vegaTokenContractAddress = Cypress.env('vegaTokenContractAddress');
@@ -41,6 +40,11 @@ before('Vega wallet teardown prep', function () {
       log: false,
     }).as('vestingContract');
   });
+});
+
+beforeEach(function () {
+  cy.wrap(this.stakingBridgeContract).as('stakingBridgeContract');
+  cy.wrap(this.vestingContract).as('vestingContract');
 });
 
 Cypress.Commands.add('deposit_asset', function (assetEthAddress) {
@@ -91,27 +95,16 @@ Cypress.Commands.add('faucet_asset', function (assetEthAddress) {
 });
 
 Cypress.Commands.add('vega_wallet_teardown', function () {
+  cy.get('body').then(($body) => {
+    if ($body.find('[data-testid="eth-wallet-associated-balances"]').length) {
+      cy.vega_wallet_teardown_vesting(this.vestingContract);
+      cy.vega_wallet_teardown_staking(this.stakingBridgeContract);
+    }
+  });
   cy.get(vegaWalletContainer).within(() => {
-    cy.get(vegaWalletAssociatedBalance)
-      .first()
-      .invoke('text')
-      .then((balance) => {
-        if (balance != '0.00') {
-          cy.vega_wallet_teardown_vesting(this.vestingContract);
-          cy.vega_wallet_teardown_staking(this.stakingBridgeContract);
-        }
-      });
     cy.get('[data-testid="associated-amount"]', { timeout: 30000 }).should(
       'contain.text',
       '0.00'
-    );
-  });
-
-  cy.get(vegaWalletContainer).within(() => {
-    cy.get(vegaWalletAssociatedBalance, { timeout: transactionTimeout }).should(
-      'contain',
-      '0.00',
-      { timeout: transactionTimeout }
     );
   });
 });
@@ -173,6 +166,22 @@ Cypress.Commands.add('vega_wallet_teardown_vesting', (vestingContract) => {
         cy.wait_for_transaction(tx);
       });
     }
+  });
+});
+
+Cypress.Commands.add('vega_wallet_associate', (amount) => {
+  amount = amount + '0'.repeat(18);
+  cy.highlight('Associating tokens');
+  cy.get('@stakingBridgeContract').then((stakingBridgeContract) => {
+    stakingBridgeContract.stake(amount, vegaWalletPubKey);
+  });
+});
+
+Cypress.Commands.add('vega_wallet_disassociate', (amount) => {
+  amount = amount + '0'.repeat(18);
+  cy.highlight('Disassociating tokens');
+  cy.get('@stakingBridgeContract').then((stakingBridgeContract) => {
+    stakingBridgeContract.remove_stake(amount, vegaWalletPubKey);
   });
 });
 


### PR DESCRIPTION
# Related issues 🔗

Closes #2058 

# Description ℹ️

Adds E2E tests for pending balances.
- Performing an association/disassocation from the application shows the pending balances bar
- Performing an association/disassocation outside of the application shows the same
- Ensure that this works for both vesting contract association and staking contract association
