### PR TITLE
fix(ui-toolkit): anchor button should be same size as button by default

### DIFF
--- a/libs/ui-toolkit/src/components/button/button.tsx
+++ b/libs/ui-toolkit/src/components/button/button.tsx
@@ -18,6 +18,9 @@ const md = 'px-10 py-2 text-base';
 const lg = 'px-14 py-4';
 const fillClasses = 'block w-full';
 const defaultClasses = [
+  'px-10 py-2',
+  'text-base',
+  'text-center',
   'border-neutral-500',
   'bg-transparent',
   'enabled:hover:bg-neutral-500/20 dark:enabled:hover:bg-neutral-500/40',

--- a/libs/ui-toolkit/src/components/button/button.tsx
+++ b/libs/ui-toolkit/src/components/button/button.tsx
@@ -11,16 +11,14 @@ import classnames from 'classnames';
 export type ButtonVariant = 'default' | 'primary' | 'secondary' | 'ternary';
 export type ButtonSize = 'lg' | 'md' | 'sm' | 'xs';
 
-const base = 'inline-block uppercase border rounded-md disabled:opacity-60';
+const base =
+  'inline-block uppercase border rounded-md disabled:opacity-60 text-base text-center';
 const xs = 'px-2 py-0 text-sm';
 const sm = 'px-2 py-1 text-sm';
 const md = 'px-10 py-2 text-base';
 const lg = 'px-14 py-4';
 const fillClasses = 'block w-full';
 const defaultClasses = [
-  'px-10 py-2',
-  'text-base',
-  'text-center',
   'border-neutral-500',
   'bg-transparent',
   'enabled:hover:bg-neutral-500/20 dark:enabled:hover:bg-neutral-500/40',
@@ -120,7 +118,7 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, AnchorButtonProps>(
   (
     {
       variant = 'default',
-      size = 'lg',
+      size = 'md',
       fill = false,
       icon,
       rightIcon,


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Anrchor button did not have text centered or the same spacing by default as a standard button. These should be consistent.