### PR TITLE
chore(trading): catch ethereum errors and capture to sentry

### DIFF
--- a/libs/web3/src/lib/use-ethereum-withdraw-approvals-manager.tsx
+++ b/libs/web3/src/lib/use-ethereum-withdraw-approvals-manager.tsx
@@ -5,6 +5,7 @@ import { addDecimal } from '@vegaprotocol/utils';
 import { useGetWithdrawThreshold } from './use-get-withdraw-threshold';
 import { useGetWithdrawDelay } from './use-get-withdraw-delay';
 import { t } from '@vegaprotocol/i18n';
+import { localLoggerFactory } from '@vegaprotocol/utils';
 
 import { CollateralBridge } from '@vegaprotocol/smart-contracts';
 
@@ -128,7 +129,16 @@ export const useEthWithdrawApprovalsManager = () => {
           approval.signatures,
         ]
       );
-    })();
+    })().catch((err) => {
+      localLoggerFactory({ application: 'web3' }).error(
+        'create withdrawal transaction',
+        err
+      );
+      update(transaction.id, {
+        status: ApprovalStatus.Error,
+        message: t('Something went wrong'),
+      });
+    });
   }, [
     getThreshold,
     getDelay,


### PR DESCRIPTION
# Related issues 🔗

Closes #2580

# Description ℹ️

Catch possibly errors from the last stage of creating transaction, when contract endpoints are requested

# Demo 📺

![Screenshot 2023-03-02 at 13 21 00](https://user-images.githubusercontent.com/338931/222427850-88d74a19-6d38-4351-9604-e701e9d4a4f8.png)


# Technical 👨‍🔧

Add catch to promise and log by logger
