### PR TITLE
chore(trading): remove unnecessary sentry capture from asyncrenderer component

### DIFF
--- a/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
+++ b/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
@@ -1,7 +1,6 @@
 import { Splash } from '../splash';
 import type { ReactNode } from 'react';
 import { t } from '@vegaprotocol/react-helpers';
-import * as Sentry from '@sentry/react';
 
 interface AsyncRendererProps<T> {
   loading: boolean;

--- a/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
+++ b/libs/ui-toolkit/src/components/async-renderer/async-renderer.tsx
@@ -27,7 +27,6 @@ export function AsyncRenderer<T = object>({
   render,
 }: AsyncRendererProps<T>) {
   if (error) {
-    Sentry.captureException(`Error rendering data: ${error.message}`);
     if (!data) {
       return (
         <Splash>


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Removes sentry capture from body of AsyncRenderer component as its already capturing errors via the Apollo error link