### PR TITLE
feat(wallet): tighten up the flow for "view as vega user"

### DIFF
--- a/libs/wallet/src/connect-dialog/connect-dialog-elements.tsx
+++ b/libs/wallet/src/connect-dialog/connect-dialog-elements.tsx
@@ -7,7 +7,7 @@ export const ConnectDialogTitle = ({ children }: { children: ReactNode }) => {
   return (
     <h1
       data-testid="wallet-dialog-title"
-      className="text-2xl uppercase mb-6 text-center"
+      className="text-2xl uppercase mb-6 text-center font-alpha"
     >
       {children}
     </h1>

--- a/libs/wallet/src/connect-dialog/connect-dialog.tsx
+++ b/libs/wallet/src/connect-dialog/connect-dialog.tsx
@@ -229,6 +229,7 @@ const ConnectorList = ({
             </li>
           )}
           <li className="mb-4 last:mb-0">
+            <div className="my-4 text-center text-vega-dark-400">{t('OR')}</div>
             <ConnectionOption
               type="view"
               text={t('View as vega user')}
@@ -264,6 +265,13 @@ const SelectedForm = ({
     return (
       <>
         <ConnectDialogContent>
+          <button
+            onClick={reset}
+            className="absolute p-2 top-0 left-0 md:top-2 md:left-2"
+            data-testid="back-button"
+          >
+            <Icon name={'chevron-left'} ariaLabel="back" size={4} />
+          </button>
           <ConnectDialogTitle>{t('Connect')}</ConnectDialogTitle>
           <div className="mb-2">
             <RestConnectorForm connector={connector} onConnect={onConnect} />
@@ -315,7 +323,11 @@ const SelectedForm = ({
     return (
       <>
         <ConnectDialogContent>
-          <ViewConnectorForm connector={connector} onConnect={onConnect} />
+          <ViewConnectorForm
+            connector={connector}
+            onConnect={onConnect}
+            reset={reset}
+          />
         </ConnectDialogContent>
         <ConnectDialogFooter />
       </>

--- a/libs/wallet/src/connect-dialog/view-connector-form.tsx
+++ b/libs/wallet/src/connect-dialog/view-connector-form.tsx
@@ -1,5 +1,11 @@
 import { t } from '@vegaprotocol/react-helpers';
-import { Button, FormGroup, Input, InputError } from '@vegaprotocol/ui-toolkit';
+import {
+  Button,
+  FormGroup,
+  Icon,
+  Input,
+  InputError,
+} from '@vegaprotocol/ui-toolkit';
 import { useForm } from 'react-hook-form';
 import type { ViewConnector } from '../connectors';
 import { useVegaWallet } from '../use-vega-wallet';
@@ -11,11 +17,13 @@ interface FormFields {
 interface RestConnectorFormProps {
   connector: ViewConnector;
   onConnect: (connector: ViewConnector) => void;
+  reset: () => void;
 }
 
 export function ViewConnectorForm({
   connector,
   onConnect,
+  reset,
 }: RestConnectorFormProps) {
   const { connect } = useVegaWallet();
   const {
@@ -41,24 +49,46 @@ export function ViewConnectorForm({
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} data-testid="view-connector-form">
-      <FormGroup label={t('Vega Pubkey')} labelFor="address">
-        <Input
-          {...register('address', {
-            required: t('Required'),
-            validate: validatePubkey,
-          })}
-          id="address"
-          data-testid="address"
-          type="text"
-        />
-        {errors.address?.message && (
-          <InputError intent="danger">{errors.address.message}</InputError>
-        )}
-      </FormGroup>
-      <Button data-testid="connect" variant="primary" type="submit" fill={true}>
-        {t('Connect')}
-      </Button>
-    </form>
+    <>
+      <button
+        onClick={reset}
+        className="absolute p-2 top-0 left-0 md:top-2 md:left-2"
+        data-testid="back-button"
+      >
+        <Icon name={'chevron-left'} ariaLabel="back" size={4} />
+      </button>
+      <form onSubmit={handleSubmit(onSubmit)} data-testid="view-connector-form">
+        <h1 className="text-2xl uppercase mb-6 text-center font-alpha">
+          {t('VIEW AS VEGA USER')}
+        </h1>
+        <p className="mb-4">
+          {t(
+            'Browse from the perspective of another Vega user in read-only mode.'
+          )}
+        </p>
+        <FormGroup label={t('Vega Pubkey')} labelFor="address">
+          <Input
+            {...register('address', {
+              required: t('Required'),
+              validate: validatePubkey,
+            })}
+            id="address"
+            data-testid="address"
+            type="text"
+          />
+          {errors.address?.message && (
+            <InputError intent="danger">{errors.address.message}</InputError>
+          )}
+        </FormGroup>
+        <Button
+          data-testid="connect"
+          variant="primary"
+          type="submit"
+          fill={true}
+        >
+          {t('Browse network')}
+        </Button>
+      </form>
+    </>
   );
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #2725

# Description ℹ️

Makes changes to the 'view as vega user' wallet connection option. Also adds a back button to the hosted wallet and vega user connection options.

# Demo 📺

<img width="632" alt="Screenshot 2023-02-17 at 16 20 55" src="https://user-images.githubusercontent.com/2410498/219708439-e15fac5c-831d-4854-bc5e-ec789b1a78dc.png">

<img width="634" alt="Screenshot 2023-02-17 at 16 20 45" src="https://user-images.githubusercontent.com/2410498/219708442-b1f5e01a-b0f8-4b75-9f26-34d12404c489.png">

<img width="632" alt="Screenshot 2023-02-17 at 16 20 38" src="https://user-images.githubusercontent.com/2410498/219708446-be6508b2-65ef-4e27-bc36-7b2b70c3a0f6.png">
