### PR TITLE
fix(governance): ensure validators tables sorting on develop

### DIFF
--- a/apps/governance/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
@@ -166,10 +166,7 @@ export const ConsensusValidatorsTable = ({
               avatarUrl,
               name,
             },
-            [ValidatorFields.STAKE]: formatNumber(
-              toBigNum(stakedTotal, decimals),
-              2
-            ),
+            [ValidatorFields.STAKE]: stakedTotal,
             [ValidatorFields.NORMALISED_VOTING_POWER]:
               getNormalisedVotingPower(votingPower),
             [ValidatorFields.UNNORMALISED_VOTING_POWER]:
@@ -198,10 +195,8 @@ export const ConsensusValidatorsTable = ({
               stakedTotal,
               totalStake
             ),
-            [ValidatorFields.PENDING_STAKE]: formatNumber(
-              toBigNum(pendingStake, decimals),
-              2
-            ),
+            [ValidatorFields.PENDING_STAKE]: pendingStake,
+            decimals,
           };
         }
       );
@@ -256,22 +251,18 @@ export const ConsensusValidatorsTable = ({
 
       return {
         ...acc,
-        [ValidatorFields.STAKE]: formatNumber(
-          toBigNum(accStake, decimals).plus(toBigNum(stake, decimals)),
-          2
-        ),
+        [ValidatorFields.STAKE]: toBigNum(accStake, decimals)
+          .plus(toBigNum(stake, decimals))
+          .toString(),
         [ValidatorFields.STAKE_SHARE]: formatNumberPercentage(
           new BigNumber(parseFloat(accStakeShare)).plus(
             new BigNumber(parseFloat(stakeShare))
           ),
           2
         ),
-        [ValidatorFields.PENDING_STAKE]: formatNumber(
-          toBigNum(accPendingStake, decimals).plus(
-            toBigNum(pendingStake, decimals)
-          ),
-          2
-        ),
+        [ValidatorFields.PENDING_STAKE]: toBigNum(accPendingStake, decimals)
+          .plus(toBigNum(pendingStake, decimals))
+          .toString(),
         [ValidatorFields.NORMALISED_VOTING_POWER]: formatNumberPercentage(
           new BigNumber(parseFloat(accNormalisedVotingPower)).plus(
             new BigNumber(parseFloat(normalisedVotingPower))
@@ -349,6 +340,8 @@ export const ConsensusValidatorsTable = ({
           field: ValidatorFields.PENDING_STAKE,
           headerName: t(ValidatorFields.PENDING_STAKE).toString(),
           headerTooltip: t('PendingStakeDescription').toString(),
+          valueFormatter: ({ value }) =>
+            formatNumber(toBigNum(value, decimals), 2),
           width: 110,
         },
       ],

--- a/apps/governance/src/routes/staking/home/validator-tables/shared.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/shared.tsx
@@ -12,6 +12,7 @@ import {
 } from '@vegaprotocol/ui-toolkit';
 import type { NodesFragmentFragment } from '../__generated___/Nodes';
 import type { PreviousEpochQuery } from '../../__generated___/PreviousEpoch';
+import { useAppState } from '../../../../contexts/app-state/app-state-context';
 
 export enum ValidatorFields {
   RANKING_INDEX = 'rankingIndex',
@@ -148,6 +149,11 @@ interface TotalStakeRendererProps {
 
 export const TotalStakeRenderer = ({ data }: TotalStakeRendererProps) => {
   const { t } = useTranslation();
+  const {
+    appState: { decimals },
+  } = useAppState();
+
+  const formattedStake = formatNumber(toBigNum(data.stake, decimals), 2);
 
   return (
     <Tooltip
@@ -160,12 +166,13 @@ export const TotalStakeRenderer = ({ data }: TotalStakeRendererProps) => {
             {t('stakedByDelegates')}: {data.stakedByDelegates.toString()}
           </div>
           <div data-testid="total-staked-tooltip">
-            {t('totalStake')}: <span className="font-bold">{data.stake}</span>
+            {t('totalStake')}:{' '}
+            <span className="font-bold">{formattedStake}</span>
           </div>
         </>
       }
     >
-      <span>{data.stake}</span>
+      <span>{formattedStake}</span>
     </Tooltip>
   );
 };

--- a/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
@@ -122,10 +122,7 @@ export const StandbyPendingValidatorsTable = ({
               avatarUrl,
               name,
             },
-            [ValidatorFields.STAKE]: formatNumber(
-              toBigNum(stakedTotal, decimals),
-              2
-            ),
+            [ValidatorFields.STAKE]: stakedTotal,
             [ValidatorFields.STAKE_NEEDED_FOR_PROMOTION]:
               individualStakeNeededForPromotion || null,
             [ValidatorFields.STAKE_NEEDED_FOR_PROMOTION_DESCRIPTION]:
@@ -154,10 +151,7 @@ export const StandbyPendingValidatorsTable = ({
               stakedTotal,
               totalStake
             ),
-            [ValidatorFields.PENDING_STAKE]: formatNumber(
-              toBigNum(pendingStake, decimals),
-              2
-            ),
+            [ValidatorFields.PENDING_STAKE]: pendingStake,
           };
         }
       );
@@ -222,6 +216,8 @@ export const StandbyPendingValidatorsTable = ({
           field: ValidatorFields.PENDING_STAKE,
           headerName: t(ValidatorFields.PENDING_STAKE).toString(),
           headerTooltip: t('PendingStakeDescription').toString(),
+          valueFormatter: ({ value }) =>
+            formatNumber(toBigNum(value, decimals), 2),
           width: 110,
         },
       ],


### PR DESCRIPTION
# Related issues 🔗

Closes #3175

# Description ℹ️

As per https://github.com/vegaprotocol/frontend-monorepo/pull/3170 (the version for the 'main' branch), this ensures correct sorting of stake values. Values are passed to AG grid in formats it is able to sort, and any further formatting required is done via the 'valueFormatter' (for fields not requiring custom tooltips) or 'cellRenderer' (for those that do)
