### PR TITLE
fix(trading): hide transfer button in view as mode

### DIFF
--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
@@ -145,7 +145,8 @@ export const VegaWalletConnectButton = () => {
     (store) => store.openVegaWalletDialog
   );
   const openTransferDialog = useTransferDialog((store) => store.open);
-  const { pubKey, pubKeys, selectPubKey, disconnect } = useVegaWallet();
+  const { pubKey, pubKeys, selectPubKey, disconnect, isReadOnly } =
+    useVegaWallet();
   const isConnected = pubKey !== null;
 
   const activeKey = useMemo(() => {
@@ -186,12 +187,14 @@ export const VegaWalletConnectButton = () => {
                   ))}
                 </DropdownMenuRadioGroup>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  data-testid="wallet-transfer"
-                  onClick={() => openTransferDialog(true)}
-                >
-                  {t('Transfer')}
-                </DropdownMenuItem>
+                {!isReadOnly && (
+                  <DropdownMenuItem
+                    data-testid="wallet-transfer"
+                    onClick={() => openTransferDialog(true)}
+                  >
+                    {t('Transfer')}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem data-testid="disconnect" onClick={disconnect}>
                   {t('Disconnect')}
                 </DropdownMenuItem>


### PR DESCRIPTION
# Related issues 🔗

Closes #3079 

# Description ℹ️

 Hide the transfer button in `view as` mode.

# Demo 📺

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/16125548/225005441-f4f73807-8fab-4aa2-a393-f3e6aac00171.png">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
