### PR TITLE
chore(explorer): remove commented out query

### DIFF
--- a/apps/explorer/src/app/components/epoch-overview/Epoch.graphql
+++ b/apps/explorer/src/app/components/epoch-overview/Epoch.graphql
@@ -22,29 +22,3 @@ query ExplorerFutureEpoch {
     }
   }
 }
-
-# query ExplorerEpoch($id: ID!) {
-#
-##### This could be useful for calculating roughly when a future epoch will
-##### occur, but epoch not exist results in a total error
-#  networkParameter(key: "validators.epoch.length") {
-#    value
-# }
-#
-##### This could be useful for relating where we are in time, but as above
-##### the total failure caused by epoch(id) not existing
-##### means this is useful
-#  currentEpoch: epoch {
-#    id
-#  }
-#
-#  epoch(id: $id) {
-#    id
-#    timestamps {
-#      start
-#      end
-#      firstBlock
-#      lastBlock
-#    }
-#  }
-#}


### PR DESCRIPTION
# Related issues 🔗

Closes #2973 

# Description ℹ️

Removes a commented out GraphQL query that breaks a pipeline elsewhere. On one hand, it probably shouldn't break pipelines, on the other hand, this query was more 'Note to self' than essential so it's an easy choice to remove it.
