### PR TITLE
fix(explorer): fix inconsistent wss urls for tm

### DIFF
--- a/apps/explorer/.env.devnet
+++ b/apps/explorer/.env.devnet
@@ -1,6 +1,6 @@
 # App configuration variables
 NX_TENDERMINT_URL=https://tm.be.devnet1.vega.xyz/tm
-NX_TENDERMINT_WEBSOCKET_URL=wss://tm.be.devnet1.vega.xyz/websocket
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.devnet1.vega.xyz/websocket
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/devnet-network.json
 NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https://explorer.fairground.wtf\"}
 NX_VEGA_ENV=DEVNET

--- a/apps/explorer/.env.mainnet
+++ b/apps/explorer/.env.mainnet
@@ -1,6 +1,6 @@
 # App configuration variables
 NX_TENDERMINT_URL=https://be.explorer.vega.xyz
-NX_TENDERMINT_WEBSOCKET_URL=wss://be.explorer.vega.xyz
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.explorer.vega.xyz/websocket
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/mainnet-network.json
 NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https://explorer.fairground.wtf\"}
 NX_VEGA_ENV=MAINNET

--- a/apps/explorer/.env.mirror
+++ b/apps/explorer/.env.mirror
@@ -1,6 +1,6 @@
 # App configuration variables
 NX_TENDERMINT_URL=https://tm.be.mainnet-mirror.vega.xyz
-NX_TENDERMINT_WEBSOCKET_URL=https://tm.be.mainnet-mirror.vega.xyz
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.mainnet-mirror.vega.xyz/websocket
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/mirror-network.json
 NX_VEGA_NETWORKS='{"DEVNET":"https://dev.token.vega.xyz","STAGNET3":"https://stagnet3.token.vega.xyz","TESTNET":"https://token.fairground.wtf","MAINNET":"https://token.vega.xyz"}'
 NX_VEGA_ENV=MIRROR

--- a/apps/explorer/.env.sandbox
+++ b/apps/explorer/.env.sandbox
@@ -7,6 +7,6 @@ NX_ETHEREUM_PROVIDER_URL=https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https://explorer.fairground.wtf\"}
 NX_TENDERMINT_URL=https://tm.sandbox.vega.xyz
-NX_TENDERMINT_WEBSOCKET_URL=wss://tm.sandbox.vega.xyz/websocket
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.sandbox.vega.xyz/websocket
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_VEGA_GOVERNANCE_URL=https://sandbox.token.vega.xyz

--- a/apps/explorer/.env.stagnet3
+++ b/apps/explorer/.env.stagnet3
@@ -1,5 +1,5 @@
 NX_TENDERMINT_URL=https://tm.n00.stagnet3.vega.xyz
-NX_TENDERMINT_WEBSOCKET_URL=wss://tm.n00.stagnet3.vega.xyz/websocket
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.stagnet3.vega.xyz/websocket
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/stagnet3-network.json
 NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https://explorer.fairground.wtf\"}
 NX_VEGA_ENV=STAGNET3

--- a/apps/explorer/.env.testnet
+++ b/apps/explorer/.env.testnet
@@ -1,7 +1,7 @@
 # App configuration variables
 NX_TENDERMINT_URL=https://tm.be.testnet.vega.xyz
 NX_BLOCK_EXPLORER=https://be.testnet.vega.xyz/rest
-NX_TENDERMINT_WEBSOCKET_URL=wss://tm.be.testnet.vega.xyz/websocket/
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.testnet.vega.xyz/websocket
 NX_VEGA_CONFIG_URL=https://static.vega.xyz/assets/testnet-network.json
 NX_VEGA_NETWORKS={\"MAINNET"\:\"https://explorer.vega.xyz"\,\"TESTNET\":\"https://explorer.fairground.wtf\"}
 NX_VEGA_ENV=TESTNET

--- a/apps/explorer/.env.validator-testnet
+++ b/apps/explorer/.env.validator-testnet
@@ -11,4 +11,4 @@ NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
 NX_VEGA_GOVERNANCE_URL=https://validator-testnet.governance.vega.xyz
 NX_TENDERMINT_URL=https://tm.be.validators-testnet.vega.xyz
 NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.xyz/rest
-NX_TENDERMINT_WEBSOCKET_URL=wss://tm.be.validators-testnet.vega.xyz/websocket/
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.validators-testnet.vega.xyz/websocket


### PR DESCRIPTION
# Related issues 🔗

Closes #3052

# Description ℹ️

The tendermint websocket is used by Explorer to know when new blocks are finalised. This is most obvious above the TX
list, where the 'Blocks since the page loaded' count ticks up. This worked in some environments, and not others. The 
cause was that the URLs in the env pointed at either outdated or incorrect wss urls. This PR makes them all correct.
