### PR TITLE
feat(explorer): add vega key and eth key rotate views

### DIFF
--- a/apps/explorer/src/app/components/txs/details/tx-eth-key-rotate.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-eth-key-rotate.tsx
@@ -1,0 +1,80 @@
+import { t } from '@vegaprotocol/react-helpers';
+import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
+import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
+import { TxDetailsShared } from './shared/tx-details-shared';
+import { TableCell, TableRow, TableWithTbody } from '../../table';
+import type { components } from '../../../../types/explorer';
+import {
+  EthExplorerLink,
+  EthExplorerLinkTypes,
+} from '../../links/eth-explorer-link/eth-explorer-link';
+import { BlockLink } from '../../links';
+
+type EthKeyRotate = components['schemas']['v1EthereumKeyRotateSubmission'];
+interface TxDetailsEthKeyRotateProps {
+  txData: BlockExplorerTransactionResult | undefined;
+  pubKey: string | undefined;
+  blockData: TendermintBlocksResponse | undefined;
+}
+
+/**
+ * A node is changing ethereum key
+ */
+export const TxDetailsEthKeyRotate = ({
+  txData,
+  pubKey,
+  blockData,
+}: TxDetailsEthKeyRotateProps) => {
+  if (!txData) {
+    return <>{t('Awaiting Block Explorer transaction details')}</>;
+  }
+
+  const k: EthKeyRotate = txData.command;
+
+  return (
+    <TableWithTbody className="mb-8">
+      <TxDetailsShared txData={txData} pubKey={pubKey} blockData={blockData} />
+      {k.targetBlock ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Target block')}</TableCell>
+          <TableCell>
+            <BlockLink height={k.targetBlock} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.currentAddress ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Old Address')}</TableCell>
+          <TableCell>
+            <EthExplorerLink
+              type={EthExplorerLinkTypes.address}
+              id={k.currentAddress}
+            />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.newAddress ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('New Address')}</TableCell>
+          <TableCell>
+            <EthExplorerLink
+              type={EthExplorerLinkTypes.address}
+              id={k.newAddress}
+            />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.submitterAddress ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Submitter address')}</TableCell>
+          <TableCell>
+            <EthExplorerLink
+              type={EthExplorerLinkTypes.address}
+              id={k.submitterAddress}
+            />
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </TableWithTbody>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/tx-key-rotate.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-key-rotate.tsx
@@ -1,0 +1,67 @@
+import { t } from '@vegaprotocol/react-helpers';
+import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
+import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
+import { TxDetailsShared } from './shared/tx-details-shared';
+import { TableCell, TableRow, TableWithTbody } from '../../table';
+import type { components } from '../../../../types/explorer';
+import { BlockLink, PartyLink } from '../../links';
+
+type KeyRotate = components['schemas']['v1KeyRotateSubmission'];
+interface TxDetailsKeyRotateProps {
+  txData: BlockExplorerTransactionResult | undefined;
+  pubKey: string | undefined;
+  blockData: TendermintBlocksResponse | undefined;
+}
+
+/**
+ * A node is changing Vega key
+ */
+export const TxDetailsKeyRotate = ({
+  txData,
+  pubKey,
+  blockData,
+}: TxDetailsKeyRotateProps) => {
+  if (!txData) {
+    return <>{t('Awaiting Block Explorer transaction details')}</>;
+  }
+
+  const k: KeyRotate = txData.command;
+
+  return (
+    <TableWithTbody className="mb-8">
+      <TxDetailsShared txData={txData} pubKey={pubKey} blockData={blockData} />
+      {k.targetBlock ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Target block')}</TableCell>
+          <TableCell>
+            <BlockLink height={k.targetBlock} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.currentPubKeyHash ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Old Address')}</TableCell>
+          <TableCell>
+            <PartyLink id={k.currentPubKeyHash} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.currentPubKeyHash ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('New Address')}</TableCell>
+          <TableCell>
+            <PartyLink id={k.currentPubKeyHash} />
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {k.newPubKeyIndex ? (
+        <TableRow modifier="bordered">
+          <TableCell>{t('Key index')}</TableCell>
+          <TableCell>
+            <code>{k.newPubKeyIndex}</code>
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </TableWithTbody>
+  );
+};


### PR DESCRIPTION
# Related issues 🔗

Closes #2125. Closes #2128.

# Description ℹ️

Adds two very similar, very simple views. One is when a validator changes Vega key, the other is their Ethereum key

