### PR TITLE
feat(governance): replace proposal and vote busEvents with subscriptions

### DIFF
--- a/apps/token/src/routes/proposals/components/propose/proposal-form-transaction-dialog.tsx
+++ b/apps/token/src/routes/proposals/components/propose/proposal-form-transaction-dialog.tsx
@@ -15,7 +15,7 @@ export const ProposalFormTransactionDialog = ({
   finalizedProposal,
   TransactionDialog,
 }: ProposalFormTransactionDialogProps) => {
-  // Render a custom complete UI if the proposal was rejected other wise
+  // Render a custom complete UI if the proposal was rejected otherwise
   // pass undefined so that the default vega transaction dialog UI gets used
   const completeContent = finalizedProposal?.rejectionReason ? (
     <p>{finalizedProposal.rejectionReason}</p>

--- a/apps/token/src/routes/proposals/propose/raw/proposal-raw.spec.tsx
+++ b/apps/token/src/routes/proposals/propose/raw/proposal-raw.spec.tsx
@@ -90,22 +90,15 @@ describe('Raw proposal form', () => {
     },
     result: {
       data: {
-        busEvents: [
-          {
-            __typename: 'BusEvent',
-            type: Schema.BusEventType.Proposal,
-            event: {
-              __typename: 'Proposal',
-              id: '2fca514cebf9f465ae31ecb4c5721e3a6f5f260425ded887ca50ba15b81a5d50',
-              reference: 'proposal-reference',
-              state: Schema.ProposalState.STATE_OPEN,
-              rejectionReason:
-                Schema.ProposalRejectionReason
-                  .PROPOSAL_ERROR_CLOSE_TIME_TOO_LATE,
-              errorDetails: 'error-details',
-            },
-          },
-        ],
+        proposals: {
+          __typename: 'Proposal',
+          id: '2fca514cebf9f465ae31ecb4c5721e3a6f5f260425ded887ca50ba15b81a5d50',
+          reference: 'proposal-reference',
+          state: Schema.ProposalState.STATE_OPEN,
+          rejectionReason:
+            Schema.ProposalRejectionReason.PROPOSAL_ERROR_CLOSE_TIME_TOO_LATE,
+          errorDetails: 'error-details',
+        },
       },
     },
     delay: 300,

--- a/libs/governance/src/lib/proposals-hooks/Proposal.graphql
+++ b/libs/governance/src/lib/proposals-hooks/Proposal.graphql
@@ -7,13 +7,8 @@ fragment ProposalEventFields on Proposal {
 }
 
 subscription ProposalEvent($partyId: ID!) {
-  busEvents(partyId: $partyId, batchSize: 0, types: [Proposal]) {
-    type
-    event {
-      ... on Proposal {
-        ...ProposalEventFields
-      }
-    }
+  proposals(partyId: $partyId) {
+    ...ProposalEventFields
   }
 }
 

--- a/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
+++ b/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
@@ -3,68 +3,165 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ProposalEventFieldsFragment = { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null };
+export type ProposalEventFieldsFragment = {
+  __typename?: 'Proposal';
+  id?: string | null;
+  reference: string;
+  state: Types.ProposalState;
+  rejectionReason?: Types.ProposalRejectionReason | null;
+  errorDetails?: string | null;
+};
 
 export type ProposalEventSubscriptionVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
 
+export type ProposalEventSubscription = {
+  __typename?: 'Subscription';
+  proposals: {
+    __typename?: 'Proposal';
+    id?: string | null;
+    reference: string;
+    state: Types.ProposalState;
+    rejectionReason?: Types.ProposalRejectionReason | null;
+    errorDetails?: string | null;
+  };
+};
 
-export type ProposalEventSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', type: Types.BusEventType, event: { __typename?: 'AccountEvent' } | { __typename?: 'Asset' } | { __typename?: 'AuctionEvent' } | { __typename?: 'Deposit' } | { __typename?: 'LiquidityProvision' } | { __typename?: 'LossSocialization' } | { __typename?: 'MarginLevels' } | { __typename?: 'Market' } | { __typename?: 'MarketData' } | { __typename?: 'MarketEvent' } | { __typename?: 'MarketTick' } | { __typename?: 'NodeSignature' } | { __typename?: 'OracleSpec' } | { __typename?: 'Order' } | { __typename?: 'Party' } | { __typename?: 'PositionResolution' } | { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null } | { __typename?: 'RiskFactor' } | { __typename?: 'SettleDistressed' } | { __typename?: 'SettlePosition' } | { __typename?: 'TimeUpdate' } | { __typename?: 'Trade' } | { __typename?: 'TransactionResult' } | { __typename?: 'TransferResponses' } | { __typename?: 'Vote' } | { __typename?: 'Withdrawal' } }> | null };
+export type UpdateNetworkParameterFieldsFragment = {
+  __typename?: 'Proposal';
+  id?: string | null;
+  state: Types.ProposalState;
+  datetime: any;
+  terms: {
+    __typename?: 'ProposalTerms';
+    enactmentDatetime?: any | null;
+    change:
+      | { __typename?: 'NewAsset' }
+      | { __typename?: 'NewFreeform' }
+      | { __typename?: 'NewMarket' }
+      | { __typename?: 'UpdateAsset' }
+      | { __typename?: 'UpdateMarket' }
+      | {
+          __typename?: 'UpdateNetworkParameter';
+          networkParameter: {
+            __typename?: 'NetworkParameter';
+            key: string;
+            value: string;
+          };
+        };
+  };
+};
 
-export type UpdateNetworkParameterFieldsFragment = { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } };
+export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{
+  [key: string]: never;
+}>;
 
-export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{ [key: string]: never; }>;
-
-
-export type OnUpdateNetworkParametersSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', event: { __typename?: 'AccountEvent' } | { __typename?: 'Asset' } | { __typename?: 'AuctionEvent' } | { __typename?: 'Deposit' } | { __typename?: 'LiquidityProvision' } | { __typename?: 'LossSocialization' } | { __typename?: 'MarginLevels' } | { __typename?: 'Market' } | { __typename?: 'MarketData' } | { __typename?: 'MarketEvent' } | { __typename?: 'MarketTick' } | { __typename?: 'NodeSignature' } | { __typename?: 'OracleSpec' } | { __typename?: 'Order' } | { __typename?: 'Party' } | { __typename?: 'PositionResolution' } | { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } } | { __typename?: 'RiskFactor' } | { __typename?: 'SettleDistressed' } | { __typename?: 'SettlePosition' } | { __typename?: 'TimeUpdate' } | { __typename?: 'Trade' } | { __typename?: 'TransactionResult' } | { __typename?: 'TransferResponses' } | { __typename?: 'Vote' } | { __typename?: 'Withdrawal' } }> | null };
+export type OnUpdateNetworkParametersSubscription = {
+  __typename?: 'Subscription';
+  busEvents?: Array<{
+    __typename?: 'BusEvent';
+    event:
+      | { __typename?: 'AccountEvent' }
+      | { __typename?: 'Asset' }
+      | { __typename?: 'AuctionEvent' }
+      | { __typename?: 'Deposit' }
+      | { __typename?: 'LiquidityProvision' }
+      | { __typename?: 'LossSocialization' }
+      | { __typename?: 'MarginLevels' }
+      | { __typename?: 'Market' }
+      | { __typename?: 'MarketData' }
+      | { __typename?: 'MarketEvent' }
+      | { __typename?: 'MarketTick' }
+      | { __typename?: 'NodeSignature' }
+      | { __typename?: 'OracleSpec' }
+      | { __typename?: 'Order' }
+      | { __typename?: 'Party' }
+      | { __typename?: 'PositionResolution' }
+      | {
+          __typename?: 'Proposal';
+          id?: string | null;
+          state: Types.ProposalState;
+          datetime: any;
+          terms: {
+            __typename?: 'ProposalTerms';
+            enactmentDatetime?: any | null;
+            change:
+              | { __typename?: 'NewAsset' }
+              | { __typename?: 'NewFreeform' }
+              | { __typename?: 'NewMarket' }
+              | { __typename?: 'UpdateAsset' }
+              | { __typename?: 'UpdateMarket' }
+              | {
+                  __typename?: 'UpdateNetworkParameter';
+                  networkParameter: {
+                    __typename?: 'NetworkParameter';
+                    key: string;
+                    value: string;
+                  };
+                };
+          };
+        }
+      | { __typename?: 'RiskFactor' }
+      | { __typename?: 'SettleDistressed' }
+      | { __typename?: 'SettlePosition' }
+      | { __typename?: 'TimeUpdate' }
+      | { __typename?: 'Trade' }
+      | { __typename?: 'TransactionResult' }
+      | { __typename?: 'TransferResponses' }
+      | { __typename?: 'Vote' }
+      | { __typename?: 'Withdrawal' };
+  }> | null;
+};
 
 export type ProposalOfMarketQueryVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
 }>;
 
-
-export type ProposalOfMarketQuery = { __typename?: 'Query', proposal?: { __typename?: 'Proposal', id?: string | null, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null } } | null };
+export type ProposalOfMarketQuery = {
+  __typename?: 'Query';
+  proposal?: {
+    __typename?: 'Proposal';
+    id?: string | null;
+    terms: { __typename?: 'ProposalTerms'; enactmentDatetime?: any | null };
+  } | null;
+};
 
 export const ProposalEventFieldsFragmentDoc = gql`
-    fragment ProposalEventFields on Proposal {
-  id
-  reference
-  state
-  rejectionReason
-  errorDetails
-}
-    `;
+  fragment ProposalEventFields on Proposal {
+    id
+    reference
+    state
+    rejectionReason
+    errorDetails
+  }
+`;
 export const UpdateNetworkParameterFieldsFragmentDoc = gql`
-    fragment UpdateNetworkParameterFields on Proposal {
-  id
-  state
-  datetime
-  terms {
-    enactmentDatetime
-    change {
-      ... on UpdateNetworkParameter {
-        networkParameter {
-          key
-          value
+  fragment UpdateNetworkParameterFields on Proposal {
+    id
+    state
+    datetime
+    terms {
+      enactmentDatetime
+      change {
+        ... on UpdateNetworkParameter {
+          networkParameter {
+            key
+            value
+          }
         }
       }
     }
   }
-}
-    `;
+`;
 export const ProposalEventDocument = gql`
-    subscription ProposalEvent($partyId: ID!) {
-  busEvents(partyId: $partyId, batchSize: 0, types: [Proposal]) {
-    type
-    event {
-      ... on Proposal {
-        ...ProposalEventFields
-      }
+  subscription ProposalEvent($partyId: ID!) {
+    proposals(partyId: $partyId) {
+      ...ProposalEventFields
     }
   }
-}
-    ${ProposalEventFieldsFragmentDoc}`;
+  ${ProposalEventFieldsFragmentDoc}
+`;
 
 /**
  * __useProposalEventSubscription__
@@ -82,23 +179,35 @@ export const ProposalEventDocument = gql`
  *   },
  * });
  */
-export function useProposalEventSubscription(baseOptions: Apollo.SubscriptionHookOptions<ProposalEventSubscription, ProposalEventSubscriptionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useSubscription<ProposalEventSubscription, ProposalEventSubscriptionVariables>(ProposalEventDocument, options);
-      }
-export type ProposalEventSubscriptionHookResult = ReturnType<typeof useProposalEventSubscription>;
-export type ProposalEventSubscriptionResult = Apollo.SubscriptionResult<ProposalEventSubscription>;
+export function useProposalEventSubscription(
+  baseOptions: Apollo.SubscriptionHookOptions<
+    ProposalEventSubscription,
+    ProposalEventSubscriptionVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSubscription<
+    ProposalEventSubscription,
+    ProposalEventSubscriptionVariables
+  >(ProposalEventDocument, options);
+}
+export type ProposalEventSubscriptionHookResult = ReturnType<
+  typeof useProposalEventSubscription
+>;
+export type ProposalEventSubscriptionResult =
+  Apollo.SubscriptionResult<ProposalEventSubscription>;
 export const OnUpdateNetworkParametersDocument = gql`
-    subscription OnUpdateNetworkParameters {
-  busEvents(types: [Proposal], batchSize: 0) {
-    event {
-      ... on Proposal {
-        ...UpdateNetworkParameterFields
+  subscription OnUpdateNetworkParameters {
+    busEvents(types: [Proposal], batchSize: 0) {
+      event {
+        ... on Proposal {
+          ...UpdateNetworkParameterFields
+        }
       }
     }
   }
-}
-    ${UpdateNetworkParameterFieldsFragmentDoc}`;
+  ${UpdateNetworkParameterFieldsFragmentDoc}
+`;
 
 /**
  * __useOnUpdateNetworkParametersSubscription__
@@ -115,22 +224,33 @@ export const OnUpdateNetworkParametersDocument = gql`
  *   },
  * });
  */
-export function useOnUpdateNetworkParametersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<OnUpdateNetworkParametersSubscription, OnUpdateNetworkParametersSubscriptionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useSubscription<OnUpdateNetworkParametersSubscription, OnUpdateNetworkParametersSubscriptionVariables>(OnUpdateNetworkParametersDocument, options);
-      }
-export type OnUpdateNetworkParametersSubscriptionHookResult = ReturnType<typeof useOnUpdateNetworkParametersSubscription>;
-export type OnUpdateNetworkParametersSubscriptionResult = Apollo.SubscriptionResult<OnUpdateNetworkParametersSubscription>;
+export function useOnUpdateNetworkParametersSubscription(
+  baseOptions?: Apollo.SubscriptionHookOptions<
+    OnUpdateNetworkParametersSubscription,
+    OnUpdateNetworkParametersSubscriptionVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSubscription<
+    OnUpdateNetworkParametersSubscription,
+    OnUpdateNetworkParametersSubscriptionVariables
+  >(OnUpdateNetworkParametersDocument, options);
+}
+export type OnUpdateNetworkParametersSubscriptionHookResult = ReturnType<
+  typeof useOnUpdateNetworkParametersSubscription
+>;
+export type OnUpdateNetworkParametersSubscriptionResult =
+  Apollo.SubscriptionResult<OnUpdateNetworkParametersSubscription>;
 export const ProposalOfMarketDocument = gql`
-    query ProposalOfMarket($marketId: ID!) {
-  proposal(id: $marketId) {
-    id
-    terms {
-      enactmentDatetime
+  query ProposalOfMarket($marketId: ID!) {
+    proposal(id: $marketId) {
+      id
+      terms {
+        enactmentDatetime
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useProposalOfMarketQuery__
@@ -148,14 +268,37 @@ export const ProposalOfMarketDocument = gql`
  *   },
  * });
  */
-export function useProposalOfMarketQuery(baseOptions: Apollo.QueryHookOptions<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(ProposalOfMarketDocument, options);
-      }
-export function useProposalOfMarketLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(ProposalOfMarketDocument, options);
-        }
-export type ProposalOfMarketQueryHookResult = ReturnType<typeof useProposalOfMarketQuery>;
-export type ProposalOfMarketLazyQueryHookResult = ReturnType<typeof useProposalOfMarketLazyQuery>;
-export type ProposalOfMarketQueryResult = Apollo.QueryResult<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>;
+export function useProposalOfMarketQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ProposalOfMarketQuery,
+    ProposalOfMarketQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(
+    ProposalOfMarketDocument,
+    options
+  );
+}
+export function useProposalOfMarketLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ProposalOfMarketQuery,
+    ProposalOfMarketQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ProposalOfMarketQuery,
+    ProposalOfMarketQueryVariables
+  >(ProposalOfMarketDocument, options);
+}
+export type ProposalOfMarketQueryHookResult = ReturnType<
+  typeof useProposalOfMarketQuery
+>;
+export type ProposalOfMarketLazyQueryHookResult = ReturnType<
+  typeof useProposalOfMarketLazyQuery
+>;
+export type ProposalOfMarketQueryResult = Apollo.QueryResult<
+  ProposalOfMarketQuery,
+  ProposalOfMarketQueryVariables
+>;

--- a/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
+++ b/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
@@ -3,165 +3,63 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ProposalEventFieldsFragment = {
-  __typename?: 'Proposal';
-  id?: string | null;
-  reference: string;
-  state: Types.ProposalState;
-  rejectionReason?: Types.ProposalRejectionReason | null;
-  errorDetails?: string | null;
-};
+export type ProposalEventFieldsFragment = { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null };
 
 export type ProposalEventSubscriptionVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
 
-export type ProposalEventSubscription = {
-  __typename?: 'Subscription';
-  proposals: {
-    __typename?: 'Proposal';
-    id?: string | null;
-    reference: string;
-    state: Types.ProposalState;
-    rejectionReason?: Types.ProposalRejectionReason | null;
-    errorDetails?: string | null;
-  };
-};
 
-export type UpdateNetworkParameterFieldsFragment = {
-  __typename?: 'Proposal';
-  id?: string | null;
-  state: Types.ProposalState;
-  datetime: any;
-  terms: {
-    __typename?: 'ProposalTerms';
-    enactmentDatetime?: any | null;
-    change:
-      | { __typename?: 'NewAsset' }
-      | { __typename?: 'NewFreeform' }
-      | { __typename?: 'NewMarket' }
-      | { __typename?: 'UpdateAsset' }
-      | { __typename?: 'UpdateMarket' }
-      | {
-          __typename?: 'UpdateNetworkParameter';
-          networkParameter: {
-            __typename?: 'NetworkParameter';
-            key: string;
-            value: string;
-          };
-        };
-  };
-};
+export type ProposalEventSubscription = { __typename?: 'Subscription', proposals: { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null } };
 
-export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{
-  [key: string]: never;
-}>;
+export type UpdateNetworkParameterFieldsFragment = { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } };
 
-export type OnUpdateNetworkParametersSubscription = {
-  __typename?: 'Subscription';
-  busEvents?: Array<{
-    __typename?: 'BusEvent';
-    event:
-      | { __typename?: 'AccountEvent' }
-      | { __typename?: 'Asset' }
-      | { __typename?: 'AuctionEvent' }
-      | { __typename?: 'Deposit' }
-      | { __typename?: 'LiquidityProvision' }
-      | { __typename?: 'LossSocialization' }
-      | { __typename?: 'MarginLevels' }
-      | { __typename?: 'Market' }
-      | { __typename?: 'MarketData' }
-      | { __typename?: 'MarketEvent' }
-      | { __typename?: 'MarketTick' }
-      | { __typename?: 'NodeSignature' }
-      | { __typename?: 'OracleSpec' }
-      | { __typename?: 'Order' }
-      | { __typename?: 'Party' }
-      | { __typename?: 'PositionResolution' }
-      | {
-          __typename?: 'Proposal';
-          id?: string | null;
-          state: Types.ProposalState;
-          datetime: any;
-          terms: {
-            __typename?: 'ProposalTerms';
-            enactmentDatetime?: any | null;
-            change:
-              | { __typename?: 'NewAsset' }
-              | { __typename?: 'NewFreeform' }
-              | { __typename?: 'NewMarket' }
-              | { __typename?: 'UpdateAsset' }
-              | { __typename?: 'UpdateMarket' }
-              | {
-                  __typename?: 'UpdateNetworkParameter';
-                  networkParameter: {
-                    __typename?: 'NetworkParameter';
-                    key: string;
-                    value: string;
-                  };
-                };
-          };
-        }
-      | { __typename?: 'RiskFactor' }
-      | { __typename?: 'SettleDistressed' }
-      | { __typename?: 'SettlePosition' }
-      | { __typename?: 'TimeUpdate' }
-      | { __typename?: 'Trade' }
-      | { __typename?: 'TransactionResult' }
-      | { __typename?: 'TransferResponses' }
-      | { __typename?: 'Vote' }
-      | { __typename?: 'Withdrawal' };
-  }> | null;
-};
+export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type OnUpdateNetworkParametersSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', event: { __typename?: 'AccountEvent' } | { __typename?: 'Asset' } | { __typename?: 'AuctionEvent' } | { __typename?: 'Deposit' } | { __typename?: 'LiquidityProvision' } | { __typename?: 'LossSocialization' } | { __typename?: 'MarginLevels' } | { __typename?: 'Market' } | { __typename?: 'MarketData' } | { __typename?: 'MarketEvent' } | { __typename?: 'MarketTick' } | { __typename?: 'NodeSignature' } | { __typename?: 'OracleSpec' } | { __typename?: 'Order' } | { __typename?: 'Party' } | { __typename?: 'PositionResolution' } | { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } } | { __typename?: 'RiskFactor' } | { __typename?: 'SettleDistressed' } | { __typename?: 'SettlePosition' } | { __typename?: 'TimeUpdate' } | { __typename?: 'Trade' } | { __typename?: 'TransactionResult' } | { __typename?: 'TransferResponses' } | { __typename?: 'Vote' } | { __typename?: 'Withdrawal' } }> | null };
 
 export type ProposalOfMarketQueryVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
 }>;
 
-export type ProposalOfMarketQuery = {
-  __typename?: 'Query';
-  proposal?: {
-    __typename?: 'Proposal';
-    id?: string | null;
-    terms: { __typename?: 'ProposalTerms'; enactmentDatetime?: any | null };
-  } | null;
-};
+
+export type ProposalOfMarketQuery = { __typename?: 'Query', proposal?: { __typename?: 'Proposal', id?: string | null, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null } } | null };
 
 export const ProposalEventFieldsFragmentDoc = gql`
-  fragment ProposalEventFields on Proposal {
-    id
-    reference
-    state
-    rejectionReason
-    errorDetails
-  }
-`;
+    fragment ProposalEventFields on Proposal {
+  id
+  reference
+  state
+  rejectionReason
+  errorDetails
+}
+    `;
 export const UpdateNetworkParameterFieldsFragmentDoc = gql`
-  fragment UpdateNetworkParameterFields on Proposal {
-    id
-    state
-    datetime
-    terms {
-      enactmentDatetime
-      change {
-        ... on UpdateNetworkParameter {
-          networkParameter {
-            key
-            value
-          }
+    fragment UpdateNetworkParameterFields on Proposal {
+  id
+  state
+  datetime
+  terms {
+    enactmentDatetime
+    change {
+      ... on UpdateNetworkParameter {
+        networkParameter {
+          key
+          value
         }
       }
     }
   }
-`;
+}
+    `;
 export const ProposalEventDocument = gql`
-  subscription ProposalEvent($partyId: ID!) {
-    proposals(partyId: $partyId) {
-      ...ProposalEventFields
-    }
+    subscription ProposalEvent($partyId: ID!) {
+  proposals(partyId: $partyId) {
+    ...ProposalEventFields
   }
-  ${ProposalEventFieldsFragmentDoc}
-`;
+}
+    ${ProposalEventFieldsFragmentDoc}`;
 
 /**
  * __useProposalEventSubscription__
@@ -179,35 +77,23 @@ export const ProposalEventDocument = gql`
  *   },
  * });
  */
-export function useProposalEventSubscription(
-  baseOptions: Apollo.SubscriptionHookOptions<
-    ProposalEventSubscription,
-    ProposalEventSubscriptionVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useSubscription<
-    ProposalEventSubscription,
-    ProposalEventSubscriptionVariables
-  >(ProposalEventDocument, options);
-}
-export type ProposalEventSubscriptionHookResult = ReturnType<
-  typeof useProposalEventSubscription
->;
-export type ProposalEventSubscriptionResult =
-  Apollo.SubscriptionResult<ProposalEventSubscription>;
+export function useProposalEventSubscription(baseOptions: Apollo.SubscriptionHookOptions<ProposalEventSubscription, ProposalEventSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<ProposalEventSubscription, ProposalEventSubscriptionVariables>(ProposalEventDocument, options);
+      }
+export type ProposalEventSubscriptionHookResult = ReturnType<typeof useProposalEventSubscription>;
+export type ProposalEventSubscriptionResult = Apollo.SubscriptionResult<ProposalEventSubscription>;
 export const OnUpdateNetworkParametersDocument = gql`
-  subscription OnUpdateNetworkParameters {
-    busEvents(types: [Proposal], batchSize: 0) {
-      event {
-        ... on Proposal {
-          ...UpdateNetworkParameterFields
-        }
+    subscription OnUpdateNetworkParameters {
+  busEvents(types: [Proposal], batchSize: 0) {
+    event {
+      ... on Proposal {
+        ...UpdateNetworkParameterFields
       }
     }
   }
-  ${UpdateNetworkParameterFieldsFragmentDoc}
-`;
+}
+    ${UpdateNetworkParameterFieldsFragmentDoc}`;
 
 /**
  * __useOnUpdateNetworkParametersSubscription__
@@ -224,33 +110,22 @@ export const OnUpdateNetworkParametersDocument = gql`
  *   },
  * });
  */
-export function useOnUpdateNetworkParametersSubscription(
-  baseOptions?: Apollo.SubscriptionHookOptions<
-    OnUpdateNetworkParametersSubscription,
-    OnUpdateNetworkParametersSubscriptionVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useSubscription<
-    OnUpdateNetworkParametersSubscription,
-    OnUpdateNetworkParametersSubscriptionVariables
-  >(OnUpdateNetworkParametersDocument, options);
-}
-export type OnUpdateNetworkParametersSubscriptionHookResult = ReturnType<
-  typeof useOnUpdateNetworkParametersSubscription
->;
-export type OnUpdateNetworkParametersSubscriptionResult =
-  Apollo.SubscriptionResult<OnUpdateNetworkParametersSubscription>;
-export const ProposalOfMarketDocument = gql`
-  query ProposalOfMarket($marketId: ID!) {
-    proposal(id: $marketId) {
-      id
-      terms {
-        enactmentDatetime
+export function useOnUpdateNetworkParametersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<OnUpdateNetworkParametersSubscription, OnUpdateNetworkParametersSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<OnUpdateNetworkParametersSubscription, OnUpdateNetworkParametersSubscriptionVariables>(OnUpdateNetworkParametersDocument, options);
       }
+export type OnUpdateNetworkParametersSubscriptionHookResult = ReturnType<typeof useOnUpdateNetworkParametersSubscription>;
+export type OnUpdateNetworkParametersSubscriptionResult = Apollo.SubscriptionResult<OnUpdateNetworkParametersSubscription>;
+export const ProposalOfMarketDocument = gql`
+    query ProposalOfMarket($marketId: ID!) {
+  proposal(id: $marketId) {
+    id
+    terms {
+      enactmentDatetime
     }
   }
-`;
+}
+    `;
 
 /**
  * __useProposalOfMarketQuery__
@@ -268,37 +143,14 @@ export const ProposalOfMarketDocument = gql`
  *   },
  * });
  */
-export function useProposalOfMarketQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    ProposalOfMarketQuery,
-    ProposalOfMarketQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(
-    ProposalOfMarketDocument,
-    options
-  );
-}
-export function useProposalOfMarketLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ProposalOfMarketQuery,
-    ProposalOfMarketQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    ProposalOfMarketQuery,
-    ProposalOfMarketQueryVariables
-  >(ProposalOfMarketDocument, options);
-}
-export type ProposalOfMarketQueryHookResult = ReturnType<
-  typeof useProposalOfMarketQuery
->;
-export type ProposalOfMarketLazyQueryHookResult = ReturnType<
-  typeof useProposalOfMarketLazyQuery
->;
-export type ProposalOfMarketQueryResult = Apollo.QueryResult<
-  ProposalOfMarketQuery,
-  ProposalOfMarketQueryVariables
->;
+export function useProposalOfMarketQuery(baseOptions: Apollo.QueryHookOptions<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(ProposalOfMarketDocument, options);
+      }
+export function useProposalOfMarketLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>(ProposalOfMarketDocument, options);
+        }
+export type ProposalOfMarketQueryHookResult = ReturnType<typeof useProposalOfMarketQuery>;
+export type ProposalOfMarketLazyQueryHookResult = ReturnType<typeof useProposalOfMarketLazyQuery>;
+export type ProposalOfMarketQueryResult = Apollo.QueryResult<ProposalOfMarketQuery, ProposalOfMarketQueryVariables>;

--- a/libs/governance/src/lib/proposals-hooks/use-proposal-event.ts
+++ b/libs/governance/src/lib/proposals-hooks/use-proposal-event.ts
@@ -28,24 +28,15 @@ export const useProposalEvent = (transaction: VegaTxState) => {
           variables: { partyId },
         })
         .subscribe(({ data }) => {
-          if (!data?.busEvents?.length) {
+          if (!data?.proposals) {
             return;
           }
 
-          // No types available for the subscription result
-          const matchingProposalEvent = data.busEvents.find((e) => {
-            if (e.event.__typename !== 'Proposal') {
-              return false;
-            }
+          // typo in 'proposals' - this should be singular
+          const proposal = data.proposals;
 
-            return e.event.id === id;
-          });
-
-          if (
-            matchingProposalEvent &&
-            matchingProposalEvent.event.__typename === 'Proposal'
-          ) {
-            callback(matchingProposalEvent.event);
+          if (proposal.id === id) {
+            callback(proposal);
             subRef.current?.unsubscribe();
           }
         });

--- a/libs/governance/src/lib/voting-hooks/VoteSubsciption.graphql
+++ b/libs/governance/src/lib/voting-hooks/VoteSubsciption.graphql
@@ -1,13 +1,13 @@
 fragment VoteEventFields on ProposalVote {
   proposalId
-        vote {
-          value
-          datetime
-        }
+  vote {
+    value
+    datetime
+  }
 }
 
 subscription VoteEvent($partyId: ID!) {
   votes(partyId: $partyId) {
-      ...VoteEventFields
-    }
+    ...VoteEventFields
+  }
 }

--- a/libs/governance/src/lib/voting-hooks/VoteSubsciption.graphql
+++ b/libs/governance/src/lib/voting-hooks/VoteSubsciption.graphql
@@ -1,18 +1,13 @@
-fragment VoteEventFields on Vote {
+fragment VoteEventFields on ProposalVote {
   proposalId
-  value
-  datetime
+        vote {
+          value
+          datetime
+        }
 }
 
 subscription VoteEvent($partyId: ID!) {
-  busEvents(partyId: $partyId, batchSize: 0, types: [Vote]) {
-    type
-    event {
-      ... on Vote {
-        proposalId
-        value
-        datetime
-      }
+  votes(partyId: $partyId) {
+      ...VoteEventFields
     }
-  }
 }

--- a/libs/governance/src/lib/voting-hooks/__generated__/VoteSubsciption.ts
+++ b/libs/governance/src/lib/voting-hooks/__generated__/VoteSubsciption.ts
@@ -3,36 +3,31 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type VoteEventFieldsFragment = { __typename?: 'Vote', proposalId: string, value: Types.VoteValue, datetime: any };
+export type VoteEventFieldsFragment = { __typename?: 'ProposalVote', proposalId: string, vote: { __typename?: 'Vote', value: Types.VoteValue, datetime: any } };
 
 export type VoteEventSubscriptionVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
 
 
-export type VoteEventSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', type: Types.BusEventType, event: { __typename?: 'AccountEvent' } | { __typename?: 'Asset' } | { __typename?: 'AuctionEvent' } | { __typename?: 'Deposit' } | { __typename?: 'LiquidityProvision' } | { __typename?: 'LossSocialization' } | { __typename?: 'MarginLevels' } | { __typename?: 'Market' } | { __typename?: 'MarketData' } | { __typename?: 'MarketEvent' } | { __typename?: 'MarketTick' } | { __typename?: 'NodeSignature' } | { __typename?: 'OracleSpec' } | { __typename?: 'Order' } | { __typename?: 'Party' } | { __typename?: 'PositionResolution' } | { __typename?: 'Proposal' } | { __typename?: 'RiskFactor' } | { __typename?: 'SettleDistressed' } | { __typename?: 'SettlePosition' } | { __typename?: 'TimeUpdate' } | { __typename?: 'Trade' } | { __typename?: 'TransactionResult' } | { __typename?: 'TransferResponses' } | { __typename?: 'Vote', proposalId: string, value: Types.VoteValue, datetime: any } | { __typename?: 'Withdrawal' } }> | null };
+export type VoteEventSubscription = { __typename?: 'Subscription', votes: { __typename?: 'ProposalVote', proposalId: string, vote: { __typename?: 'Vote', value: Types.VoteValue, datetime: any } } };
 
 export const VoteEventFieldsFragmentDoc = gql`
-    fragment VoteEventFields on Vote {
+    fragment VoteEventFields on ProposalVote {
   proposalId
-  value
-  datetime
+  vote {
+    value
+    datetime
+  }
 }
     `;
 export const VoteEventDocument = gql`
     subscription VoteEvent($partyId: ID!) {
-  busEvents(partyId: $partyId, batchSize: 0, types: [Vote]) {
-    type
-    event {
-      ... on Vote {
-        proposalId
-        value
-        datetime
-      }
-    }
+  votes(partyId: $partyId) {
+    ...VoteEventFields
   }
 }
-    `;
+    ${VoteEventFieldsFragmentDoc}`;
 
 /**
  * __useVoteEventSubscription__

--- a/libs/governance/src/lib/voting-hooks/use-vote-event.ts
+++ b/libs/governance/src/lib/voting-hooks/use-vote-event.ts
@@ -25,23 +25,14 @@ export const useVoteEvent = (transaction: VegaTxState) => {
           variables: { partyId },
         })
         .subscribe(({ data }) => {
-          if (!data?.busEvents?.length) {
+          if (!data?.votes) {
             return;
           }
 
-          const matchingVoteEvent = data.busEvents.find((e) => {
-            if (e.event.__typename !== 'Vote') {
-              return false;
-            }
+          const vote = data.votes;
 
-            return e.event.proposalId === proposalId;
-          });
-
-          if (
-            matchingVoteEvent &&
-            matchingVoteEvent.event.__typename === 'Vote'
-          ) {
-            callback(matchingVoteEvent.event);
+          if (vote.proposalId === proposalId) {
+            callback(vote);
             subRef.current?.unsubscribe();
           }
         });


### PR DESCRIPTION
# Related issues 🔗

Closes #2858

# Description ℹ️

Replaces proposal and vote busEvents with subscriptions, as busEvents are causing performance concerns for the core team.

NOTE: this does not replace busEvents for the Trading toast proposal queries.
