### PR TITLE
feat(trading,deposits): disable deposit address

### DIFF
--- a/apps/trading-e2e/src/integration/capsule.cy.ts
+++ b/apps/trading-e2e/src/integration/capsule.cy.ts
@@ -72,7 +72,11 @@ describe('capsule - without MultiSign', { tags: '@slow' }, () => {
     cy.getByTestId('deposit-button').click();
     connectEthereumWallet('Unknown');
     cy.get(assetSelectField, txTimeout).select(btcName, { force: true });
-    cy.getByTestId('deposit-approve-submit').click();
+    cy.getByTestId('approve-warning').should(
+      'contain.text',
+      `Deposits of ${btcSymbol} not approved`
+    );
+    cy.getByTestId('deposit-submit').click();
     cy.getByTestId('dialog-title').should('contain.text', 'Approve complete');
     cy.get('[data-testid="Return to deposit"]').click();
     cy.get(amountField).clear().type('10');
@@ -407,7 +411,7 @@ describe('capsule', { tags: '@slow' }, () => {
     cy.getByTestId('deposit-button').click();
     connectEthereumWallet('Unknown');
     cy.get(assetSelectField, txTimeout).select(vegaName, { force: true });
-    cy.getByTestId('deposit-approve-submit').click();
+    cy.getByTestId('deposit-submit').click();
     cy.getByTestId('dialog-title').should('contain.text', 'Approve complete');
     cy.get('[data-testid="Return to deposit"]').click();
     cy.get(amountField).clear().type('10000');

--- a/apps/trading-e2e/src/integration/deposit.cy.ts
+++ b/apps/trading-e2e/src/integration/deposit.cy.ts
@@ -82,25 +82,6 @@ describe('deposit form validation', { tags: '@smoke' }, () => {
       .next(`[data-testid="${formFieldError}"]`)
       .should('have.text', 'Insufficient amount in Ethereum wallet');
   });
-
-  it('above deposit limit', () => {
-    // reload form with new web3 mocks
-    openDepositForm();
-    mockWeb3DepositCalls({
-      allowance: '1000',
-      depositLifetimeLimit: '600',
-      balance: '800',
-      deposited: '0',
-      dps: 5,
-    });
-    selectAsset(ASSET_EURO);
-    cy.get(amountField).clear().type('650');
-    cy.getByTestId('deposit-submit').click();
-    cy.get(`[data-testid="${formFieldError}"]`).should(
-      'have.text',
-      'Amount is above deposit limit'
-    );
-  });
 });
 
 describe('deposit actions', { tags: '@smoke' }, () => {

--- a/apps/trading-e2e/src/integration/deposit.cy.ts
+++ b/apps/trading-e2e/src/integration/deposit.cy.ts
@@ -1,3 +1,5 @@
+import { removeDecimal } from '@vegaprotocol/cypress';
+import { ethers } from 'ethers';
 import { connectEthereumWallet } from '../support/ethereum-wallet';
 import { selectAsset } from '../support/helpers';
 
@@ -44,6 +46,13 @@ describe('deposit form validation', { tags: '@smoke' }, () => {
   });
 
   it('invalid amount', () => {
+    mockWeb3DepositCalls({
+      allowance: '1000',
+      depositLifetimeLimit: '600',
+      balance: '800',
+      deposited: '0',
+      dps: 5,
+    });
     // Deposit amount smaller than minimum viable for selected asset
     // Select an amount so that we have a known decimal places value to work with
     selectAsset(ASSET_EURO);
@@ -56,14 +65,33 @@ describe('deposit form validation', { tags: '@smoke' }, () => {
   });
 
   it('insufficient funds', () => {
-    // 1001-DEPO-005
-    // Deposit amount is valid, but less than approved. This will always be the case because our
-    // CI wallet wont have approved any assets
+    mockWeb3DepositCalls({
+      allowance: '1000',
+      depositLifetimeLimit: '600',
+      balance: '800',
+      deposited: '0',
+      dps: 5,
+    });
     cy.get(amountField)
       .clear()
-      .type('100')
+      .type('850')
       .next(`[data-testid="${formFieldError}"]`)
       .should('have.text', 'Insufficient amount in Ethereum wallet');
+  });
+
+  it('above deposit limit', () => {
+    mockWeb3DepositCalls({
+      allowance: '1000',
+      depositLifetimeLimit: '600',
+      balance: '800',
+      deposited: '0',
+      dps: 5,
+    });
+    cy.get(amountField)
+      .clear()
+      .type('650')
+      .next(`[data-testid="${formFieldError}"]`)
+      .should('have.text', 'Amount is above deposit limit');
   });
 });
 
@@ -88,3 +116,90 @@ describe('deposit actions', { tags: '@smoke' }, () => {
     cy.getByTestId('deposit-submit').should('be.visible');
   });
 });
+
+function mockWeb3DepositCalls({
+  allowance,
+  depositLifetimeLimit,
+  balance,
+  deposited,
+  dps,
+}: {
+  allowance: string;
+  depositLifetimeLimit: string;
+  balance: string;
+  deposited: string;
+  dps: number;
+}) {
+  const assetContractAddress = '0x0158031158bb4df2ad02eaa31e8963e84ea978a4';
+  const collateralBridgeAddress = '0x7fe27d970bc8afc3b11cc8d9737bfb66b1efd799';
+  const toResult = (value: string, dps: number) => {
+    const rawValue = removeDecimal(value, dps);
+    return ethers.utils.hexZeroPad(
+      ethers.utils.hexlify(parseInt(rawValue)),
+      32
+    );
+  };
+  cy.intercept('POST', 'http://localhost:8545', (req) => {
+    // Mock chainId call
+    if (req.body.method === 'eth_chainId') {
+      req.alias = 'eth_chainId';
+      req.reply({
+        id: req.body.id,
+        jsonrpc: req.body.jsonrpc,
+        result: '0xaa36a7', // 11155111 for sepolia chain id
+      });
+    }
+
+    // Mock deposited amount
+    if (req.body.method === 'eth_getStorageAt') {
+      req.alias = 'eth_getStorageAt';
+      req.reply({
+        id: req.body.id,
+        jsonrpc: req.body.jsonrpc,
+        result: toResult(deposited, dps),
+      });
+    }
+
+    if (req.body.method === 'eth_call') {
+      // Mock approved amount for asset on collateral bridge
+      if (
+        req.body.params[0].to === assetContractAddress &&
+        req.body.params[0].data ===
+          '0xdd62ed3e000000000000000000000000ee7d375bcb50c26d52e1a4a472d8822a2a22d94f0000000000000000000000007fe27d970bc8afc3b11cc8d9737bfb66b1efd799'
+      ) {
+        req.alias = 'eth_call_allowance';
+        req.reply({
+          id: req.body.id,
+          jsonrpc: req.body.jsonrpc,
+          result: toResult(allowance, dps),
+        });
+      }
+      // Mock balance of asset in Ethereum wallet
+      else if (
+        req.body.params[0].to === assetContractAddress &&
+        req.body.params[0].data ===
+          '0x70a08231000000000000000000000000ee7d375bcb50c26d52e1a4a472d8822a2a22d94f'
+      ) {
+        req.alias = 'eth_call_balanceOf';
+        req.reply({
+          id: req.body.id,
+          jsonrpc: req.body.jsonrpc,
+          result: toResult(balance, dps),
+        });
+      }
+      // Mock deposit lifetime limit
+      else if (
+        req.body.params[0].to === collateralBridgeAddress &&
+        req.body.params[0].data ===
+          '0x354a897a0000000000000000000000000158031158bb4df2ad02eaa31e8963e84ea978a4'
+      ) {
+        req.alias = 'eth_call_get_deposit_maximum'; // deposit lifetime limit
+        req.reply({
+          id: req.body.id,
+          jsonrpc: req.body.jsonrpc,
+          result: toResult(depositLifetimeLimit, dps),
+        });
+      }
+    }
+  });
+}

--- a/apps/trading-e2e/src/integration/wallets.cy.ts
+++ b/apps/trading-e2e/src/integration/wallets.cy.ts
@@ -17,12 +17,13 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
   });
 
   it('can connect', () => {
-    cy.getByTestId(connectVegaBtn).click();
+    // Mock authentication
     cy.intercept('POST', 'https://wallet.testnet.vega.xyz/api/v1/auth/token', {
       body: {
         token: 'test-token',
       },
     });
+    // Mock getting keys from wallet
     cy.intercept('GET', 'https://wallet.testnet.vega.xyz/api/v1/keys', {
       body: {
         keys: [
@@ -39,6 +40,7 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
         ],
       },
     });
+    cy.getByTestId(connectVegaBtn).click();
     cy.contains('Connect Vega wallet');
     cy.contains('Hosted Fairground wallet');
 
@@ -52,11 +54,12 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
   });
 
   it('doesnt connect with invalid credentials', () => {
+    // Mock incorrect username/password
     cy.intercept('POST', 'https://wallet.testnet.vega.xyz/api/v1/auth/token', {
       body: {
         error: 'No wallet',
       },
-      statusCode: 403,
+      statusCode: 403, // 403 forbidden invalid crednetials
     });
     cy.getByTestId(connectVegaBtn).click();
     cy.getByTestId('connectors-list')
@@ -65,7 +68,7 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
     cy.getByTestId(form).find('#wallet').click().type('invalid name');
     cy.getByTestId(form).find('#passphrase').click().type('invalid password');
     cy.getByTestId('rest-connector-form').find('button[type=submit]').click();
-    cy.getByTestId('form-error').should('have.text', 'No wallet detected');
+    cy.getByTestId('form-error').should('have.text', 'Invalid credentials');
   });
 
   it('doesnt connect with empty fields', () => {

--- a/apps/trading-e2e/src/integration/wallets.cy.ts
+++ b/apps/trading-e2e/src/integration/wallets.cy.ts
@@ -18,18 +18,46 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
 
   it('can connect', () => {
     cy.getByTestId(connectVegaBtn).click();
-    mockConnectWallet();
+    cy.intercept('POST', 'https://wallet.testnet.vega.xyz/api/v1/auth/token', {
+      body: {
+        token: 'test-token',
+      },
+    });
+    cy.intercept('GET', 'https://wallet.testnet.vega.xyz/api/v1/keys', {
+      body: {
+        keys: [
+          {
+            algorithm: {
+              name: 'algo',
+              version: 1,
+            },
+            index: 0,
+            meta: [],
+            pub: 'HOSTED_PUBKEY',
+            tainted: false,
+          },
+        ],
+      },
+    });
     cy.contains('Connect Vega wallet');
     cy.contains('Hosted Fairground wallet');
 
     cy.getByTestId('connectors-list')
-      .find('[data-testid="connector-jsonRpc"]')
+      .find('[data-testid="connector-hosted"]')
       .click();
-    cy.wait('@walletReq');
+    cy.getByTestId(form).find('#wallet').click().type('user');
+    cy.getByTestId(form).find('#passphrase').click().type('pass');
+    cy.getByTestId('rest-connector-form').find('button[type=submit]').click();
     cy.getByTestId(manageVegaBtn).should('exist');
   });
 
   it('doesnt connect with invalid credentials', () => {
+    cy.intercept('POST', 'https://wallet.testnet.vega.xyz/api/v1/auth/token', {
+      body: {
+        error: 'No wallet',
+      },
+      statusCode: 403,
+    });
     cy.getByTestId(connectVegaBtn).click();
     cy.getByTestId('connectors-list')
       .find('[data-testid="connector-hosted"]')
@@ -40,7 +68,7 @@ describe('connect hosted wallet', { tags: '@smoke' }, () => {
     cy.getByTestId('form-error').should('have.text', 'No wallet detected');
   });
 
-  it('doesnt connect with invalid fields', () => {
+  it('doesnt connect with empty fields', () => {
     cy.getByTestId(connectVegaBtn).click();
     cy.getByTestId('connectors-list')
       .find('[data-testid="connector-hosted"]')

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -318,33 +318,37 @@ const SummaryMessage = memo(
     }
     if (!pubKey) {
       return (
-        <Notification
-          testId={'deal-ticket-connect-wallet'}
-          intent={Intent.Warning}
-          message={
-            <p className="text-sm pb-2">
-              You need a{' '}
-              <ExternalLink href="https://vega.xyz/wallet">
-                Vega wallet
-              </ExternalLink>{' '}
-              with {assetSymbol} to start trading in this market.
-            </p>
-          }
-          buttonProps={{
-            text: t('Connect wallet'),
-            action: openVegaWalletDialog,
-            dataTestId: 'order-connect-wallet',
-            size: 'md',
-          }}
-        />
+        <div className="mb-4">
+          <Notification
+            testId={'deal-ticket-connect-wallet'}
+            intent={Intent.Warning}
+            message={
+              <p className="text-sm pb-2">
+                You need a{' '}
+                <ExternalLink href="https://vega.xyz/wallet">
+                  Vega wallet
+                </ExternalLink>{' '}
+                with {assetSymbol} to start trading in this market.
+              </p>
+            }
+            buttonProps={{
+              text: t('Connect wallet'),
+              action: openVegaWalletDialog,
+              dataTestId: 'order-connect-wallet',
+              size: 'md',
+            }}
+          />
+        </div>
       );
     }
     if (errorMessage === SummaryValidationType.NoCollateral) {
       return (
-        <ZeroBalanceError
-          asset={market.tradableInstrument.instrument.product.settlementAsset}
-          onClickCollateral={onClickCollateral}
-        />
+        <div className="mb-4">
+          <ZeroBalanceError
+            asset={market.tradableInstrument.instrument.product.settlementAsset}
+            onClickCollateral={onClickCollateral}
+          />
+        </div>
       );
     }
 
@@ -363,7 +367,11 @@ const SummaryMessage = memo(
     // If there is no blocking error but user doesn't have enough
     // balance render the margin warning, but still allow submission
     if (balanceError) {
-      return <MarginWarning balance={balance} margin={margin} asset={asset} />;
+      return (
+        <div className="mb-4">
+          <MarginWarning balance={balance} margin={margin} asset={asset} />;
+        </div>
+      );
     }
 
     // Show auction mode warning
@@ -375,13 +383,15 @@ const SummaryMessage = memo(
       ].includes(marketData.marketTradingMode)
     ) {
       return (
-        <Notification
-          intent={Intent.Warning}
-          testId={'dealticket-warning-auction'}
-          message={t(
-            'Any orders placed now will not trade until the auction ends'
-          )}
-        />
+        <div className="mb-4">
+          <Notification
+            intent={Intent.Warning}
+            testId={'dealticket-warning-auction'}
+            message={t(
+              'Any orders placed now will not trade until the auction ends'
+            )}
+          />
+        </div>
       );
     }
 

--- a/libs/deposits/src/lib/deposit-form.spec.tsx
+++ b/libs/deposits/src/lib/deposit-form.spec.tsx
@@ -145,7 +145,7 @@ describe('Deposit form', () => {
       fireEvent.submit(screen.getByTestId('deposit-form'));
 
       expect(
-        await screen.findByText('Insufficient amount in Ethereum wallet')
+        await screen.findByText('Amount is above deposit limit')
       ).toBeInTheDocument();
     });
 
@@ -166,7 +166,7 @@ describe('Deposit form', () => {
       fireEvent.submit(screen.getByTestId('deposit-form'));
 
       expect(
-        await screen.findByText('Amount is above approved amount')
+        await screen.findByText('Amount is above approved amount.')
       ).toBeInTheDocument();
     });
 

--- a/libs/deposits/src/lib/deposit-form.spec.tsx
+++ b/libs/deposits/src/lib/deposit-form.spec.tsx
@@ -4,10 +4,12 @@ import type { DepositFormProps } from './deposit-form';
 import { DepositForm } from './deposit-form';
 import * as Schema from '@vegaprotocol/types';
 import { useVegaWallet } from '@vegaprotocol/wallet';
+import { useWeb3ConnectStore } from '@vegaprotocol/web3';
 import { useWeb3React } from '@web3-react/core';
 import type { AssetFieldsFragment } from '@vegaprotocol/assets';
 
 jest.mock('@vegaprotocol/wallet');
+jest.mock('@vegaprotocol/web3');
 jest.mock('@web3-react/core');
 
 const mockConnector = { deactivate: jest.fn() };
@@ -37,6 +39,8 @@ function generateAsset(): AssetFieldsFragment {
 let asset: AssetFieldsFragment;
 let props: DepositFormProps;
 const MOCK_ETH_ADDRESS = '0x72c22822A19D20DE7e426fB84aa047399Ddd8853';
+const MOCK_VEGA_KEY =
+  '70d14a321e02e71992fd115563df765000ccc4775cbe71a0e2f9ff5a3b9dc680';
 
 beforeEach(() => {
   asset = generateAsset();
@@ -89,14 +93,17 @@ describe('Deposit form', () => {
       });
     });
 
-    it('fails when submitted with invalid ethereum address', async () => {
-      (useWeb3React as jest.Mock).mockReturnValue({ account: '123' });
+    it('fails when Ethereum wallet not connected', async () => {
+      (useWeb3React as jest.Mock).mockReturnValue({
+        isActive: false,
+        account: '',
+      });
       render(<DepositForm {...props} />);
 
       fireEvent.submit(screen.getByTestId('deposit-form'));
 
       expect(
-        await screen.findByText('Invalid Ethereum address')
+        await screen.findByText('Connect Ethereum wallet')
       ).toBeInTheDocument();
     });
 
@@ -193,9 +200,9 @@ describe('Deposit form', () => {
     });
   });
 
-  it('handles deposit approvals', () => {
+  it('handles deposit approvals', async () => {
     const mockUseVegaWallet = useVegaWallet as jest.Mock;
-    mockUseVegaWallet.mockReturnValue({ pubKey: null });
+    mockUseVegaWallet.mockReturnValue({ pubKey: MOCK_VEGA_KEY });
 
     const mockUseWeb3React = useWeb3React as jest.Mock;
     mockUseWeb3React.mockReturnValue({
@@ -212,13 +219,18 @@ describe('Deposit form', () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByText(`Approve ${asset.symbol}`, {
-        selector: '[type="button"]',
-      })
+    expect(screen.queryByLabelText('Amount')).not.toBeInTheDocument();
+    expect(screen.getByTestId('approve-warning')).toHaveTextContent(
+      `Deposits of ${asset.symbol} not approved`
     );
 
-    expect(props.submitApprove).toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole('button', { name: `Approve ${asset.symbol}` })
+    );
+
+    await waitFor(() => {
+      expect(props.submitApprove).toHaveBeenCalled();
+    });
   });
 
   it('handles submitting a deposit', async () => {
@@ -283,5 +295,56 @@ describe('Deposit form', () => {
   it('does not shows "View asset details" button when no asset is selected', async () => {
     render(<DepositForm {...props} />);
     expect(await screen.queryAllByTestId('view-asset-details')).toHaveLength(0);
+  });
+
+  it('renders a connect button if Ethereum wallet is not connected', () => {
+    (useWeb3React as jest.Mock).mockReturnValue({
+      isActive: false,
+      account: '',
+    });
+    render(<DepositForm {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('From (Ethereum address)')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a disabled input if Ethereum wallet is connected', () => {
+    (useWeb3React as jest.Mock).mockReturnValue({
+      isActive: true,
+      account: MOCK_ETH_ADDRESS,
+    });
+    render(<DepositForm {...props} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Connect' })
+    ).not.toBeInTheDocument();
+    const fromInput = screen.getByLabelText('From (Ethereum address)');
+    expect(fromInput).toHaveValue(MOCK_ETH_ADDRESS);
+    expect(fromInput).toBeDisabled();
+    expect(fromInput).toHaveAttribute('readonly');
+  });
+
+  it('prevents submission if you are on the wrong chain', () => {
+    (useWeb3React as jest.Mock).mockReturnValue({
+      isActive: true,
+      account: MOCK_ETH_ADDRESS,
+      chainId: 1,
+    });
+    (useWeb3ConnectStore as unknown as jest.Mock).mockImplementation(
+      // eslint-disable-next-line
+      (selector: (result: ReturnType<typeof useWeb3ConnectStore>) => any) => {
+        return selector({
+          desiredChainId: 11155111,
+          open: jest.fn(),
+          foo: 'asdf',
+        });
+      }
+    );
+    render(<DepositForm {...props} />);
+    expect(screen.getByTestId('chain-error')).toHaveTextContent(
+      /this app only works on/i
+    );
   });
 });

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -186,12 +186,16 @@ export const DepositForm = ({
                       },
                     })}
                   />
-                  <DisconnectEthereumButton />
+                  <DisconnectEthereumButton
+                    onDisconnect={() => {
+                      setValue('from', ''); // clear from value so required ethereum connection validation works
+                    }}
+                  />
                 </>
               );
             }
             return (
-              <Button onClick={openDialog} fill={true}>
+              <Button onClick={openDialog} variant="primary" fill={true}>
                 {t('Connect')}
               </Button>
             );
@@ -365,7 +369,7 @@ const FormButton = ({ selectedAsset, formState }: FormButtonProps) => {
       <Button
         type="submit"
         data-testid="deposit-submit"
-        variant="primary"
+        variant={isActive ? 'primary' : 'default'}
         fill={true}
         disabled={invalidChain}
       >
@@ -387,7 +391,11 @@ const UseButton = (props: UseButtonProps) => {
   );
 };
 
-const DisconnectEthereumButton = () => {
+const DisconnectEthereumButton = ({
+  onDisconnect,
+}: {
+  onDisconnect: () => void;
+}) => {
   const { connector } = useWeb3React();
   const [, , removeEagerConnector] = useLocalStorage(ETHEREUM_EAGER_CONNECT);
 
@@ -396,6 +404,7 @@ const DisconnectEthereumButton = () => {
       onClick={() => {
         connector.deactivate();
         removeEagerConnector();
+        onDisconnect();
       }}
       data-testid="disconnect-ethereum-wallet"
     >

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -200,6 +200,7 @@ export const DepositForm = ({
                 variant="primary"
                 fill={true}
                 type="button"
+                data-testid="connect-eth-wallet-btn"
               >
                 {t('Connect')}
               </Button>

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -290,6 +290,7 @@ export const DepositForm = ({
             deposited={deposited}
             balance={balance}
             asset={selectedAsset}
+            allowance={allowance}
           />
         </div>
       )}
@@ -308,7 +309,7 @@ export const DepositForm = ({
                   if (value.isGreaterThan(maxAmount.available)) {
                     return t('Insufficient amount in Ethereum wallet');
                   } else if (value.isGreaterThan(maxAmount.limit)) {
-                    return t('Amount is above temporary deposit limit');
+                    return t('Amount is above deposit limit');
                   } else if (value.isGreaterThan(maxAmount.approved)) {
                     return t('Amount is above approved amount');
                   }

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -171,7 +171,7 @@ export const DepositForm = ({
           }}
           defaultValue={account}
           render={() => {
-            if (isActive) {
+            if (isActive && account) {
               return (
                 <>
                   <Input
@@ -195,7 +195,12 @@ export const DepositForm = ({
               );
             }
             return (
-              <Button onClick={openDialog} variant="primary" fill={true}>
+              <Button
+                onClick={openDialog}
+                variant="primary"
+                fill={true}
+                type="button"
+              >
                 {t('Connect')}
               </Button>
             );
@@ -352,6 +357,7 @@ const FormButton = ({ selectedAsset, formState }: FormButtonProps) => {
         <div className="mb-2">
           <Notification
             intent={Intent.Warning}
+            testId="approve-warning"
             message={t(`Deposits of ${selectedAsset?.symbol} not approved`)}
           />
         </div>
@@ -360,6 +366,7 @@ const FormButton = ({ selectedAsset, formState }: FormButtonProps) => {
         <div className="mb-2">
           <Notification
             intent={Intent.Danger}
+            testId="chain-error"
             message={t(
               `This app only works on ${getChainName(desiredChainId)}.`
             )}

--- a/libs/deposits/src/lib/deposit-limits.tsx
+++ b/libs/deposits/src/lib/deposit-limits.tsx
@@ -11,6 +11,7 @@ interface DepositLimitsProps {
   deposited: BigNumber;
   asset: Asset;
   balance?: BigNumber;
+  allowance?: BigNumber;
 }
 
 export const DepositLimits = ({
@@ -18,6 +19,7 @@ export const DepositLimits = ({
   deposited,
   asset,
   balance,
+  allowance,
 }: DepositLimitsProps) => {
   const limits = [
     {
@@ -43,6 +45,12 @@ export const DepositLimits = ({
       label: t('Remaining'),
       rawValue: max.minus(deposited),
       value: compactNumber(max.minus(deposited), asset.decimals),
+    },
+    {
+      key: 'ALLOWANCE',
+      label: t('Approved'),
+      rawValue: allowance,
+      value: allowance ? compactNumber(allowance, asset.decimals) : '-',
     },
   ];
 

--- a/libs/governance/src/components/asset-proposal-notification.tsx
+++ b/libs/governance/src/components/asset-proposal-notification.tsx
@@ -27,12 +27,13 @@ export const AssetProposalNotification = ({
       </>
     );
     return (
-      <Notification
-        intent={Intent.Warning}
-        message={message}
-        testId="asset-proposal-notification"
-        className="mb-2"
-      />
+      <div className="mb-2">
+        <Notification
+          intent={Intent.Warning}
+          message={message}
+          testId="asset-proposal-notification"
+        />
+      </div>
     );
   }
 

--- a/libs/governance/src/components/market-proposal-notification.tsx
+++ b/libs/governance/src/components/market-proposal-notification.tsx
@@ -34,7 +34,6 @@ export const MarketProposalNotification = ({
           intent={Intent.Warning}
           message={message}
           testId="market-proposal-notification"
-          className="px-2 py-1"
         />
       </div>
     );

--- a/libs/ui-toolkit/src/components/notification/notification.tsx
+++ b/libs/ui-toolkit/src/components/notification/notification.tsx
@@ -19,7 +19,6 @@ type NotificationProps = {
     size?: ButtonSize;
   };
   testId?: string;
-  className?: string;
 };
 
 const getIcon = (intent: Intent): IconName => {
@@ -39,7 +38,6 @@ export const Notification = ({
   title,
   testId,
   buttonProps,
-  className,
 }: NotificationProps) => {
   return (
     <div
@@ -61,8 +59,7 @@ export const Notification = ({
             intent === Intent.Warning,
           'bg-vega-pink-300 dark:bg-vega-pink-650': intent === Intent.Danger,
         },
-        'border rounded p-2 flex items-start gap-2.5 my-4',
-        className
+        'border rounded p-2 flex items-start gap-2.5'
       )}
     >
       <div


### PR DESCRIPTION
# Related issues 🔗

Closes #2823 
Closes #2807 

# Description ℹ️

- Makes the approval step more explicit by removing the amount field.
- Makes connecting an Ethereum account more obvious by providing a connect button in place of the input field.
- Shows approved amount field 

# Demo 📺

Connect flow with validation:
<img src="https://user-images.githubusercontent.com/6803987/219465935-c4278000-30a0-406e-b7f0-c8d5f0fffa8b.jpg" width="200" />

No amount field if user has never approved:
<img src="https://user-images.githubusercontent.com/6803987/219465987-e8059c9b-76e1-4c02-be02-61f3fbe18cc3.jpg" width="200" />

Re prompt for approval if amount is more than approved
<img src="https://user-images.githubusercontent.com/6803987/220534278-10113e1b-2abf-4442-86f5-8266805eb6e3.jpg" width="200" />


# Technical 👨‍🔧

- Removed classname prop from notification to avoid modification of spacing
- Removed default spacing from Notification component, adjust areas where its used to apply the spacing from the parent
