### PR TITLE
fix(explorer): format els as percentage in network param view

### DIFF
--- a/apps/explorer-e2e/src/fixtures/net_parameter_format_lookup.json
+++ b/apps/explorer-e2e/src/fixtures/net_parameter_format_lookup.json
@@ -22,7 +22,6 @@
     "governance.proposal.updateAsset.minProposerBalance",
     "governance.proposal.updateAsset.minVoterBalance",
     "governance.proposal.updateAsset.requiredParticipation",
-    "governance.proposal.updateMarket.minProposerEquityLikeShare",
     "market.fee.factors.infrastructureFee",
     "market.fee.factors.makerFee",
     "market.liquidity.bondPenaltyParameter",
@@ -77,6 +76,7 @@
     "governance.proposal.updateMarket.requiredParticipationLP",
     "governance.proposal.updateNetParam.requiredMajority",
     "governance.proposal.updateNetParam.requiredParticipation",
+    "governance.proposal.updateMarket.minProposerEquityLikeShare",
     "validators.vote.required"
   ],
   "duration": [

--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -31,6 +31,7 @@ const PERCENTAGE_PARAMS = [
   'governance.proposal.updateMarket.requiredParticipationLP',
   'governance.proposal.updateNetParam.requiredMajority',
   'governance.proposal.updateNetParam.requiredParticipation',
+  'governance.proposal.updateMarket.minProposerEquityLikeShare',
   'validators.vote.required',
 ];
 


### PR DESCRIPTION
# Related issues 🔗

Closes #3080

# Description ℹ️
`minimumProposerEquityLikeShare` is a percentage, but was being display as a number. Now it's being displayed as a percentage.

# Demo

<img width="946" alt="Screenshot 2023-03-10 at 15 20 13" src="https://user-images.githubusercontent.com/6678/224354367-76f8be99-dff1-4dba-88b4-de5d97b19ac0.png">
