### PR TITLE
chore(ci): add utils and i18n libs as options for publish to npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -12,6 +12,8 @@ on:
           - react-helpers
           - tailwindcss-config
           - types
+          - utils
+          - i18n
 
 jobs:
   publish:


### PR DESCRIPTION
#3022 add two more packages for us to publish to npm in order for `@vegaprotocol/ui-toolkit` to be consumable - this PR adds those as options on the manually-triggered publish to npm workflow.