### PR TITLE
feat(explorer): improve display of multi cancellations

### DIFF
--- a/apps/explorer/src/app/components/order-summary/order-cancellation.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-cancellation.tsx
@@ -1,0 +1,26 @@
+import { t } from '@vegaprotocol/i18n';
+
+interface CancelSummaryProps {
+  orderId?: string;
+  marketId?: string;
+}
+
+/**
+ * Simple component for rendering a reasonable string from an order cancellation
+ */
+export const CancelSummary = ({ orderId, marketId }: CancelSummaryProps) => {
+  return <span className="font-bold">{getLabel(orderId, marketId)}</span>;
+};
+
+export function getLabel(
+  orderId: string | undefined,
+  marketId: string | undefined
+): string {
+  if (!orderId && !marketId) {
+    return t('All orders');
+  } else if (marketId && !orderId) {
+    return t('All in market');
+  }
+
+  return '-';
+}

--- a/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/batch-submission/batch-cancel.tsx
@@ -2,6 +2,7 @@ import type { BatchCancellationInstruction } from '../../../../routes/types/bloc
 import { TxOrderType } from '../../tx-order-type';
 import { MarketLink } from '../../../links';
 import OrderSummary from '../../../order-summary/order-summary';
+import { CancelSummary } from '../../../order-summary/order-cancellation';
 
 interface BatchCancelProps {
   index: number;
@@ -19,7 +20,14 @@ export const BatchCancel = ({ index, submission }: BatchCancelProps) => {
         <TxOrderType orderType={'OrderCancellation'} />
       </td>
       <td>
-        <OrderSummary id={submission.orderId} modifier="cancelled" />
+        {submission.orderId ? (
+          <OrderSummary id={submission.orderId} modifier="cancelled" />
+        ) : (
+          <CancelSummary
+            orderId={submission.orderId}
+            marketId={submission.marketId}
+          />
+        )}
       </td>
       <td>
         <MarketLink id={submission.marketId} />

--- a/apps/explorer/src/app/components/txs/details/tx-order-cancel.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-order-cancel.tsx
@@ -5,6 +5,8 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
 import DeterministicOrderDetails from '../../order-details/deterministic-order-details';
+import { CancelSummary } from '../../order-summary/order-cancellation';
+import Hash from '../../links/hash';
 
 interface TxDetailsOrderCancelProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -24,8 +26,8 @@ export const TxDetailsOrderCancel = ({
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
 
-  const marketId: string = txData.command.orderCancellation.marketId || '-';
-  const orderId: string = txData.command.orderCancellation.orderId || '-';
+  const marketId: string = txData.command.orderCancellation.marketId;
+  const orderId: string = txData.command.orderCancellation.orderId;
 
   return (
     <>
@@ -38,18 +40,24 @@ export const TxDetailsOrderCancel = ({
         <TableRow modifier="bordered">
           <TableCell>{t('Order')}</TableCell>
           <TableCell>
-            <code>{orderId}</code>
+            {orderId ? (
+              <Hash text={orderId} />
+            ) : (
+              <CancelSummary orderId={orderId} marketId={marketId} />
+            )}
           </TableCell>
         </TableRow>
-        <TableRow modifier="bordered">
-          <TableCell>{t('Market')}</TableCell>
-          <TableCell>
-            <MarketLink id={marketId} />
-          </TableCell>
-        </TableRow>
+        {marketId ? (
+          <TableRow modifier="bordered">
+            <TableCell>{t('Market')}</TableCell>
+            <TableCell>
+              <MarketLink id={marketId} />
+            </TableCell>
+          </TableRow>
+        ) : null}
       </TableWithTbody>
 
-      {orderId !== '-' ? <DeterministicOrderDetails id={orderId} /> : null}
+      {orderId ? <DeterministicOrderDetails id={orderId} /> : null}
     </>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #3106

# Description ℹ️

A 'Cancel Order' can optionally:
- *not* specify an order ID, specify a market = cancel all orders in market
- *not* specify an order ID and *not* specify a market = cancel all orders

Previously this was just rendered as a '-' in Order ID and '-' in Market. Now a new component renders a more useful
explanation of the situation

# Demo 📺

## This is a normal cancellation with an order ID and a market
<img width="905" alt="Screenshot 2023-03-09 at 17 50 54" src="https://user-images.githubusercontent.com/6678/224119658-d917ccfd-6148-4eb7-8059-02bdd98f701a.png">

## This cancellation specifies nothing, so it cancels all orders
<img width="858" alt="Screenshot 2023-03-09 at 18 20 48" src="https://user-images.githubusercontent.com/6678/224119702-93af1ae5-3caf-4b46-9b0b-a3266b0a1faf.png">

## This cancellation closes all orders in a market
<img width="824" alt="Screenshot 2023-03-09 at 18 21 29" src="https://user-images.githubusercontent.com/6678/224119812-e5840e60-5b98-4671-9526-6d0f20bbbfbe.png">

## The cancellation in this batch order closes all orders in a specified market
<img width="973" alt="Screenshot 2023-03-09 at 18 16 20" src="https://user-images.githubusercontent.com/6678/224119218-a87f1eae-f591-48e0-be66-d62ba64bd57b.png">

