### PR TITLE
fix(explorer): incorrect destination in market link components

### DIFF
--- a/apps/explorer/src/app/components/links/market-link/market-link.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.tsx
@@ -48,7 +48,7 @@ const MarketLink = ({
       <Link
         className="underline"
         {...props}
-        to={`/${Routes.MARKETS}#${id}`}
+        to={`/${Routes.MARKETS}/${id}`}
         title={id}
       >
         {label}
@@ -56,7 +56,7 @@ const MarketLink = ({
     );
   } else {
     return (
-      <Link className="underline" {...props} to={`/${Routes.MARKETS}#${id}`}>
+      <Link className="underline" {...props} to={`/${Routes.MARKETS}/${id}`}>
         <Hash text={id} />
       </Link>
     );


### PR DESCRIPTION
# Related issues 🔗

Closes #2967

# Description ℹ️
After the new Market list and Market by ID page came in, we didn't update the MarketLink component to use the new address. 
As a result, if a user clicked on the 'Market' link in an Order TX page (for example) it would taken them to the market
list page and not the specific market page. This is because we moved from anchor links to proper individual pages

