### PR TITLE
fix(explorer): add size in market component for remaining order size

### DIFF
--- a/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
@@ -101,7 +101,7 @@ const DeterministicOrderDetails = ({
                   {t('Remaining')}
                 </h2>
                 <h5 className="text-lg font-medium text-gray-500 mb-0">
-                  {o.remaining}
+                  <SizeInMarket size={o.remaining} marketId={o.market.id} />
                 </h5>
               </div>
             )}


### PR DESCRIPTION
# Related issues 🔗

Closes #3029

# Description ℹ️

Order size was displayed correctly, but not remaining. Now remaining is too.
