### PR TITLE
fix(explorer): use position decimal places to format size in order

### DIFF
--- a/apps/explorer/src/app/components/links/market-link/Market.graphql
+++ b/apps/explorer/src/app/components/links/market-link/Market.graphql
@@ -2,6 +2,7 @@ query ExplorerMarket($id: ID!) {
   market(id: $id) {
     id
     decimalPlaces
+    positionDecimalPlaces
     tradableInstrument {
       instrument {
         name

--- a/apps/explorer/src/app/components/links/market-link/__generated__/Market.ts
+++ b/apps/explorer/src/app/components/links/market-link/__generated__/Market.ts
@@ -8,7 +8,7 @@ export type ExplorerMarketQueryVariables = Types.Exact<{
 }>;
 
 
-export type ExplorerMarketQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string, settlementAsset: { __typename?: 'Asset', decimals: number } } } } } | null };
+export type ExplorerMarketQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, positionDecimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string, settlementAsset: { __typename?: 'Asset', decimals: number } } } } } | null };
 
 
 export const ExplorerMarketDocument = gql`
@@ -16,6 +16,7 @@ export const ExplorerMarketDocument = gql`
   market(id: $id) {
     id
     decimalPlaces
+    positionDecimalPlaces
     tradableInstrument {
       instrument {
         name

--- a/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
@@ -55,6 +55,7 @@ describe('Market link component', () => {
           market: {
             id: '123',
             decimalPlaces: 5,
+            positionDecimalPlaces: 2,
             state: 'irrelevant-test-data',
             tradableInstrument: {
               instrument: {

--- a/apps/explorer/src/app/components/order-details/Order.graphql
+++ b/apps/explorer/src/app/components/order-details/Order.graphql
@@ -19,6 +19,7 @@ fragment ExplorerDeterministicOrderFields on Order {
   market {
     id
     decimalPlaces
+    positionDecimalPlaces
     tradableInstrument {
       instrument {
         name

--- a/apps/explorer/src/app/components/order-details/__generated__/Order.ts
+++ b/apps/explorer/src/app/components/order-details/__generated__/Order.ts
@@ -3,7 +3,7 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ExplorerDeterministicOrderFieldsFragment = { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } };
+export type ExplorerDeterministicOrderFieldsFragment = { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, positionDecimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } };
 
 export type ExplorerDeterministicOrderQueryVariables = Types.Exact<{
   orderId: Types.Scalars['ID'];
@@ -11,7 +11,7 @@ export type ExplorerDeterministicOrderQueryVariables = Types.Exact<{
 }>;
 
 
-export type ExplorerDeterministicOrderQuery = { __typename?: 'Query', orderByID: { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } } };
+export type ExplorerDeterministicOrderQuery = { __typename?: 'Query', orderByID: { __typename?: 'Order', id: string, type?: Types.OrderType | null, reference: string, status: Types.OrderStatus, version: string, createdAt: any, updatedAt?: any | null, expiresAt?: any | null, timeInForce: Types.OrderTimeInForce, price: string, side: Types.Side, remaining: string, size: string, rejectionReason?: Types.OrderRejectionReason | null, party: { __typename?: 'Party', id: string }, market: { __typename?: 'Market', id: string, decimalPlaces: number, positionDecimalPlaces: number, state: Types.MarketState, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', name: string, product: { __typename?: 'Future', quoteName: string } } } } } };
 
 export const ExplorerDeterministicOrderFieldsFragmentDoc = gql`
     fragment ExplorerDeterministicOrderFields on Order {
@@ -35,6 +35,7 @@ export const ExplorerDeterministicOrderFieldsFragmentDoc = gql`
   market {
     id
     decimalPlaces
+    positionDecimalPlaces
     tradableInstrument {
       instrument {
         name

--- a/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
@@ -61,6 +61,7 @@ function renderExistingAmend(id: string, version: number, amend: Amend) {
               __typename: 'Market',
               id: '789',
               state: 'STATUS_ACTIVE',
+              positionDecimalPlaces: 2,
               decimalPlaces: '5',
               tradableInstrument: {
                 instrument: {
@@ -88,6 +89,7 @@ function renderExistingAmend(id: string, version: number, amend: Amend) {
           market: {
             id: '789',
             decimalPlaces: 5,
+            positionDecimalPlaces: 2,
             state: 'irrelevant-test-data',
             tradableInstrument: {
               instrument: {

--- a/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
@@ -4,6 +4,7 @@ import { MarketLink } from '../links';
 import PriceInMarket from '../price-in-market/price-in-market';
 import { Time } from '../time';
 import { sideText, statusText, tifFull, tifShort } from './lib/order-labels';
+import SizeInMarket from '../size-in-market/size-in-market';
 
 export interface DeterministicOrderDetailsProps {
   id: string;
@@ -90,7 +91,7 @@ const DeterministicOrderDetails = ({
             <div className="mb-12 md:mb-0">
               <h2 className="text-2xl font-bold text-dark mb-4">{t('Size')}</h2>
               <h5 className="text-lg font-medium text-gray-500 mb-0">
-                {o.size}
+                <SizeInMarket size={o.size} marketId={o.market.id} />
               </h5>
             </div>
 

--- a/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
@@ -38,6 +38,7 @@ const mock = {
           __typename: 'Market',
           id: '789',
           state: 'STATE_ACTIVE',
+          positionDecimalPlaces: 2,
           decimalPlaces: 2,
           tradableInstrument: {
             instrument: {

--- a/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
@@ -90,6 +90,7 @@ describe('Order TX Summary component', () => {
           market: {
             id: '123',
             decimalPlaces: 2,
+            positionDecimalPlaces: 2,
             state: 'irrelevant-test-data',
             tradableInstrument: {
               instrument: {

--- a/apps/explorer/src/app/components/price-in-market/price-in-market.spec.tsx
+++ b/apps/explorer/src/app/components/price-in-market/price-in-market.spec.tsx
@@ -37,6 +37,7 @@ const fullMock = {
       market: {
         id: '123',
         decimalPlaces: 2,
+        positionDecimalPlaces: 2,
         state: 'irrelevant-test-data',
         tradableInstrument: {
           instrument: {

--- a/apps/explorer/src/app/components/size-in-market/size-in-market.spec.tsx
+++ b/apps/explorer/src/app/components/size-in-market/size-in-market.spec.tsx
@@ -1,0 +1,69 @@
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import type { MockedResponse } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import SizeInMarket from './size-in-market';
+import type { DecimalSource } from './size-in-market';
+import { ExplorerMarketDocument } from '../links/market-link/__generated__/Market';
+
+function renderComponent(
+  price: string,
+  marketId: string,
+  mocks: MockedResponse[],
+  decimalSource: DecimalSource = 'MARKET'
+) {
+  return (
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <MemoryRouter>
+        <SizeInMarket
+          marketId={marketId}
+          size={price}
+          decimalSource={decimalSource}
+        />
+      </MemoryRouter>
+    </MockedProvider>
+  );
+}
+
+const fullMock = {
+  request: {
+    query: ExplorerMarketDocument,
+    variables: {
+      id: '123',
+    },
+  },
+  result: {
+    data: {
+      market: {
+        id: '123',
+        decimalPlaces: 2,
+        positionDecimalPlaces: 2,
+        state: 'irrelevant-test-data',
+        tradableInstrument: {
+          instrument: {
+            name: 'test dai',
+            product: {
+              __typename: 'Future',
+              quoteName: 'dai',
+              settlementAsset: {
+                decimals: 18,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('Size in Market component', () => {
+  it('Renders the raw size when there is no market data', () => {
+    const res = render(renderComponent('100', '123', []));
+    expect(res.getByText('100')).toBeInTheDocument();
+  });
+
+  it('Renders the formatted size when market data is fetched', async () => {
+    const res = render(renderComponent('100', '123', [fullMock]));
+    expect(await res.findByText('1.00')).toBeInTheDocument();
+  });
+});

--- a/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
+++ b/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
@@ -1,0 +1,41 @@
+import { addDecimalsFormatNumber } from '@vegaprotocol/react-helpers';
+import { useExplorerMarketQuery } from '../links/market-link/__generated__/Market';
+
+export type DecimalSource = 'MARKET';
+
+export type PriceInMarketProps = {
+  marketId: string;
+  size: string | number;
+  decimalSource?: DecimalSource;
+};
+
+/**
+ * Given a market ID and an order size it will fetch the market
+ * order size, and format the size accordingly
+ */
+const SizeInMarket = ({
+  marketId,
+  size,
+  decimalSource = 'MARKET',
+}: PriceInMarketProps) => {
+  const { data } = useExplorerMarketQuery({
+    variables: { id: marketId },
+    fetchPolicy: 'cache-first',
+  });
+
+  let label = size;
+
+  if (data) {
+    if (decimalSource === 'MARKET' && data.market?.positionDecimalPlaces) {
+      label = addDecimalsFormatNumber(size, data.market.positionDecimalPlaces);
+    }
+  }
+
+  return (
+    <label>
+      <span>{label}</span>
+    </label>
+  );
+};
+
+export default SizeInMarket;


### PR DESCRIPTION
# Related issues 🔗

Closes #2860

# Description ℹ️

Update market queries to fetch positionDecimalPlaces and use that to format size field on orders.

- Update Market queries
- Add `SizeInMarket` component

<img width="832" alt="Screenshot 2023-02-06 at 15 55 46" src="https://user-images.githubusercontent.com/6678/217022890-7cca7119-5d44-413c-97b4-ecf39bbfc2d3.png">

