### PR TITLE
fix(governance): overstaked penalty shown as NaN

### DIFF
--- a/apps/token/src/routes/staking/shared.ts
+++ b/apps/token/src/routes/staking/shared.ts
@@ -59,11 +59,17 @@ export const getOverstakedAmount = (
 export const getOverstakingPenalty = (
   overstakedAmount: BigNumber,
   stakedOnNode: string
-) =>
-  formatNumberPercentage(
+) => {
+  // avoid division by zero
+  if (new BigNumber(stakedOnNode).isZero() || overstakedAmount.isZero()) {
+    return '0';
+  }
+
+  return formatNumberPercentage(
     overstakedAmount.dividedBy(new BigNumber(stakedOnNode)).times(100),
     2
   );
+};
 
 export const getTotalPenalties = (
   rawValidatorScore: string | null | undefined,


### PR DESCRIPTION
# Related issues 🔗

Closes #2886

# Description ℹ️

Fixed a division by zero error when validators have no stake.
