### PR TITLE
fix(environment): console not finding node

### DIFF
--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -11,7 +11,7 @@
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "lib": ["es5", "es6", "dom", "dom.iterable"]
+    "lib": ["es2021", "dom", "dom.iterable"]
   },
   "exclude": ["./src/types/explorer.d.ts"],
   "include": [],

--- a/apps/multisig-signer/tsconfig.json
+++ b/apps/multisig-signer/tsconfig.json
@@ -10,8 +10,7 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "lib": ["es5", "es6", "dom", "dom.iterable"]
+    "noFallthroughCasesInSwitch": true
   },
   "include": [],
   "references": [

--- a/libs/environment/src/hooks/use-environment.ts
+++ b/libs/environment/src/hooks/use-environment.ts
@@ -31,7 +31,7 @@ type Actions = {
 export type Env = Environment & EnvState;
 export type EnvStore = Env & Actions;
 
-const STORAGE_KEY = 'vega_url';
+export const STORAGE_KEY = 'vega_url';
 const SUBSCRIPTION_TIMEOUT = 3000;
 
 export const useEnvironment = create<EnvStore>((set, get) => ({

--- a/libs/environment/src/hooks/use-environment.ts
+++ b/libs/environment/src/hooks/use-environment.ts
@@ -168,9 +168,15 @@ const fetchConfig = async (url?: string) => {
  * Find a suitable node by running a test query and test
  * subscription, against a list of clients, first to resolve wins
  */
-const findNode = (clients: ClientCollection): Promise<string | null> => {
+const findNode = async (clients: ClientCollection): Promise<string | null> => {
   const tests = Object.entries(clients).map((args) => testNode(...args));
-  return Promise.race(tests);
+  try {
+    const url = await Promise.any(tests);
+    return url;
+  } catch {
+    // All tests rejected, no suitable node found
+    return null;
+  }
 };
 
 /**
@@ -180,19 +186,21 @@ const testNode = async (
   url: string,
   client: Client
 ): Promise<string | null> => {
-  try {
-    const results = await Promise.all([
-      testQuery(client),
-      testSubscription(client),
-    ]);
-    if (results[0] && results[1]) {
-      return url;
-    }
-    return null;
-  } catch (err) {
-    console.warn(`Tests failed for ${url}`);
-    return null;
+  const results = await Promise.all([
+    // these promises will only resolve with true/false
+    testQuery(client),
+    testSubscription(client),
+  ]);
+  if (results[0] && results[1]) {
+    return url;
   }
+
+  const message = `Tests failed for node: ${url}`;
+  console.warn(message);
+
+  // throwing here will mean this tests is ignored and a different
+  // node that hopefully does resolve will fulfill the Promise.any
+  throw new Error(message);
 };
 
 /**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
# Related issues 🔗

Closes #3039 

# Description ℹ️

Fixes a problem where the useEnvironment hook would select a node even if it was down and not responding

# Technical 👨‍🔧

- Changes useEnvironment hook to use Promise.any rather than Promise.race. The former will wait for the first fulfilled promise whereas the latter will wait for the first promise to settle (even if promise is rejected).
- Beefed up some missing functionality in unit tests
