### PR TITLE
fix(trading): edit order strikethrough

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -83,7 +83,10 @@ export const DealTicket = ({
   const order = watch();
 
   watch((orderData) => {
-    if (orderData.type === OrderType.TYPE_LIMIT && orderData.price === '') {
+    const persistable = !(
+      orderData.type === OrderType.TYPE_LIMIT && orderData.price === ''
+    );
+    if (persistable) {
       setPersistedOrder(orderData as DealTicketFormFields);
     }
   });

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -22,7 +22,11 @@ import {
   normalizeOrderAmendment,
   useVegaTransactionStore,
 } from '@vegaprotocol/wallet';
-import type { VegaTxState, TransactionResult } from '@vegaprotocol/wallet';
+import type {
+  VegaTxState,
+  TransactionResult,
+  OrderTxUpdateFieldsFragment,
+} from '@vegaprotocol/wallet';
 import { OrderEditDialog } from '../order-list/order-edit-dialog';
 import type { OrderSubFieldsFragment } from '../../order-hooks';
 import * as Schema from '@vegaprotocol/types';
@@ -203,7 +207,19 @@ export const OrderListManager = ({
               fields.limitPrice,
               fields.size
             );
-            create({ orderAmendment });
+            const originalOrder: OrderTxUpdateFieldsFragment = {
+              type: editOrder.type,
+              id: editOrder.id,
+              status: editOrder.status,
+              createdAt: editOrder.createdAt,
+              size: editOrder.size,
+              price: editOrder.price,
+              timeInForce: editOrder.timeInForce,
+              expiresAt: editOrder.expiresAt,
+              side: editOrder.side,
+              marketId: editOrder.market.id,
+            };
+            create({ orderAmendment }, originalOrder);
             setEditOrder(null);
           }}
         />

--- a/libs/wallet/src/use-vega-transaction-store.spec.tsx
+++ b/libs/wallet/src/use-vega-transaction-store.spec.tsx
@@ -119,11 +119,21 @@ describe('useVegaTransactionStore', () => {
         .getState()
         .transactions.map((t) => t?.order?.price)
     ).toEqual(['1125', '1125', '1125']);
+
+    const result = {
+      orderAmendment: {
+        marketId:
+          '3aa2a828687cc3d59e92445d294891cbbd40e2165bbfb15674158ef5d4e8848d',
+        orderId:
+          '6a4fcd0ba478df2f284ef5f6d3c64a478cb8043d3afe36f66f92c0ed92631e64',
+        price: '1122',
+        sizeDelta: 0,
+        timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,
+      },
+    };
     expect(
-      useVegaTransactionStore
-        .getState()
-        .transactions.map((t) => t?.body.orderAmendment.price)
-    ).toEqual(['1122', '1122', '1122']);
+      useVegaTransactionStore.getState().transactions.map((t) => t?.body)
+    ).toStrictEqual([result, result, result]);
   });
 
   it('sets dialogOpen to false on dismiss', () => {

--- a/libs/wallet/src/use-vega-transaction-store.tsx
+++ b/libs/wallet/src/use-vega-transaction-store.tsx
@@ -33,10 +33,7 @@ export interface VegaStoredTxState extends VegaTxState {
 }
 export interface VegaTransactionStore {
   transactions: (VegaStoredTxState | undefined)[];
-  create: (
-    tx: Transaction,
-    originalOrder?: OrderTxUpdateFieldsFragment
-  ) => number;
+  create: (tx: Transaction, order?: OrderTxUpdateFieldsFragment) => number;
   update: (
     index: number,
     update: Partial<
@@ -58,10 +55,7 @@ export interface VegaTransactionStore {
 export const useVegaTransactionStore = create(
   subscribeWithSelector<VegaTransactionStore>((set, get) => ({
     transactions: [] as VegaStoredTxState[],
-    create: (
-      body: Transaction,
-      originalOrder?: OrderTxUpdateFieldsFragment
-    ) => {
+    create: (body: Transaction, order?: OrderTxUpdateFieldsFragment) => {
       const transactions = get().transactions;
       const now = new Date();
       const transaction: VegaStoredTxState = {
@@ -74,7 +68,7 @@ export const useVegaTransactionStore = create(
         signature: null,
         status: VegaTxStatus.Requested,
         dialogOpen: true,
-        order: originalOrder,
+        order,
       };
       set({ transactions: transactions.concat(transaction) });
       return transaction.id;
@@ -175,7 +169,7 @@ export const useVegaTransactionStore = create(
             transaction.order =
               isOrderAmendmentTransaction(transaction?.body) &&
               transaction.order
-                ? transaction.order
+                ? transaction.order // the transaction.order would be the original order amended
                 : order;
             transaction.status = VegaTxStatus.Complete;
             transaction.dialogOpen = true;


### PR DESCRIPTION
# Related issues 🔗

Closes #2695 

# Description ℹ️

Edit order strikethrough shows correct values.

# Demo 📺

![Screenshot 2023-03-01 at 14 05 58](https://user-images.githubusercontent.com/16125548/222170360-875f2bbf-cbaa-4a26-83f5-92891f7fa000.png)
![Screenshot 2023-03-01 at 14 06 04](https://user-images.githubusercontent.com/16125548/222170403-1fffa377-63a3-4be9-87e6-da64a2e35c2e.png)

 Same for size:
 
 
![image](https://user-images.githubusercontent.com/16125548/222182403-ac2c4039-f13b-4233-83b8-b04c8e548dc1.png)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
