### PR TITLE
fix(token): router incorrectly configured, causing query spamming

### DIFF
--- a/apps/token/src/routes/router-config.tsx
+++ b/apps/token/src/routes/router-config.tsx
@@ -52,10 +52,18 @@ const LazyRedemptionTranche = React.lazy(
       /* webpackChunkName: "route-redemption-tranche", webpackPrefetch: true */ './redemption/tranche'
     )
 );
-const LazyStaking = React.lazy(
+
+const LazyStakingIndex = React.lazy(
   () =>
     import(
       /* webpackChunkName: "route-staking", webpackPrefetch: true */ './staking'
+    )
+);
+
+const LazyStakingList = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "route-staking-index", webpackPrefetch: true */ './staking/staking'
     )
 );
 
@@ -73,24 +81,10 @@ const LazyStakingDisassociate = React.lazy(
     )
 );
 
-const LazyStakingIndex = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "route-staking-index", webpackPrefetch: true */ './staking/staking'
-    )
-);
-
 const LazyStakingNode = React.lazy(
   () =>
     import(
       /* webpackChunkName: "route-staking-node", webpackPrefetch: true */ './staking/staking-node'
-    )
-);
-
-const LazyStakingNodes = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "route-staking-nodes", webpackPrefetch: true */ './staking/staking-nodes-container'
     )
 );
 
@@ -174,18 +168,14 @@ const routerConfig = [
   {
     path: Routes.STAKING,
     name: 'Staking',
-    component: LazyStaking,
+    component: LazyStakingIndex,
     children: [
       { path: 'associate', element: <LazyStakingAssociate /> },
       { path: 'disassociate', element: <LazyStakingDisassociate /> },
       { path: ':node', element: <LazyStakingNode /> },
       {
         index: true,
-        element: (
-          <LazyStakingNodes>
-            {({ data }) => <LazyStakingIndex data={data} />}
-          </LazyStakingNodes>
-        ),
+        element: <LazyStakingList />,
       },
     ],
   },


### PR DESCRIPTION
# Description ℹ️

Mainnet on token is spamming requests due to a poorly configured router

The router was nesting two routes incorrectly. Due to the type policy the first would fire off and then the second, which would cause changes to the first query causing it to refetch, repeat infinitely. These did not need to be passing data between each other, and should not have been used together at all as there was a different container for that route, which this PR is now using.