### PR TITLE
fix(governance): navigation token drop down behaviour

### DIFF
--- a/apps/token/src/components/nav/nav-dropdown.tsx
+++ b/apps/token/src/components/nav/nav-dropdown.tsx
@@ -18,7 +18,7 @@ export const NavDropDown = ({ navbarTheme }: { navbarTheme: NavbarTheme }) => {
       <AppNavLink
         name={
           <NavDropdownMenuTrigger
-            className="w-auto flex items-center"
+            className="w-auto flex items-center -m-3 p-3 cursor-pointer"
             data-testid="state-trigger"
             onClick={() => setOpen(!isOpen)}
           >

--- a/libs/ui-toolkit/src/components/nav-dropdown/dropdown-menu.tsx
+++ b/libs/ui-toolkit/src/components/nav-dropdown/dropdown-menu.tsx
@@ -53,7 +53,7 @@ export const NavDropdownMenuContent = forwardRef<
   <DropdownMenuPrimitive.Content
     {...contentProps}
     ref={forwardedRef}
-    className="bg-vega-dark-100 mt-4 py-4 rounded-xl border border-vega-dark-200 text-white"
+    className="z-10 bg-vega-dark-100 mt-4 py-4 rounded-xl border border-vega-dark-200 text-white"
     align="start"
     sideOffset={10}
   />


### PR DESCRIPTION
# Related issues 🔗

Closes #2656
Closes #2875

# Description ℹ️

Ensures Token dropdown menu opens consistently regardless of where in the link is clicked. Also added the correct cursor (good spot @neildawson) and as it was a one liner, I also fixed the z-index issue with the dropdown itself (#2875)
