### PR TITLE
feat(deposits): deposit flow

### DIFF
--- a/apps/trading-e2e/src/integration/capsule.cy.ts
+++ b/apps/trading-e2e/src/integration/capsule.cy.ts
@@ -41,6 +41,7 @@ const completeWithdrawalBtn = 'complete-withdrawal';
 const submitTransferBtn = '[type="submit"]';
 const transferForm = 'transfer-form';
 const depositSubmit = 'deposit-submit';
+const approveSubmit = 'approve-submit';
 
 // Because the tests are run on a live network to optimize time, the tests are interdependent and must be run in the given order.
 describe('capsule - without MultiSign', { tags: '@slow' }, () => {
@@ -73,13 +74,13 @@ describe('capsule - without MultiSign', { tags: '@slow' }, () => {
     cy.getByTestId('deposit-button').click();
     connectEthereumWallet('Unknown');
     cy.get(assetSelectField, txTimeout).select(btcName, { force: true });
-    cy.getByTestId('approve-warning').should(
+    cy.getByTestId('approve-default').should(
       'contain.text',
-      `Deposits of ${btcSymbol} not approved`
+      `Before you can make a deposit of your chosen asset, ${btcSymbol}, you need to approve its use in your Ethereum wallet`
     );
-    cy.getByTestId(depositSubmit).click();
-    cy.getByTestId('dialog-title').should('contain.text', 'Approve complete');
-    cy.get('[data-testid="Return to deposit"]').click();
+    cy.getByTestId(approveSubmit).click();
+    cy.getByTestId('approve-pending').should('exist');
+    cy.getByTestId('approve-confirmed').should('exist');
     cy.get(amountField).clear().type('10');
     cy.getByTestId(depositSubmit).click();
     cy.getByTestId(toastContent, txTimeout).should(

--- a/apps/trading-e2e/src/integration/deposit.cy.ts
+++ b/apps/trading-e2e/src/integration/deposit.cy.ts
@@ -31,7 +31,13 @@ describe('deposit form validation', { tags: '@smoke' }, () => {
   it('handles empty fields', () => {
     cy.getByTestId('deposit-submit').click();
     cy.getByTestId(formFieldError).should('contain.text', 'Required');
-    cy.getByTestId(formFieldError).should('have.length', 2);
+    // once Ethereum wallet is connected and key selected the only field that will
+    // error is the asset select
+    cy.getByTestId(formFieldError).should('have.length', 1);
+    cy.get('[data-testid="input-error-text"][aria-describedby="asset"]').should(
+      'have.length',
+      1
+    );
   });
 
   it('unable to select assets not enabled', () => {
@@ -41,12 +47,13 @@ describe('deposit form validation', { tags: '@smoke' }, () => {
     cy.get(assetSelectField + ' option:contains(Asset 4)').should('not.exist');
   });
 
-  it('invalid public key', () => {
-    cy.get(toAddressField)
-      .clear()
-      .type('INVALID_DEPOSIT_TO_ADDRESS')
-      .next(`[data-testid="${formFieldError}"]`)
-      .should('have.text', 'Invalid Vega key');
+  it('invalid public key when entering address manually', () => {
+    cy.getByTestId('enter-pubkey-manually').click();
+    cy.get(toAddressField).clear().type('INVALID_DEPOSIT_TO_ADDRESS');
+    cy.get(`[data-testid="${formFieldError}"][aria-describedby="to"]`).should(
+      'have.text',
+      'Invalid Vega key'
+    );
   });
 
   it('invalid amount', () => {

--- a/apps/trading-e2e/src/integration/wallets.cy.ts
+++ b/apps/trading-e2e/src/integration/wallets.cy.ts
@@ -151,7 +151,7 @@ describe('ethereum wallet', { tags: '@smoke' }, () => {
     cy.getByTestId('Deposits').click();
     cy.getByTestId('deposit-button').click();
     connectEthereumWallet('MetaMask');
-    cy.getByTestId('ethereum-address').should('have.value', ethWalletAddress);
+    cy.getByTestId('ethereum-address').should('have.text', ethWalletAddress);
     cy.getByTestId('disconnect-ethereum-wallet')
       .should('have.text', 'Disconnect')
       .click();

--- a/apps/trading-e2e/src/integration/wallets.cy.ts
+++ b/apps/trading-e2e/src/integration/wallets.cy.ts
@@ -151,7 +151,7 @@ describe('ethereum wallet', { tags: '@smoke' }, () => {
     cy.getByTestId('Deposits').click();
     cy.getByTestId('deposit-button').click();
     connectEthereumWallet('MetaMask');
-    cy.get('#ethereum-address').should('have.value', ethWalletAddress);
+    cy.getByTestId('ethereum-address').should('have.value', ethWalletAddress);
     cy.getByTestId('disconnect-ethereum-wallet')
       .should('have.text', 'Disconnect')
       .click();

--- a/apps/trading/lib/hooks/use-ethereum-transaction-toasts.tsx
+++ b/apps/trading/lib/hooks/use-ethereum-transaction-toasts.tsx
@@ -177,22 +177,14 @@ export const useEthereumTransactionToasts = () => {
     store.remove,
   ]);
 
-  const [dismissTx, deleteTx] = useEthTransactionStore((state) => [
-    state.dismiss,
-    state.delete,
-  ]);
+  const dismissTx = useEthTransactionStore((state) => state.dismiss);
 
   const onClose = useCallback(
     (tx: EthStoredTxState) => () => {
-      const safeToDelete = isFinal(tx);
-      if (safeToDelete) {
-        deleteTx(tx.id);
-      } else {
-        dismissTx(tx.id);
-      }
+      dismissTx(tx.id);
       removeToast(`eth-${tx.id}`);
     },
-    [deleteTx, dismissTx, removeToast]
+    [dismissTx, removeToast]
   );
 
   const fromEthTransaction = useCallback(

--- a/libs/deal-ticket/src/components/deal-ticket/expiry-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/expiry-selector.tsx
@@ -22,7 +22,11 @@ export const ExpirySelector = ({
   const dateFormatted = formatForInput(date);
   const minDate = formatForInput(date);
   return (
-    <FormGroup label={t('Expiry time/date')} labelFor="expiration">
+    <FormGroup
+      label={t('Expiry time/date')}
+      labelFor="expiration"
+      compact={true}
+    >
       <Input
         data-testid="date-picker-field"
         id="expiration"

--- a/libs/deal-ticket/src/components/deal-ticket/side-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/side-selector.tsx
@@ -26,7 +26,11 @@ export const SideSelector = ({ value, onSelect }: SideSelectorProps) => {
   };
 
   return (
-    <FormGroup label={t('Direction')} labelFor="order-side-toggle">
+    <FormGroup
+      label={t('Direction')}
+      labelFor="order-side-toggle"
+      compact={true}
+    >
       <Toggle
         id="order-side-toggle"
         name="order-side"

--- a/libs/deal-ticket/src/components/deal-ticket/time-in-force-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/time-in-force-selector.tsx
@@ -119,7 +119,11 @@ export const TimeInForceSelector = ({
   };
 
   return (
-    <FormGroup label={t('Time in force')} labelFor="select-time-in-force">
+    <FormGroup
+      label={t('Time in force')}
+      labelFor="select-time-in-force"
+      compact={true}
+    >
       <Select
         id="select-time-in-force"
         value={value}

--- a/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
@@ -74,7 +74,7 @@ export const TypeSelector = ({
   };
 
   return (
-    <FormGroup label={t('Order type')} labelFor="order-type">
+    <FormGroup label={t('Order type')} labelFor="order-type" compact={true}>
       <Toggle
         id="order-type"
         name="order-type"

--- a/libs/deposits/src/lib/approve-notification.tsx
+++ b/libs/deposits/src/lib/approve-notification.tsx
@@ -55,6 +55,7 @@ export const ApproveNotification = ({
           size: 'sm',
           text: `Approve ${selectedAsset?.symbol}`,
           action: onApprove,
+          dataTestId: 'approve-submit',
         }}
       />
     </div>
@@ -73,6 +74,7 @@ export const ApproveNotification = ({
           size: 'sm',
           text: `Approve ${selectedAsset?.symbol}`,
           action: onApprove,
+          dataTestId: 'reapprove-submit',
         }}
       />
     </div>

--- a/libs/deposits/src/lib/approve-notification.tsx
+++ b/libs/deposits/src/lib/approve-notification.tsx
@@ -1,0 +1,213 @@
+import type { Asset } from '@vegaprotocol/assets';
+import { useEnvironment } from '@vegaprotocol/environment';
+import { t } from '@vegaprotocol/i18n';
+import { ExternalLink, Intent, Notification } from '@vegaprotocol/ui-toolkit';
+import { formatNumber } from '@vegaprotocol/utils';
+import type { EthStoredTxState } from '@vegaprotocol/web3';
+import { EthTxStatus, useEthTransactionStore } from '@vegaprotocol/web3';
+import BigNumber from 'bignumber.js';
+import type { DepositBalances } from './use-deposit-balances';
+
+interface ApproveNotificationProps {
+  isActive: boolean;
+  selectedAsset?: Asset;
+  onApprove: () => void;
+  approved: boolean;
+  balances: DepositBalances | null;
+  amount: string;
+  approveTxId: number | null;
+}
+
+export const ApproveNotification = ({
+  isActive,
+  selectedAsset,
+  onApprove,
+  amount,
+  balances,
+  approved,
+  approveTxId,
+}: ApproveNotificationProps) => {
+  const tx = useEthTransactionStore((state) => {
+    return state.transactions.find((t) => t?.id === approveTxId);
+  });
+
+  if (!isActive) {
+    return null;
+  }
+
+  if (!selectedAsset) {
+    return null;
+  }
+
+  if (!balances) {
+    return null;
+  }
+
+  const approvePrompt = (
+    <div className="mb-4">
+      <Notification
+        intent={Intent.Warning}
+        testId="approve-default"
+        message={t(
+          `Before you can make a deposit of your chosen asset, ${selectedAsset?.symbol}, you need to approve its use in your Ethereum wallet`
+        )}
+        buttonProps={{
+          size: 'sm',
+          text: `Approve ${selectedAsset?.symbol}`,
+          action: onApprove,
+        }}
+      />
+    </div>
+  );
+  const reApprovePrompt = (
+    <div className="mb-4">
+      <Notification
+        intent={Intent.Warning}
+        testId="reapprove-default"
+        message={t(
+          `Approve again to deposit more than ${formatNumber(
+            balances.allowance.toString()
+          )}`
+        )}
+        buttonProps={{
+          size: 'sm',
+          text: `Approve ${selectedAsset?.symbol}`,
+          action: onApprove,
+        }}
+      />
+    </div>
+  );
+  const approvalFeedback = (
+    <ApprovalTxFeedback
+      tx={tx}
+      selectedAsset={selectedAsset}
+      allowance={balances.allowance}
+    />
+  );
+
+  // always show requested and pending states
+  if (
+    tx &&
+    [EthTxStatus.Requested, EthTxStatus.Pending, EthTxStatus.Complete].includes(
+      tx.status
+    )
+  ) {
+    return approvalFeedback;
+  }
+
+  if (!approved) {
+    return approvePrompt;
+  }
+
+  if (new BigNumber(amount).isGreaterThan(balances.allowance)) {
+    return reApprovePrompt;
+  }
+
+  if (
+    tx &&
+    tx.status === EthTxStatus.Error &&
+    // @ts-ignore tx.error not typed correctly
+    tx.error.code === 'ACTION_REJECTED'
+  ) {
+    return approvePrompt;
+  }
+
+  return approvalFeedback;
+};
+
+const ApprovalTxFeedback = ({
+  tx,
+  selectedAsset,
+  allowance,
+}: {
+  tx: EthStoredTxState | undefined;
+  selectedAsset: Asset;
+  allowance?: BigNumber;
+}) => {
+  const { ETHERSCAN_URL } = useEnvironment();
+
+  if (!tx) return null;
+
+  const txLink = tx.txHash && (
+    <ExternalLink href={`${ETHERSCAN_URL}/tx/${tx.txHash}`}>
+      {t('View on Etherscan')}
+    </ExternalLink>
+  );
+
+  if (tx.status === EthTxStatus.Error) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Danger}
+          testId="approve-error"
+          message={
+            <p>
+              {t('Approval failed')} {txLink}
+            </p>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Requested) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Warning}
+          testId="approve-requested"
+          message={t(
+            `Go to your Ethereum wallet and approve the transaction to enable the use of ${selectedAsset?.symbol}`
+          )}
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Pending) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Primary}
+          testId="approve-pending"
+          message={
+            <>
+              <p>
+                {t(
+                  `Your ${selectedAsset?.symbol} is being confirmed by the Ethereum network. When this is complete, you can continue your deposit`
+                )}{' '}
+              </p>
+              {txLink && <p>{txLink}</p>}
+            </>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Confirmed) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Success}
+          testId="approve-confirmed"
+          message={
+            <>
+              <p>
+                {t(
+                  `You can now make deposits in ${
+                    selectedAsset?.symbol
+                  }, up to a maximum of ${formatNumber(
+                    allowance?.toString() || 0
+                  )}`
+                )}
+              </p>
+              {txLink && <p>{txLink}</p>}
+            </>
+          }
+        />
+      </div>
+    );
+  }
+  return null;
+};

--- a/libs/deposits/src/lib/deposit-container.tsx
+++ b/libs/deposits/src/lib/deposit-container.tsx
@@ -4,18 +4,11 @@ import { DepositManager } from './deposit-manager';
 import { t } from '@vegaprotocol/i18n';
 import { useDataProvider } from '@vegaprotocol/react-helpers';
 import { enabledAssetsProvider } from '@vegaprotocol/assets';
-import type { DepositDialogStylePropsSetter } from './deposit-dialog';
 
 /**
  *  Fetches data required for the Deposit page
  */
-export const DepositContainer = ({
-  assetId,
-  setDialogStyleProps,
-}: {
-  assetId?: string;
-  setDialogStyleProps?: DepositDialogStylePropsSetter;
-}) => {
+export const DepositContainer = ({ assetId }: { assetId?: string }) => {
   const { VEGA_ENV } = useEnvironment();
   const { data, loading, error } = useDataProvider({
     dataProvider: enabledAssetsProvider,
@@ -28,7 +21,6 @@ export const DepositContainer = ({
           assetId={assetId}
           assets={data}
           isFaucetable={VEGA_ENV !== Networks.MAINNET}
-          setDialogStyleProps={setDialogStyleProps}
         />
       ) : (
         <Splash>

--- a/libs/deposits/src/lib/deposit-dialog.tsx
+++ b/libs/deposits/src/lib/deposit-dialog.tsx
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { t } from '@vegaprotocol/i18n';
-import type { Intent } from '@vegaprotocol/ui-toolkit';
 import { Dialog } from '@vegaprotocol/ui-toolkit';
-import { useCallback, useState } from 'react';
 import { DepositContainer } from './deposit-container';
 import { useWeb3ConnectStore } from '@vegaprotocol/web3';
 import { useAssetDetailsDialogStore } from '@vegaprotocol/assets';
@@ -24,22 +22,6 @@ export const useDepositDialog = create<State & Actions>((set) => ({
   close: () => set(() => ({ assetId: undefined, isOpen: false })),
 }));
 
-export type DepositDialogStyleProps = {
-  title: string;
-  icon?: JSX.Element;
-  intent?: Intent;
-};
-
-export type DepositDialogStylePropsSetter = (
-  props?: DepositDialogStyleProps
-) => void;
-
-const DEFAULT_STYLE: DepositDialogStyleProps = {
-  title: t('Deposit'),
-  intent: undefined,
-  icon: undefined,
-};
-
 export const DepositDialog = () => {
   const { assetId, isOpen, open, close } = useDepositDialog();
   const assetDetailsDialogOpen = useAssetDetailsDialogStore(
@@ -48,25 +30,13 @@ export const DepositDialog = () => {
   const connectWalletDialogIsOpen = useWeb3ConnectStore(
     (state) => state.isOpen
   );
-  const [dialogStyleProps, _setDialogStyleProps] = useState(DEFAULT_STYLE);
-  const setDialogStyleProps: DepositDialogStylePropsSetter =
-    useCallback<DepositDialogStylePropsSetter>(
-      (props) =>
-        props
-          ? _setDialogStyleProps(props)
-          : _setDialogStyleProps(DEFAULT_STYLE),
-      [_setDialogStyleProps]
-    );
   return (
     <Dialog
       open={isOpen && !(connectWalletDialogIsOpen || assetDetailsDialogOpen)}
       onChange={(isOpen) => (isOpen ? open() : close())}
-      {...dialogStyleProps}
+      title={t('Deposit')}
     >
-      <DepositContainer
-        assetId={assetId}
-        setDialogStyleProps={setDialogStyleProps}
-      />
+      <DepositContainer assetId={assetId} />
     </Dialog>
   );
 };

--- a/libs/deposits/src/lib/deposit-form.spec.tsx
+++ b/libs/deposits/src/lib/deposit-form.spec.tsx
@@ -80,7 +80,7 @@ describe('Deposit form', () => {
 
     // Assert default values (including) from/to provided by useVegaWallet and useWeb3React
     expect(screen.getByText('From (Ethereum address)')).toBeInTheDocument();
-    expect(screen.getByTestId('ethereum-account')).toHaveTextContent(
+    expect(screen.getByTestId('ethereum-address')).toHaveTextContent(
       MOCK_ETH_ADDRESS
     );
     expect(screen.getByLabelText('Asset')).toHaveValue('');
@@ -338,7 +338,7 @@ describe('Deposit form', () => {
       screen.queryByRole('button', { name: 'Connect' })
     ).not.toBeInTheDocument();
     expect(screen.getByText('From (Ethereum address)')).toBeInTheDocument();
-    expect(screen.getByTestId('ethereum-account')).toHaveTextContent(
+    expect(screen.getByTestId('ethereum-address')).toHaveTextContent(
       MOCK_ETH_ADDRESS
     );
   });

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -687,6 +687,7 @@ const FaucetNotification = ({ selectedAsset, tx }: FaucetNotificationProps) => {
         <Notification
           intent={Intent.Danger}
           testId="faucet-error"
+          // @ts-ignore tx.error not typed correctly
           message={t(`Faucet failed: ${tx.error?.reason}`)}
         />
       </div>

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -157,8 +157,8 @@ export const DepositForm = ({
           render={() => {
             if (isActive && account) {
               return (
-                <div className="text-sm">
-                  <p className="mb-1" data-testid="ethereum-account">
+                <div className="text-sm" aria-describedby="ethereum-address">
+                  <p className="mb-1" data-testid="ethereum-address">
                     {account}
                   </p>
                   <DisconnectEthereumButton

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -360,12 +360,16 @@ export const DepositForm = ({
         approved={approved}
         amount={amount}
       />
-      <FormButton />
+      <FormButton approved={approved} />
     </form>
   );
 };
 
-const FormButton = () => {
+interface FormButtonProps {
+  approved: boolean;
+}
+
+const FormButton = ({ approved }: FormButtonProps) => {
   const { isActive, chainId } = useWeb3React();
   const desiredChainId = useWeb3ConnectStore((store) => store.desiredChainId);
   const invalidChain = isActive && chainId !== desiredChainId;
@@ -387,7 +391,7 @@ const FormButton = () => {
         data-testid="deposit-submit"
         variant={isActive ? 'primary' : 'default'}
         fill={true}
-        disabled={invalidChain}
+        disabled={!approved || invalidChain}
       >
         {t('Deposit')}
       </Button>

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -1,4 +1,4 @@
-import type { Asset } from '@vegaprotocol/assets';
+import type { Asset, AssetFieldsFragment } from '@vegaprotocol/assets';
 import { AssetOption } from '@vegaprotocol/assets';
 import {
   ethereumAddress,
@@ -40,6 +40,7 @@ import {
 import type { DepositBalances } from './use-deposit-balances';
 import { FaucetNotification } from './faucet-notification';
 import { ApproveNotification } from './approve-notification';
+import { PartialOnUndefinedDeepOptions } from 'type-fest';
 
 interface FormFields {
   asset: string;
@@ -360,16 +361,17 @@ export const DepositForm = ({
         approved={approved}
         amount={amount}
       />
-      <FormButton approved={approved} />
+      <FormButton approved={approved} selectedAsset={selectedAsset} />
     </form>
   );
 };
 
 interface FormButtonProps {
   approved: boolean;
+  selectedAsset: AssetFieldsFragment | undefined;
 }
 
-const FormButton = ({ approved }: FormButtonProps) => {
+const FormButton = ({ approved, selectedAsset }: FormButtonProps) => {
   const { isActive, chainId } = useWeb3React();
   const desiredChainId = useWeb3ConnectStore((store) => store.desiredChainId);
   const invalidChain = isActive && chainId !== desiredChainId;
@@ -391,7 +393,7 @@ const FormButton = ({ approved }: FormButtonProps) => {
         data-testid="deposit-submit"
         variant={isActive ? 'primary' : 'default'}
         fill={true}
-        disabled={!approved || invalidChain}
+        disabled={invalidChain || (selectedAsset && !approved)}
       >
         {t('Deposit')}
       </Button>

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -460,6 +460,7 @@ export const AddressField = ({
             onChange();
           }}
           className="ml-auto text-sm absolute top-0 right-0 underline"
+          data-testid="enter-pubkey-manually"
         >
           {isInput ? t('Select from wallet') : t('Enter manually')}
         </button>

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -158,7 +158,9 @@ export const DepositForm = ({
             if (isActive && account) {
               return (
                 <div className="text-sm">
-                  <p className="mb-1">{account}</p>
+                  <p className="mb-1" data-testid="ethereum-account">
+                    {account}
+                  </p>
                   <DisconnectEthereumButton
                     onDisconnect={() => {
                       setValue('from', ''); // clear from value so required ethereum connection validation works

--- a/libs/deposits/src/lib/deposit-form.tsx
+++ b/libs/deposits/src/lib/deposit-form.tsx
@@ -40,7 +40,6 @@ import {
 import type { DepositBalances } from './use-deposit-balances';
 import { FaucetNotification } from './faucet-notification';
 import { ApproveNotification } from './approve-notification';
-import { PartialOnUndefinedDeepOptions } from 'type-fest';
 
 interface FormFields {
   asset: string;

--- a/libs/deposits/src/lib/deposit-limits.tsx
+++ b/libs/deposits/src/lib/deposit-limits.tsx
@@ -35,7 +35,7 @@ export const DepositLimits = ({
     },
     {
       key: 'MAX_LIMIT',
-      label: t('Maximum total deposit amount'),
+      label: t('Lifetime deposit allowance'),
       rawValue: max,
       value: <CompactNumber number={max} decimals={asset.decimals} />,
     },

--- a/libs/deposits/src/lib/deposit-manager.tsx
+++ b/libs/deposits/src/lib/deposit-manager.tsx
@@ -5,19 +5,15 @@ import { prepend0x } from '@vegaprotocol/smart-contracts';
 import sortBy from 'lodash/sortBy';
 import { useSubmitApproval } from './use-submit-approval';
 import { useSubmitFaucet } from './use-submit-faucet';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useDepositBalances } from './use-deposit-balances';
 import { useDepositDialog } from './deposit-dialog';
 import type { Asset } from '@vegaprotocol/assets';
-import pick from 'lodash/pick';
-import type { EthTransaction } from '@vegaprotocol/web3';
 import {
-  EthTxStatus,
   useEthTransactionStore,
   useBridgeContract,
   useEthereumConfig,
 } from '@vegaprotocol/web3';
-import { t } from '@vegaprotocol/i18n';
 
 interface DepositManagerProps {
   assetId?: string;
@@ -37,7 +33,7 @@ export const DepositManager = ({
   const bridgeContract = useBridgeContract();
   const closeDepositDialog = useDepositDialog((state) => state.close);
 
-  const { balance, allowance, deposited, max, refresh } = useDepositBalances(
+  const { getBalances, reset, balances } = useDepositBalances(
     asset,
     isFaucetable
   );
@@ -71,8 +67,8 @@ export const DepositManager = ({
 
   return (
     <DepositForm
-      balance={balance}
       selectedAsset={asset}
+      onDisconnect={reset}
       onSelectAsset={(id) => {
         setAssetId(id);
         faucet.reset();
@@ -81,18 +77,16 @@ export const DepositManager = ({
       assets={sortBy(assets, 'name')}
       submitApprove={async () => {
         await approve.perform();
-        refresh();
+        getBalances();
       }}
       approveTx={approve.transaction}
       submitDeposit={submitDeposit}
       requestFaucet={async () => {
         await faucet.perform();
-        refresh();
+        getBalances();
       }}
       faucetTx={faucet.transaction}
-      deposited={deposited}
-      max={max}
-      allowance={allowance}
+      balances={balances}
       isFaucetable={isFaucetable}
     />
   );

--- a/libs/deposits/src/lib/deposit-manager.tsx
+++ b/libs/deposits/src/lib/deposit-manager.tsx
@@ -48,16 +48,6 @@ export const DepositManager = ({
   // Set up faucet transaction
   const faucet = useSubmitFaucet(asset);
 
-  // const transactionInProgress = [approve.TxContent, faucet.TxContent].filter(
-  //   (t) => t.status !== EthTxStatus.Default
-  // )[0];
-
-  // useEffect(() => {
-  //   setDialogStyleProps?.(getProps(transactionInProgress));
-  // }, [setDialogStyleProps, transactionInProgress]);
-
-  const returnLabel = t('Return to deposit');
-
   const submitDeposit = (
     args: Parameters<DepositFormProps['submitDeposit']>['0']
   ) => {
@@ -80,34 +70,30 @@ export const DepositManager = ({
   };
 
   return (
-    <>
-      <DepositForm
-        balance={balance}
-        selectedAsset={asset}
-        onSelectAsset={(id) => {
-          setAssetId(id);
-          faucet.reset();
-          approve.reset();
-        }}
-        assets={sortBy(assets, 'name')}
-        submitApprove={async () => {
-          await approve.perform();
-          refresh();
-        }}
-        approveStatus={approve.transaction}
-        submitDeposit={submitDeposit}
-        requestFaucet={async () => {
-          await faucet.perform();
-          refresh();
-        }}
-        deposited={deposited}
-        max={max}
-        allowance={allowance}
-        isFaucetable={isFaucetable}
-      />
-
-      {/* <approve.TxContent.Content returnLabel={returnLabel} /> */}
-      <faucet.TxContent.Content returnLabel={returnLabel} />
-    </>
+    <DepositForm
+      balance={balance}
+      selectedAsset={asset}
+      onSelectAsset={(id) => {
+        setAssetId(id);
+        faucet.reset();
+        approve.reset();
+      }}
+      assets={sortBy(assets, 'name')}
+      submitApprove={async () => {
+        await approve.perform();
+        refresh();
+      }}
+      approveTx={approve.transaction}
+      submitDeposit={submitDeposit}
+      requestFaucet={async () => {
+        await faucet.perform();
+        refresh();
+      }}
+      faucetTx={faucet.transaction}
+      deposited={deposited}
+      max={max}
+      allowance={allowance}
+      isFaucetable={isFaucetable}
+    />
   );
 };

--- a/libs/deposits/src/lib/deposit-manager.tsx
+++ b/libs/deposits/src/lib/deposit-manager.tsx
@@ -71,6 +71,10 @@ export const DepositManager = ({
       onDisconnect={reset}
       onSelectAsset={(id) => {
         setAssetId(id);
+        // When we change asset, also clear the tracked faucet/approve transactions so
+        // we dont render stale UI
+        approve.reset();
+        faucet.reset();
       }}
       assets={sortBy(assets, 'name')}
       submitApprove={approve.perform}

--- a/libs/deposits/src/lib/deposit-manager.tsx
+++ b/libs/deposits/src/lib/deposit-manager.tsx
@@ -39,10 +39,10 @@ export const DepositManager = ({
   );
 
   // Set up approve transaction
-  const approve = useSubmitApproval(asset);
+  const approve = useSubmitApproval(asset, getBalances);
 
   // Set up faucet transaction
-  const faucet = useSubmitFaucet(asset);
+  const faucet = useSubmitFaucet(asset, getBalances);
 
   const submitDeposit = (
     args: Parameters<DepositFormProps['submitDeposit']>['0']
@@ -71,21 +71,13 @@ export const DepositManager = ({
       onDisconnect={reset}
       onSelectAsset={(id) => {
         setAssetId(id);
-        faucet.reset();
-        approve.reset();
       }}
       assets={sortBy(assets, 'name')}
-      submitApprove={async () => {
-        await approve.perform();
-        getBalances();
-      }}
-      approveTx={approve.transaction}
+      submitApprove={approve.perform}
       submitDeposit={submitDeposit}
-      requestFaucet={async () => {
-        await faucet.perform();
-        getBalances();
-      }}
-      faucetTx={faucet.transaction}
+      submitFaucet={faucet.perform}
+      faucetTxId={faucet.id}
+      approveTxId={approve.id}
       balances={balances}
       isFaucetable={isFaucetable}
     />

--- a/libs/deposits/src/lib/faucet-notification.tsx
+++ b/libs/deposits/src/lib/faucet-notification.tsx
@@ -1,0 +1,108 @@
+import type { Asset } from '@vegaprotocol/assets';
+import { useEnvironment } from '@vegaprotocol/environment';
+import { t } from '@vegaprotocol/i18n';
+import { ExternalLink, Intent, Notification } from '@vegaprotocol/ui-toolkit';
+import { EthTxStatus, useEthTransactionStore } from '@vegaprotocol/web3';
+
+interface FaucetNotificationProps {
+  isActive: boolean;
+  selectedAsset?: Asset;
+  faucetTxId: number | null;
+}
+
+/**
+ * Render a notification for the faucet transaction
+ */
+export const FaucetNotification = ({
+  isActive,
+  selectedAsset,
+  faucetTxId,
+}: FaucetNotificationProps) => {
+  const { ETHERSCAN_URL } = useEnvironment();
+  const tx = useEthTransactionStore((state) => {
+    return state.transactions.find((t) => t?.id === faucetTxId);
+  });
+
+  if (!isActive) {
+    return null;
+  }
+
+  if (!selectedAsset) {
+    return null;
+  }
+
+  if (!tx) {
+    return null;
+  }
+
+  if (tx.status === EthTxStatus.Error) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Danger}
+          testId="faucet-error"
+          // @ts-ignore tx.error not typed correctly
+          message={t(`Faucet failed: ${tx.error?.reason}`)}
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Requested) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Warning}
+          testId="faucet-requested"
+          message={t(
+            `Go to your Ethereum wallet and approve the transaction to faucet ${selectedAsset?.symbol}`
+          )}
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Pending) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Primary}
+          testId="faucet-pending"
+          message={
+            <p>
+              {t('Waiting...')}{' '}
+              {tx.txHash && (
+                <ExternalLink href={`${ETHERSCAN_URL}/tx/${tx.txHash}`}>
+                  {t('View on Etherscan')}
+                </ExternalLink>
+              )}
+            </p>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (tx.status === EthTxStatus.Confirmed) {
+    return (
+      <div className="mb-4">
+        <Notification
+          intent={Intent.Success}
+          testId="faucet-confirmed"
+          message={
+            <p>
+              {t('Faucet successful')}{' '}
+              {tx.txHash && (
+                <ExternalLink href={`${ETHERSCAN_URL}/tx/${tx.txHash}`}>
+                  {t('View on Etherscan')}
+                </ExternalLink>
+              )}
+            </p>
+          }
+        />
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/libs/deposits/src/lib/faucet-notification.tsx
+++ b/libs/deposits/src/lib/faucet-notification.tsx
@@ -55,7 +55,7 @@ export const FaucetNotification = ({
           intent={Intent.Warning}
           testId="faucet-requested"
           message={t(
-            `Go to your Ethereum wallet and approve the transaction to faucet ${selectedAsset?.symbol}`
+            `Go to your Ethereum wallet and approve the faucet transaction for ${selectedAsset?.symbol}`
           )}
         />
       </div>
@@ -70,7 +70,7 @@ export const FaucetNotification = ({
           testId="faucet-pending"
           message={
             <p>
-              {t('Waiting...')}{' '}
+              {t('Faucet pending...')}{' '}
               {tx.txHash && (
                 <ExternalLink href={`${ETHERSCAN_URL}/tx/${tx.txHash}`}>
                   {t('View on Etherscan')}

--- a/libs/deposits/src/lib/use-deposit-balances.ts
+++ b/libs/deposits/src/lib/use-deposit-balances.ts
@@ -7,7 +7,6 @@ import { useGetBalanceOfERC20Token } from './use-get-balance-of-erc20-token';
 import { useGetDepositMaximum } from './use-get-deposit-maximum';
 import { useGetDepositedAmount } from './use-get-deposited-amount';
 import { isAssetTypeERC20 } from '@vegaprotocol/utils';
-import { usePrevious } from '@vegaprotocol/react-helpers';
 import { useAccountBalance } from '@vegaprotocol/accounts';
 import type { Asset } from '@vegaprotocol/assets';
 
@@ -65,6 +64,7 @@ export const useDepositBalances = (
       });
     } catch (err) {
       Sentry.captureException(err);
+      setState(null);
     }
   }, [asset, getAllowance, getBalance, getDepositMaximum, getDepositedAmount]);
 

--- a/libs/deposits/src/lib/use-submit-approval.ts
+++ b/libs/deposits/src/lib/use-submit-approval.ts
@@ -32,6 +32,9 @@ export const useSubmitApproval = (
 
   return {
     id,
+    reset: () => {
+      setId(null);
+    },
     perform: () => {
       if (!asset || !config) return;
       const amount = removeDecimal('1000000', asset.decimals);

--- a/libs/deposits/src/lib/use-submit-approval.ts
+++ b/libs/deposits/src/lib/use-submit-approval.ts
@@ -1,36 +1,45 @@
 import { isAssetTypeERC20, removeDecimal } from '@vegaprotocol/utils';
-import * as Sentry from '@sentry/react';
-import type { Token } from '@vegaprotocol/smart-contracts';
 import {
+  EthTxStatus,
   useEthereumConfig,
-  useEthereumTransaction,
+  useEthTransactionStore,
   useTokenContract,
 } from '@vegaprotocol/web3';
 import type { Asset } from '@vegaprotocol/assets';
+import { useEffect, useState } from 'react';
 
-export const useSubmitApproval = (asset?: Asset) => {
+export const useSubmitApproval = (
+  asset: Asset | undefined,
+  getBalances: () => void
+) => {
+  const [id, setId] = useState<number | null>(null);
+  const createEthTransaction = useEthTransactionStore((state) => state.create);
+  const tx = useEthTransactionStore((state) => {
+    return state.transactions.find((t) => t?.id === id);
+  });
   const { config } = useEthereumConfig();
   const contract = useTokenContract(
     isAssetTypeERC20(asset) ? asset.source.contractAddress : undefined,
     true
   );
-  const transaction = useEthereumTransaction<Token, 'approve'>(
-    contract,
-    'approve'
-  );
+
+  // When tx is confirmed refresh balances
+  useEffect(() => {
+    if (tx?.status === EthTxStatus.Confirmed) {
+      getBalances();
+    }
+  }, [tx?.status, getBalances]);
+
   return {
-    ...transaction,
-    perform: async () => {
+    id,
+    perform: () => {
       if (!asset || !config) return;
-      try {
-        const amount = removeDecimal('1000000', asset.decimals);
-        await transaction.perform(
-          config.collateral_bridge_contract.address,
-          amount
-        );
-      } catch (err) {
-        Sentry.captureException(err);
-      }
+      const amount = removeDecimal('1000000', asset.decimals);
+      const id = createEthTransaction(contract, 'approve', [
+        config?.collateral_bridge_contract.address,
+        amount,
+      ]);
+      setId(id);
     },
   };
 };

--- a/libs/deposits/src/lib/use-submit-faucet.ts
+++ b/libs/deposits/src/lib/use-submit-faucet.ts
@@ -1,26 +1,38 @@
-import type { TokenFaucetable } from '@vegaprotocol/smart-contracts';
-import * as Sentry from '@sentry/react';
-import { useEthereumTransaction, useTokenContract } from '@vegaprotocol/web3';
+import {
+  EthTxStatus,
+  useEthTransactionStore,
+  useTokenContract,
+} from '@vegaprotocol/web3';
 import { isAssetTypeERC20 } from '@vegaprotocol/utils';
 import type { Asset } from '@vegaprotocol/assets';
+import { useEffect, useState } from 'react';
 
-export const useSubmitFaucet = (asset?: Asset) => {
+export const useSubmitFaucet = (
+  asset: Asset | undefined,
+  getBalances: () => void
+) => {
+  const [id, setId] = useState<number | null>(null);
+  const createEthTransaction = useEthTransactionStore((state) => state.create);
+  const tx = useEthTransactionStore((state) => {
+    return state.transactions.find((t) => t?.id === id);
+  });
   const contract = useTokenContract(
     isAssetTypeERC20(asset) ? asset.source.contractAddress : undefined,
     true
   );
-  const transaction = useEthereumTransaction<TokenFaucetable, 'faucet'>(
-    contract,
-    'faucet'
-  );
+
+  // When tx is confirmed refresh balances
+  useEffect(() => {
+    if (tx?.status === EthTxStatus.Confirmed) {
+      getBalances();
+    }
+  }, [tx?.status, getBalances]);
+
   return {
-    ...transaction,
-    perform: async () => {
-      try {
-        await transaction.perform();
-      } catch (err) {
-        Sentry.captureException(err);
-      }
+    id,
+    perform: () => {
+      const id = createEthTransaction(contract, 'faucet', []);
+      setId(id);
     },
   };
 };

--- a/libs/deposits/src/lib/use-submit-faucet.ts
+++ b/libs/deposits/src/lib/use-submit-faucet.ts
@@ -30,6 +30,9 @@ export const useSubmitFaucet = (
 
   return {
     id,
+    reset: () => {
+      setId(null);
+    },
     perform: () => {
       const id = createEthTransaction(contract, 'faucet', []);
       setId(id);

--- a/libs/ui-toolkit/src/components/form-group/form-group.tsx
+++ b/libs/ui-toolkit/src/components/form-group/form-group.tsx
@@ -9,6 +9,7 @@ export interface FormGroupProps {
   hideLabel?: boolean;
   labelDescription?: string;
   labelAlign?: 'left' | 'right';
+  compact?: boolean;
 }
 
 export const FormGroup = ({
@@ -19,8 +20,16 @@ export const FormGroup = ({
   labelDescription,
   labelAlign = 'left',
   hideLabel = false,
+  compact = false,
 }: FormGroupProps) => {
-  const wrapperClasses = classNames('relative mb-2', className);
+  const wrapperClasses = classNames(
+    'relative',
+    {
+      'mb-2': compact,
+      'mb-4': !compact,
+    },
+    className
+  );
   const labelClasses = classNames('block mb-2 text-sm', {
     'text-right': labelAlign === 'right',
     'sr-only': hideLabel,

--- a/libs/web3/src/lib/use-ethereum-transaction-store.tsx
+++ b/libs/web3/src/lib/use-ethereum-transaction-store.tsx
@@ -26,7 +26,7 @@ export interface EthStoredTxState extends EthTxState {
   methodName: ContractMethod;
   args: string[];
   requiredConfirmations: number;
-  requiresConfirmation: boolean;
+  requiresConfirmation: boolean; // whether or not the tx needs external confirmation (IE from a subscription even)
   assetId?: string;
   deposit?: DepositBusEventFieldsFragment;
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #2566 

# Description ℹ️

Updates deposit flow to
- Make connection more obvious via a primary button and validation
- Make choosing which key to deposit to easier by providing a dropdown (as well as manual entry option)
- Show feedback inline for faucet and approve transactions
- Show toasts so the user is notified even if the form dialog is closed

# Demo 📺
<img src= "https://user-images.githubusercontent.com/6803987/223254048-7ec2ff7e-a2b0-4b92-8f61-866c1ebe70fd.jpg" width="200" />
<img src= "https://user-images.githubusercontent.com/6803987/223254503-f4f73767-7150-4f0c-a851-b377bf15318c.jpg" width="200" />
<img src= "https://user-images.githubusercontent.com/6803987/223254594-84da346e-4fc1-4691-b91f-27820bc124ff.jpg" width="200" />
<img src= "https://user-images.githubusercontent.com/6803987/223254774-68cf6269-9ed7-4dc0-a610-15856c6ceff8.jpg" width="200" />


# Technical 👨‍🔧

- Connects to the ethereum transaction store so you will also get toasts for deposit TXs
- Updates the ethereum toast manager to not delete the tx on close, but only dismiss
