### PR TITLE
fix(explorer): neaten validators mobile view

### DIFF
--- a/apps/explorer/src/app/routes/validators/validators-page.tsx
+++ b/apps/explorer/src/app/routes/validators/validators-page.tsx
@@ -305,18 +305,22 @@ export const ValidatorsPage = () => {
                           </div>
                         </KeyValueTableRow>
                         {v.avatarUrl && (
-                        <KeyValueTableRow>
-                          <div>{t('Avatar')}</div>
-                          <div>
-                        <ExternalLink href={validatorPage} className="mx-auto">
-                          <img
-                            className="max-w-[75px] md:max-w-[200px] max-h-[80px]"
-                            src={v.avatarUrl}
-                            alt={validatorName}
-                          />
-                        </ExternalLink>
-                          </div>
-                      </KeyValueTableRow>)}
+                          <KeyValueTableRow>
+                            <div>{t('Avatar')}</div>
+                            <div>
+                              <ExternalLink
+                                href={validatorPage}
+                                className="mx-auto"
+                              >
+                                <img
+                                  className="max-w-[75px] md:max-w-[200px] max-h-[80px]"
+                                  src={v.avatarUrl}
+                                  alt={validatorName}
+                                />
+                              </ExternalLink>
+                            </div>
+                          </KeyValueTableRow>
+                        )}
                       </KeyValueTable>
                     </div>
                   </div>

--- a/apps/explorer/src/app/routes/validators/validators-page.tsx
+++ b/apps/explorer/src/app/routes/validators/validators-page.tsx
@@ -176,25 +176,14 @@ export const ValidatorsPage = () => {
               const validatorName =
                 v.name && v.name.length > 0 ? v.name : truncateMiddle(v.id);
               return (
-                <li className="mb-5" key={v.id}>
+                <li className="mb-5 relative" key={v.id}>
                   <div
                     data-testid="validator-tile"
                     validator-id={v.id}
-                    className="border border-vega-light-200 dark:border-vega-dark-200 rounded p-2 overflow-hidden relative flex gap-2 items-start justify-between"
+                    className="border border-vega-light-200 dark:border-vega-dark-200 rounded p-2 overflow-hidden"
                   >
-                    {v.avatarUrl && (
-                      <div className="w-20">
-                        <ExternalLink href={validatorPage}>
-                          <img
-                            className="w-full"
-                            src={v.avatarUrl}
-                            alt={validatorName}
-                          />
-                        </ExternalLink>
-                      </div>
-                    )}
                     <div className="w-full">
-                      <h2 className="font-alpha text-2xl">
+                      <h2 className="font-alpha text-2xl leading-[60px]">
                         <ExternalLink href={validatorPage}>
                           {validatorName}
                         </ExternalLink>
@@ -315,6 +304,19 @@ export const ValidatorsPage = () => {
                             </div>
                           </div>
                         </KeyValueTableRow>
+                        {v.avatarUrl && (
+                        <KeyValueTableRow>
+                          <div>{t('Avatar')}</div>
+                          <div>
+                        <ExternalLink href={validatorPage} className="mx-auto">
+                          <img
+                            className="max-w-[75px] md:max-w-[200px] max-h-[80px]"
+                            src={v.avatarUrl}
+                            alt={validatorName}
+                          />
+                        </ExternalLink>
+                          </div>
+                      </KeyValueTableRow>)}
                       </KeyValueTable>
                     </div>
                   </div>


### PR DESCRIPTION
# Related issues 🔗

Closes #3096

# Description ℹ️

The validators table view could be quite untidy for a few reasons:

- The old nav used to cause an overflow (fixed in #3069)
- Not all validators have set avatars, but there is always space for it
- On mobile, the avatars squish the interesting content

I tried a variety of approaches but in the end the one that looked best was putting the avatar in to the key value
table row at the bottom. If there is none set, the row doesn't appear. The size and width is limited

# Demo 📺

<img width="822" alt="Screenshot 2023-03-10 at 16 57 47" src="https://user-images.githubusercontent.com/6678/224377556-7feb8b4a-330b-458f-9925-a9f02631728a.png">

![Screen Shot 2023-03-10 at 16 58 48](https://user-images.githubusercontent.com/6678/224377579-9962ebf3-9491-4c91-8a79-f74502a1f6e5.png)

![Screen Shot 2023-03-10 at 16 58 43](https://user-images.githubusercontent.com/6678/224377591-2c7278d4-fea5-4dd3-843e-86626322ea90.png)
