### PR TITLE
fix(trading): fees breakdown layout and condense tabs

### DIFF
--- a/libs/market-info/src/components/fees-breakdown/fees-breakdown.tsx
+++ b/libs/market-info/src/components/fees-breakdown/fees-breakdown.tsx
@@ -74,7 +74,7 @@ export const FeesBreakdown = ({
       : '-';
   };
   return (
-    <dl className="grid grid-cols-5">
+    <dl className="grid grid-cols-6">
       <dt className="col-span-2">{t('Infrastructure fee')}</dt>
       {feeFactors && (
         <dd className="text-right col-span-1">
@@ -83,7 +83,7 @@ export const FeesBreakdown = ({
           )}
         </dd>
       )}
-      <dd className="text-right col-span-2">
+      <dd className="text-right col-span-3">
         {formatValue(fees.infrastructureFee)} {symbol || ''}
       </dd>
       <dt className="col-span-2">{t('Liquidity fee')}</dt>
@@ -94,7 +94,7 @@ export const FeesBreakdown = ({
           )}
         </dd>
       )}
-      <dd className="text-right col-span-2">
+      <dd className="text-right col-span-3">
         {formatValue(fees.liquidityFee)} {symbol || ''}
       </dd>
       <dt className="col-span-2">{t('Maker fee')}</dt>
@@ -105,7 +105,7 @@ export const FeesBreakdown = ({
           )}
         </dd>
       )}
-      <dd className="text-right col-span-2">
+      <dd className="text-right col-span-3">
         {formatValue(fees.makerFee)} {symbol || ''}
       </dd>
       <dt className="col-span-2">{t('Total fees')}</dt>
@@ -114,7 +114,7 @@ export const FeesBreakdown = ({
           {totalFeesPercentage(feeFactors)}
         </dd>
       )}
-      <dd className="text-right col-span-2">
+      <dd className="text-right col-span-3">
         {formatValue(totalFees)} {symbol || ''}
       </dd>
     </dl>

--- a/libs/ui-toolkit/src/components/tabs/tabs.tsx
+++ b/libs/ui-toolkit/src/components/tabs/tabs.tsx
@@ -28,7 +28,7 @@ export const Tabs = ({ children, active: activeDefaultId }: TabsProps) => {
             if (!isValidElement(child) || child.props.hidden) return null;
             const isActive = child.props.id === activeTab;
             const triggerClass = classNames(
-              'relative px-4 py-2 border-r border-default',
+              'relative px-4 py-1 border-r border-default',
               'uppercase',
               {
                 'cursor-default': isActive,


### PR DESCRIPTION
# Related issues 🔗

Closes #2965 

# Description ℹ️

fix fees breakdown layout and condense tabs

# Demo 📺
Before:
<img width="594" alt="Screenshot 2023-02-23 at 11 51 20" src="https://user-images.githubusercontent.com/16125548/220898723-e4da13c0-efcd-45d4-8ad5-dba1d58597aa.png">

After:
<img width="1060" alt="Screenshot 2023-02-23 at 11 51 14" src="https://user-images.githubusercontent.com/16125548/220898810-e3d385b3-23b0-46a4-927e-f8731c573678.png">


Before: 
<img width="1252" alt="Screenshot 2023-02-23 at 11 51 46" src="https://user-images.githubusercontent.com/16125548/220898924-e4557e0d-4f37-4c96-8f6f-ec7781902dae.png">

After:
<img width="1248" alt="Screenshot 2023-02-23 at 11 51 38" src="https://user-images.githubusercontent.com/16125548/220898859-f1cb3dbe-6588-45ef-b0d1-26563f98a1c7.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
