### PR TITLE
fix(governance): paginate rewards as well as delegations data

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
@@ -21,6 +21,12 @@ export const EpochIndividualRewards = () => {
             first: Number(delegationsPagination),
           }
         : undefined,
+      // we can use the same value for rewardsPagination as delegationsPagination
+      rewardsPagination: delegationsPagination
+        ? {
+            first: Number(delegationsPagination),
+          }
+        : undefined,
     },
     skip: !pubKey,
   });

--- a/apps/governance/src/routes/rewards/home/Rewards.graphql
+++ b/apps/governance/src/routes/rewards/home/Rewards.graphql
@@ -21,10 +21,10 @@ fragment DelegationFields on Delegation {
   epoch
 }
 
-query Rewards($partyId: ID!, $delegationsPagination: Pagination) {
+query Rewards($partyId: ID!, $delegationsPagination: Pagination, $rewardsPagination: Pagination) {
   party(id: $partyId) {
     id
-    rewardsConnection {
+    rewardsConnection(pagination: $rewardsPagination) {
       edges {
         node {
           ...RewardFields

--- a/apps/governance/src/routes/rewards/home/Rewards.graphql
+++ b/apps/governance/src/routes/rewards/home/Rewards.graphql
@@ -21,7 +21,11 @@ fragment DelegationFields on Delegation {
   epoch
 }
 
-query Rewards($partyId: ID!, $delegationsPagination: Pagination, $rewardsPagination: Pagination) {
+query Rewards(
+  $partyId: ID!
+  $delegationsPagination: Pagination
+  $rewardsPagination: Pagination
+) {
   party(id: $partyId) {
     id
     rewardsConnection(pagination: $rewardsPagination) {

--- a/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
+++ b/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
@@ -10,6 +10,7 @@ export type DelegationFieldsFragment = { __typename?: 'Delegation', amount: stri
 export type RewardsQueryVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
   delegationsPagination?: Types.InputMaybe<Types.Pagination>;
+  rewardsPagination?: Types.InputMaybe<Types.Pagination>;
 }>;
 
 
@@ -75,10 +76,10 @@ export const EpochFieldsFragmentDoc = gql`
 }
     `;
 export const RewardsDocument = gql`
-    query Rewards($partyId: ID!, $delegationsPagination: Pagination) {
+    query Rewards($partyId: ID!, $delegationsPagination: Pagination, $rewardsPagination: Pagination) {
   party(id: $partyId) {
     id
-    rewardsConnection {
+    rewardsConnection(pagination: $rewardsPagination) {
       edges {
         node {
           ...RewardFields
@@ -119,6 +120,7 @@ ${DelegationFieldsFragmentDoc}`;
  *   variables: {
  *      partyId: // value for 'partyId'
  *      delegationsPagination: // value for 'delegationsPagination'
+ *      rewardsPagination: // value for 'rewardsPagination'
  *   },
  * });
  */


### PR DESCRIPTION
# Related issues 🔗

Closes #3275

# Description ℹ️

We had previously been paginating delegations data, but testing exposed that we hadn't been paginating rewards data too. Now we do. We're setting an arbitrary pagination number of 50 for now, as there's a separate ticket to deal with pagination  properly (https://github.com/vegaprotocol/frontend-monorepo/issues/794).
