### PR TITLE
chore(trading,governance): remove busEvent for proposals

### DIFF
--- a/apps/token/src/hooks/use-pending-balances-manager.spec.ts
+++ b/apps/token/src/hooks/use-pending-balances-manager.spec.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
 import { usePendingBalancesStore } from './use-pending-balances-manager';
 import type { Event } from 'ethers';
 

--- a/libs/governance/src/lib/proposals-hooks/Proposal.graphql
+++ b/libs/governance/src/lib/proposals-hooks/Proposal.graphql
@@ -1,3 +1,17 @@
+fragment ProposalEventFields on Proposal {
+  id
+  reference
+  state
+  rejectionReason
+  errorDetails
+}
+
+subscription ProposalEvent($partyId: ID!) {
+  proposals(partyId: $partyId) {
+    ...ProposalEventFields
+  }
+}
+
 fragment UpdateNetworkParameterProposal on Proposal {
   id
   state

--- a/libs/governance/src/lib/proposals-hooks/Proposal.graphql
+++ b/libs/governance/src/lib/proposals-hooks/Proposal.graphql
@@ -1,17 +1,3 @@
-fragment ProposalEventFields on Proposal {
-  id
-  reference
-  state
-  rejectionReason
-  errorDetails
-}
-
-subscription ProposalEvent($partyId: ID!) {
-  proposals(partyId: $partyId) {
-    ...ProposalEventFields
-  }
-}
-
 fragment UpdateNetworkParameterProposal on Proposal {
   id
   state
@@ -27,12 +13,8 @@ fragment UpdateNetworkParameterProposal on Proposal {
 }
 
 subscription OnUpdateNetworkParameters {
-  busEvents(types: [Proposal], batchSize: 0) {
-    event {
-      ... on Proposal {
-        ...UpdateNetworkParameterProposal
-      }
-    }
+  proposals {
+    ...UpdateNetworkParameterProposal
   }
 }
 

--- a/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
+++ b/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
@@ -4,6 +4,15 @@ import { gql } from '@apollo/client';
 import { UpdateNetworkParameterFielsFragmentDoc } from '../../proposals-data-provider/__generated__/Proposals';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
+export type ProposalEventFieldsFragment = { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null };
+
+export type ProposalEventSubscriptionVariables = Types.Exact<{
+  partyId: Types.Scalars['ID'];
+}>;
+
+
+export type ProposalEventSubscription = { __typename?: 'Subscription', proposals: { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null } };
+
 export type UpdateNetworkParameterProposalFragment = { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } };
 
 export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{ [key: string]: never; }>;
@@ -18,6 +27,15 @@ export type ProposalOfMarketQueryVariables = Types.Exact<{
 
 export type ProposalOfMarketQuery = { __typename?: 'Query', proposal?: { __typename?: 'Proposal', id?: string | null, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null } } | null };
 
+export const ProposalEventFieldsFragmentDoc = gql`
+    fragment ProposalEventFields on Proposal {
+  id
+  reference
+  state
+  rejectionReason
+  errorDetails
+}
+    `;
 export const UpdateNetworkParameterProposalFragmentDoc = gql`
     fragment UpdateNetworkParameterProposal on Proposal {
   id
@@ -33,6 +51,36 @@ export const UpdateNetworkParameterProposalFragmentDoc = gql`
   }
 }
     ${UpdateNetworkParameterFielsFragmentDoc}`;
+export const ProposalEventDocument = gql`
+    subscription ProposalEvent($partyId: ID!) {
+  proposals(partyId: $partyId) {
+    ...ProposalEventFields
+  }
+}
+    ${ProposalEventFieldsFragmentDoc}`;
+
+/**
+ * __useProposalEventSubscription__
+ *
+ * To run a query within a React component, call `useProposalEventSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useProposalEventSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useProposalEventSubscription({
+ *   variables: {
+ *      partyId: // value for 'partyId'
+ *   },
+ * });
+ */
+export function useProposalEventSubscription(baseOptions: Apollo.SubscriptionHookOptions<ProposalEventSubscription, ProposalEventSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<ProposalEventSubscription, ProposalEventSubscriptionVariables>(ProposalEventDocument, options);
+      }
+export type ProposalEventSubscriptionHookResult = ReturnType<typeof useProposalEventSubscription>;
+export type ProposalEventSubscriptionResult = Apollo.SubscriptionResult<ProposalEventSubscription>;
 export const OnUpdateNetworkParametersDocument = gql`
     subscription OnUpdateNetworkParameters {
   proposals {

--- a/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
+++ b/libs/governance/src/lib/proposals-hooks/__generated__/Proposal.ts
@@ -4,21 +4,12 @@ import { gql } from '@apollo/client';
 import { UpdateNetworkParameterFielsFragmentDoc } from '../../proposals-data-provider/__generated__/Proposals';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ProposalEventFieldsFragment = { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null };
-
-export type ProposalEventSubscriptionVariables = Types.Exact<{
-  partyId: Types.Scalars['ID'];
-}>;
-
-
-export type ProposalEventSubscription = { __typename?: 'Subscription', proposals: { __typename?: 'Proposal', id?: string | null, reference: string, state: Types.ProposalState, rejectionReason?: Types.ProposalRejectionReason | null, errorDetails?: string | null } };
-
 export type UpdateNetworkParameterProposalFragment = { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } };
 
 export type OnUpdateNetworkParametersSubscriptionVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type OnUpdateNetworkParametersSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', event: { __typename?: 'AccountEvent' } | { __typename?: 'Asset' } | { __typename?: 'AuctionEvent' } | { __typename?: 'Deposit' } | { __typename?: 'LiquidityProvision' } | { __typename?: 'LossSocialization' } | { __typename?: 'MarginLevels' } | { __typename?: 'Market' } | { __typename?: 'MarketData' } | { __typename?: 'MarketEvent' } | { __typename?: 'MarketTick' } | { __typename?: 'NodeSignature' } | { __typename?: 'OracleSpec' } | { __typename?: 'Order' } | { __typename?: 'Party' } | { __typename?: 'PositionResolution' } | { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } } | { __typename?: 'RiskFactor' } | { __typename?: 'SettleDistressed' } | { __typename?: 'SettlePosition' } | { __typename?: 'TimeUpdate' } | { __typename?: 'Trade' } | { __typename?: 'TransactionResult' } | { __typename?: 'TransferResponses' } | { __typename?: 'Vote' } | { __typename?: 'Withdrawal' } }> | null };
+export type OnUpdateNetworkParametersSubscription = { __typename?: 'Subscription', proposals: { __typename?: 'Proposal', id?: string | null, state: Types.ProposalState, datetime: any, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null, change: { __typename?: 'NewAsset' } | { __typename?: 'NewFreeform' } | { __typename?: 'NewMarket' } | { __typename?: 'UpdateAsset' } | { __typename?: 'UpdateMarket' } | { __typename?: 'UpdateNetworkParameter', networkParameter: { __typename?: 'NetworkParameter', key: string, value: string } } } } };
 
 export type ProposalOfMarketQueryVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
@@ -27,15 +18,6 @@ export type ProposalOfMarketQueryVariables = Types.Exact<{
 
 export type ProposalOfMarketQuery = { __typename?: 'Query', proposal?: { __typename?: 'Proposal', id?: string | null, terms: { __typename?: 'ProposalTerms', enactmentDatetime?: any | null } } | null };
 
-export const ProposalEventFieldsFragmentDoc = gql`
-    fragment ProposalEventFields on Proposal {
-  id
-  reference
-  state
-  rejectionReason
-  errorDetails
-}
-    `;
 export const UpdateNetworkParameterProposalFragmentDoc = gql`
     fragment UpdateNetworkParameterProposal on Proposal {
   id
@@ -51,44 +33,10 @@ export const UpdateNetworkParameterProposalFragmentDoc = gql`
   }
 }
     ${UpdateNetworkParameterFielsFragmentDoc}`;
-export const ProposalEventDocument = gql`
-    subscription ProposalEvent($partyId: ID!) {
-  proposals(partyId: $partyId) {
-    ...ProposalEventFields
-  }
-}
-    ${ProposalEventFieldsFragmentDoc}`;
-
-/**
- * __useProposalEventSubscription__
- *
- * To run a query within a React component, call `useProposalEventSubscription` and pass it any options that fit your needs.
- * When your component renders, `useProposalEventSubscription` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useProposalEventSubscription({
- *   variables: {
- *      partyId: // value for 'partyId'
- *   },
- * });
- */
-export function useProposalEventSubscription(baseOptions: Apollo.SubscriptionHookOptions<ProposalEventSubscription, ProposalEventSubscriptionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useSubscription<ProposalEventSubscription, ProposalEventSubscriptionVariables>(ProposalEventDocument, options);
-      }
-export type ProposalEventSubscriptionHookResult = ReturnType<typeof useProposalEventSubscription>;
-export type ProposalEventSubscriptionResult = Apollo.SubscriptionResult<ProposalEventSubscription>;
 export const OnUpdateNetworkParametersDocument = gql`
     subscription OnUpdateNetworkParameters {
-  busEvents(types: [Proposal], batchSize: 0) {
-    event {
-      ... on Proposal {
-        ...UpdateNetworkParameterProposal
-      }
-    }
+  proposals {
+    ...UpdateNetworkParameterProposal
   }
 }
     ${UpdateNetworkParameterProposalFragmentDoc}`;

--- a/libs/governance/src/lib/proposals-hooks/use-update-network-paramaters-toasts.tsx
+++ b/libs/governance/src/lib/proposals-hooks/use-update-network-paramaters-toasts.tsx
@@ -7,11 +7,16 @@ import type { Toast } from '@vegaprotocol/ui-toolkit';
 import { ToastHeading } from '@vegaprotocol/ui-toolkit';
 import { useToasts } from '@vegaprotocol/ui-toolkit';
 import { ExternalLink, Intent } from '@vegaprotocol/ui-toolkit';
-import compact from 'lodash/compact';
 import { useCallback } from 'react';
 import type { UpdateNetworkParameterProposalFragment } from './__generated__/Proposal';
 import { useOnUpdateNetworkParametersSubscription } from './__generated__/Proposal';
 
+export const PROPOSAL_STATES_TO_TOAST = [
+  ProposalState.STATE_DECLINED,
+  ProposalState.STATE_ENACTED,
+  ProposalState.STATE_OPEN,
+  ProposalState.STATE_PASSED,
+];
 const CLOSE_AFTER = 5000;
 type Proposal = UpdateNetworkParameterProposalFragment;
 
@@ -75,26 +80,16 @@ export const useUpdateNetworkParametersToasts = () => {
     [remove]
   );
 
-  useOnUpdateNetworkParametersSubscription({
-    onData: (options) => {
-      const events = compact(options.data.data?.busEvents);
-      if (!events || events.length === 0) return;
-      const validProposals = events
-        .filter(
-          (ev) =>
-            ev.event.__typename === 'Proposal' &&
-            ev.event.terms.__typename === 'ProposalTerms' &&
-            ev.event.terms.change.__typename === 'UpdateNetworkParameter' &&
-            [
-              ProposalState.STATE_DECLINED,
-              ProposalState.STATE_ENACTED,
-              ProposalState.STATE_OPEN,
-              ProposalState.STATE_PASSED,
-            ].includes(ev.event.state)
-        )
-        .map((ev) => ev.event as Proposal);
-      if (validProposals.length < 5) {
-        validProposals.forEach((p) => setToast(fromProposal(p)));
+  return useOnUpdateNetworkParametersSubscription({
+    onData: ({ data }) => {
+      // note proposals is poorly named, it is actually a single proposal
+      const proposal = data.data?.proposals;
+      if (!proposal) return;
+      if (proposal.terms.change.__typename !== 'UpdateNetworkParameter') return;
+
+      // if one of the following states show a toast
+      if (PROPOSAL_STATES_TO_TOAST.includes(proposal.state)) {
+        setToast(fromProposal(proposal));
       }
     },
   });

--- a/libs/governance/src/lib/proposals-hooks/use-update-network-parameters-toasts.spec.tsx
+++ b/libs/governance/src/lib/proposals-hooks/use-update-network-parameters-toasts.spec.tsx
@@ -1,16 +1,19 @@
+import merge from 'lodash/merge';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
-import { renderHook } from '@testing-library/react-hooks';
 import { ProposalState } from '@vegaprotocol/types';
 import type { ReactNode } from 'react';
-import { useUpdateNetworkParametersToasts } from './use-update-network-paramaters-toasts';
+import {
+  PROPOSAL_STATES_TO_TOAST,
+  useUpdateNetworkParametersToasts,
+} from './use-update-network-paramaters-toasts';
 import type {
   UpdateNetworkParameterProposalFragment,
   OnUpdateNetworkParametersSubscription,
 } from './__generated__/Proposal';
 import { OnUpdateNetworkParametersDocument } from './__generated__/Proposal';
 import { useToasts } from '@vegaprotocol/ui-toolkit';
-import { waitFor } from '@testing-library/react';
+import { waitFor, renderHook } from '@testing-library/react';
 
 const render = (mocks?: MockedResponse[]) => {
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -42,56 +45,6 @@ const generateUpdateNetworkParametersProposal = (
   },
 });
 
-const mockedWrongEvent: MockedResponse<OnUpdateNetworkParametersSubscription> =
-  {
-    request: {
-      query: OnUpdateNetworkParametersDocument,
-    },
-    result: {
-      data: {
-        __typename: 'Subscription',
-        busEvents: [
-          {
-            __typename: 'BusEvent',
-            event: {
-              __typename: 'Asset',
-            },
-          },
-        ],
-      },
-    },
-  };
-
-const mockedEmptyEvent: MockedResponse<OnUpdateNetworkParametersSubscription> =
-  {
-    request: {
-      query: OnUpdateNetworkParametersDocument,
-    },
-    result: {
-      data: {
-        __typename: 'Subscription',
-        busEvents: [],
-      },
-    },
-  };
-
-const mockedEvent: MockedResponse<OnUpdateNetworkParametersSubscription> = {
-  request: {
-    query: OnUpdateNetworkParametersDocument,
-  },
-  result: {
-    data: {
-      __typename: 'Subscription',
-      busEvents: [
-        {
-          __typename: 'BusEvent',
-          event: generateUpdateNetworkParametersProposal('abc.def', '123.456'),
-        },
-      ],
-    },
-  },
-};
-
 const INITIAL = useToasts.getState();
 
 const clear = () => {
@@ -102,23 +55,113 @@ describe('useUpdateNetworkParametersToasts', () => {
   beforeEach(clear);
   afterAll(clear);
 
-  it('returns toast for update network parameters bus event', async () => {
-    render([mockedEvent]);
-    await waitFor(() => {
-      expect(useToasts.getState().count).toBe(1);
-    });
-  });
+  it.each(PROPOSAL_STATES_TO_TOAST)(
+    'toasts for %s network param proposals',
+    async (state) => {
+      const mockOpenProposal: MockedResponse<OnUpdateNetworkParametersSubscription> =
+        {
+          request: {
+            query: OnUpdateNetworkParametersDocument,
+          },
+          result: {
+            data: {
+              proposals: generateUpdateNetworkParametersProposal(
+                'abc.def',
+                '123.456',
+                state
+              ),
+            },
+          },
+        };
+      const { result } = render([mockOpenProposal]);
+      expect(result.current.loading).toBe(true);
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(useToasts.getState().count).toBe(1);
+      });
+    }
+  );
 
-  it('does not return toast for empty event', async () => {
-    render([mockedEmptyEvent]);
+  const IGNORE_STATES = Object.keys(ProposalState).filter((state) => {
+    return !PROPOSAL_STATES_TO_TOAST.includes(state as ProposalState);
+  }) as ProposalState[];
+  it.each(IGNORE_STATES)('does not toast for %s proposals', async (state) => {
+    const mockFailedProposal: MockedResponse<OnUpdateNetworkParametersSubscription> =
+      {
+        request: {
+          query: OnUpdateNetworkParametersDocument,
+        },
+        result: {
+          data: {
+            proposals: generateUpdateNetworkParametersProposal(
+              'abc.def',
+              '123.456',
+              state
+            ),
+          },
+        },
+      };
+    const { result } = render([mockFailedProposal]);
+    expect(result.current.loading).toBe(true);
     await waitFor(() => {
+      expect(result.current.loading).toBe(false);
       expect(useToasts.getState().count).toBe(0);
     });
   });
 
-  it('does not return toast for wrong event', async () => {
-    render([mockedWrongEvent]);
+  it('does not return toast for empty propsal', async () => {
+    const error = console.error;
+    console.error = () => {
+      /* no op */
+    };
+    const mockEmptyProposal: MockedResponse<OnUpdateNetworkParametersSubscription> =
+      {
+        request: {
+          query: OnUpdateNetworkParametersDocument,
+        },
+        result: {
+          data: {
+            proposals:
+              undefined as unknown as UpdateNetworkParameterProposalFragment,
+          },
+        },
+      };
+
+    const { result } = render([mockEmptyProposal]);
+    expect(result.current.loading).toBe(true);
     await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(useToasts.getState().count).toBe(0);
+    });
+    console.error = error;
+  });
+
+  it('does not return toast for wrong proposal type', async () => {
+    const wrongProposalType = merge(
+      generateUpdateNetworkParametersProposal('a', 'b'),
+      {
+        terms: {
+          change: {
+            __typename: 'NewMarket',
+          },
+        },
+      }
+    );
+    const mockWrongProposalType: MockedResponse<OnUpdateNetworkParametersSubscription> =
+      {
+        request: {
+          query: OnUpdateNetworkParametersDocument,
+        },
+        result: {
+          data: {
+            proposals: wrongProposalType,
+          },
+        },
+      };
+    const { result } = render([mockWrongProposalType]);
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
       expect(useToasts.getState().count).toBe(0);
     });
   });

--- a/libs/wallet/src/use-vega-transaction-updater.spec.tsx
+++ b/libs/wallet/src/use-vega-transaction-updater.spec.tsx
@@ -1,9 +1,8 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
 import type { ReactNode } from 'react';
 import { useVegaTransactionUpdater } from './use-vega-transaction-updater';
-import waitForNextTick from 'flush-promises';
 import {
   OrderTxUpdateDocument,
   TransactionEventDocument,
@@ -112,14 +111,13 @@ const mockedTransactionResultBusEvent: MockedResponse<TransactionEventSubscripti
       data: {
         busEvents: [
           {
-            type: BusEventType.Order,
+            type: BusEventType.TransactionResult,
             event: transactionResultBusEvent,
           },
         ],
       },
     },
   };
-
 const withdrawalBusEvent: WithdrawalBusEventFieldsFragment = {
   id: '2fca514cebf9f465ae31ecb4c5721e3a6f5f260425ded887ca50ba15b81a5d50',
   status: WithdrawalStatus.STATUS_OPEN,
@@ -167,20 +165,16 @@ const mockedWithdrawalBusEvent: MockedResponse<WithdrawalBusEventSubscription> =
 describe('useVegaTransactionManager', () => {
   it('updates order on OrderTxUpdate', async () => {
     mockTransactionStoreState.mockReturnValue(defaultState);
-    const { waitForNextUpdate } = render([mockedOrderUpdate]);
-    await act(async () => {
-      waitForNextUpdate();
-      await waitForNextTick();
+    render([mockedOrderUpdate]);
+    await waitFor(() => {
       expect(updateOrder).toHaveBeenCalledWith(orderUpdate);
     });
   });
 
   it('updates transaction on TransactionResultBusEvents', async () => {
     mockTransactionStoreState.mockReturnValue(defaultState);
-    const { waitForNextUpdate } = render([mockedTransactionResultBusEvent]);
-    await act(async () => {
-      waitForNextUpdate();
-      await waitForNextTick();
+    render([mockedTransactionResultBusEvent]);
+    await waitFor(() => {
       expect(updateTransactionResult).toHaveBeenCalledWith(
         transactionResultBusEvent
       );
@@ -193,10 +187,8 @@ describe('useVegaTransactionManager', () => {
     mockWaitForWithdrawalApproval.mockResolvedValueOnce(
       erc20WithdrawalApproval
     );
-    const { waitForNextUpdate } = render([mockedWithdrawalBusEvent]);
-    await act(async () => {
-      waitForNextUpdate();
-      await waitForNextTick();
+    render([mockedWithdrawalBusEvent]);
+    await waitFor(() => {
       expect(updateWithdrawal).toHaveBeenCalledWith(
         withdrawalBusEvent,
         erc20WithdrawalApproval

--- a/libs/wallet/src/use-vega-transaction-updater.tsx
+++ b/libs/wallet/src/use-vega-transaction-updater.tsx
@@ -38,9 +38,9 @@ export const useVegaTransactionUpdater = () => {
       result.data?.busEvents?.forEach((event) => {
         if (event.event.__typename === 'Withdrawal') {
           const withdrawal = event.event;
-          waitForWithdrawalApproval(withdrawal.id, client).then((approval) =>
-            updateWithdrawal(withdrawal, approval)
-          );
+          waitForWithdrawalApproval(withdrawal.id, client).then((approval) => {
+            updateWithdrawal(withdrawal, approval);
+          });
         }
       }),
   });

--- a/libs/web3/src/lib/use-ethereum-transaction-updater.spec.tsx
+++ b/libs/web3/src/lib/use-ethereum-transaction-updater.spec.tsx
@@ -1,9 +1,8 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
 import type { ReactNode } from 'react';
 import { useEthTransactionUpdater } from './use-ethereum-transaction-updater';
-import waitForNextTick from 'flush-promises';
 import {
   DepositBusEventDocument,
   VegaWalletContext,
@@ -77,9 +76,9 @@ const mockedDepositBusEvent: MockedResponse<DepositBusEventSubscription> = {
 describe('useEthTransactionUpdater', () => {
   it('updates deposit on DepositBusEvents', async () => {
     mockTransactionStoreState.mockReturnValue(defaultState);
-    const { waitForNextUpdate } = render([mockedDepositBusEvent]);
-    waitForNextUpdate();
-    await waitForNextTick();
-    expect(updateDeposit).toHaveBeenCalledWith(depositBusEvent);
+    render([mockedDepositBusEvent]);
+    await waitFor(() => {
+      expect(updateDeposit).toHaveBeenCalledWith(depositBusEvent);
+    });
   });
 });

--- a/libs/web3/src/lib/use-ethereum-transaction-updater.spec.tsx
+++ b/libs/web3/src/lib/use-ethereum-transaction-updater.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
 import type { ReactNode } from 'react';

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "@svgr/webpack": "^5.4.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "13.3.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.1",
     "@types/classnames": "^2.3.1",
     "@types/faker": "^5.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6364,14 +6364,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
@@ -19129,13 +19121,6 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-hook-form@^7.27.0:
   version "7.37.0"


### PR DESCRIPTION
# Related issues 🔗

Closes #2945 

# Description ℹ️

Changes a subscription that is used to open a toast about network parameter proposals to use the bespoke proposal subscription as proposal bus events have been removed

# Technical 👨‍🔧

Additionally:
- Added more test coverage to the use-update-network-parameters-toasts hook
- Fixed evergreen test cases in use-vega-transaction-updater.spec.tsx
- Remove remaining usage of @testing-library/react-hooks and remove from package.json
