### PR TITLE
fix(explorer,trading): asset details should show quantum in asset dps

### DIFF
--- a/libs/assets/src/lib/asset-details-table.tsx
+++ b/libs/assets/src/lib/asset-details-table.tsx
@@ -86,7 +86,7 @@ export const rows: Rows = [
     key: AssetDetail.QUANTUM,
     label: t('Quantum'),
     tooltip: t('The minimum economically meaningful amount of the asset'),
-    value: (asset) => asset.quantum,
+    value: (asset) => num(asset, asset.quantum),
   },
   {
     key: AssetDetail.STATUS,


### PR DESCRIPTION
# Related issues 🔗

Closes #2907

# Description ℹ️

The asset quantum is often '1', but '1' really means '1 increment of the smallest number of decimal places'. This PR
formats the Quantum in the asset details table with the decimal places.

# Demo 📺

