### PR TITLE
fix(trading):  deal ticket expiry not wiped out after changing TIF from GTT

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -205,7 +205,9 @@ export const DealTicket = ({
                 type,
                 // when changing type also update the tif to what was last used of new type
                 timeInForce: lastTIF[type] || order.timeInForce,
+                expiresAt: undefined,
               });
+              clearErrors('expiresAt');
             }}
             market={market}
             marketData={marketData}
@@ -253,7 +255,12 @@ export const DealTicket = ({
               update({ timeInForce });
               // Set tif value for the given order type, so that when switching
               // types we know the last used TIF for the given order type
-              setLastTIF((curr) => ({ ...curr, [order.type]: timeInForce }));
+              setLastTIF((curr) => ({
+                ...curr,
+                [order.type]: timeInForce,
+                expiresAt: undefined,
+              }));
+              clearErrors('expiresAt');
             }}
             market={market}
             marketData={marketData}

--- a/libs/deal-ticket/src/constants.ts
+++ b/libs/deal-ticket/src/constants.ts
@@ -13,7 +13,7 @@ export const EST_TOTAL_MARGIN_TOOLTIP_TEXT = t(
 export const MARGIN_ACCOUNT_TOOLTIP_TEXT = t('Margin account balance');
 export const MARGIN_DIFF_TOOLTIP_TEXT = (settlementAsset: string) =>
   t(
-    "The additional margin required for your new position (taking into account volume and open orders), compared to your current margin. Measured in the market's settlement asset ($s).",
+    "The additional margin required for your new position (taking into account volume and open orders), compared to your current margin. Measured in the market's settlement asset (%s).",
     [settlementAsset]
   );
 export const CONTRACTS_MARGIN_TOOLTIP_TEXT = t(

--- a/libs/deal-ticket/src/hooks/use-fee-deal-ticket-details.tsx
+++ b/libs/deal-ticket/src/hooks/use-fee-deal-ticket-details.tsx
@@ -11,8 +11,6 @@ import { useMemo } from 'react';
 import type { Market, MarketData } from '@vegaprotocol/market-list';
 import type { OrderSubmissionBody } from '@vegaprotocol/wallet';
 import {
-  EST_CLOSEOUT_TOOLTIP_TEXT,
-  // EST_MARGIN_TOOLTIP_TEXT,
   EST_TOTAL_MARGIN_TOOLTIP_TEXT,
   NOTIONAL_SIZE_TOOLTIP_TEXT,
   MARGIN_ACCOUNT_TOOLTIP_TEXT,
@@ -100,16 +98,13 @@ export interface FeeDetails {
 export const getFeeDetailsValues = ({
   balance,
   assetSymbol,
-  estCloseOut,
   estimateOrder,
-  margin,
   market,
   notionalSize,
   totalMargin,
 }: FeeDetails) => {
   const assetDecimals =
     market.tradableInstrument.instrument.product.settlementAsset.decimals;
-  const quoteName = market.tradableInstrument.instrument.product.quoteName;
   const formatValueWithMarketDp = (
     value: string | number | null | undefined
   ): string => {
@@ -192,12 +187,6 @@ export const getFeeDetailsValues = ({
       : `${formatValueWithAssetDp(balance)}`,
     symbol: assetSymbol,
     labelDescription: MARGIN_ACCOUNT_TOOLTIP_TEXT,
-  });
-  details.push({
-    label: t('Liquidation'),
-    value: estCloseOut && `~${formatValueWithMarketDp(estCloseOut)}`,
-    symbol: market.tradableInstrument.instrument.product.quoteName,
-    labelDescription: EST_CLOSEOUT_TOOLTIP_TEXT(quoteName),
   });
   return details;
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #3123 

# Description ℹ️

- [x] deal ticket expiry not wiped out after TIF changing
- [x] remove liquidation
- [x] fix tooltip

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
