### PR TITLE
feat(governance): no delay on tooltip for validators table column headers

### DIFF
--- a/apps/token/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
+++ b/apps/token/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
@@ -363,6 +363,7 @@ export const ConsensusValidatorsTable = ({
             customThemeParams={NODE_LIST_GRID_STYLES}
             getRowHeight={(params: RowHeightParams) => getRowHeight(params)}
             defaultColDef={defaultColDef}
+            tooltipShowDelay={0}
             animateRows={true}
             suppressCellFocus={true}
             overlayNoRowsTemplate={t('noValidators')}

--- a/apps/token/src/routes/staking/home/validator-tables/shared.tsx
+++ b/apps/token/src/routes/staking/home/validator-tables/shared.tsx
@@ -59,8 +59,6 @@ export const defaultColDef = {
   comparator: (a: string, b: string) => parseFloat(a) - parseFloat(b),
   cellStyle: { margin: '10px 0', padding: '0 12px' },
   tooltipComponent: TooltipCellComponent,
-  tooltipShowDelay: 0,
-  tooltipHideDelay: 0,
 };
 
 interface ValidatorRendererProps {

--- a/apps/token/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
+++ b/apps/token/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
@@ -236,6 +236,7 @@ export const StandbyPendingValidatorsTable = ({
           customThemeParams={NODE_LIST_GRID_STYLES}
           rowHeight={52}
           defaultColDef={defaultColDef}
+          tooltipShowDelay={0}
           animateRows={true}
           suppressCellFocus={true}
           overlayNoRowsTemplate={t('noValidators')}


### PR DESCRIPTION
# Related issues 🔗

Closes #2654

# Description ℹ️

We had the 'tooltipShowDelay' property set to 0 in the 'defaultColDef', which didn't work, even though that's where we define the tooltip component. But providing it as a separate prop to each table works, because ok. Thanks AG Grid.
