### PR TITLE
chore(ci): update validator testnet config endpoint

### DIFF
--- a/apps/static/src/assets/validator-testnet-network.json
+++ b/apps/static/src/assets/validator-testnet-network.json
@@ -1,3 +1,3 @@
 {
-  "hosts": ["https://api.validators-testnet.vega.xyz/query"]
+  "hosts": ["https://api.validators-testnet.vega.xyz/graphql"]
 }


### PR DESCRIPTION
This network moved from 0.53 to 0.68 which changes the endpoint

# Related issues 🔗

Closes #3034 