### PR TITLE
feat(deal-ticket): show total margin available for an order, and where it will come from

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from '@vegaprotocol/ui-toolkit';
+import classnames from 'classnames';
 import type { ReactNode } from 'react';
 import type { OrderSubmissionBody } from '@vegaprotocol/wallet';
 import type { Market, MarketData } from '@vegaprotocol/market-list';
@@ -11,9 +12,12 @@ interface DealTicketFeeDetailsProps {
   order: OrderSubmissionBody['orderSubmission'];
   market: Market;
   marketData: MarketData;
-  margin: string;
-  totalMargin: string;
-  balance: string;
+  currentInitialMargin?: string;
+  currentMaintenanceMargin?: string;
+  estimatedInitialMargin: string;
+  estimatedTotalInitialMargin: string;
+  marginAccountBalance: string;
+  generalAccountBalance: string;
 }
 
 export interface DealTicketFeeDetailProps {
@@ -45,23 +49,22 @@ export const DealTicketFeeDetails = ({
   order,
   market,
   marketData,
-  margin,
-  totalMargin,
-  balance,
+  ...args
 }: DealTicketFeeDetailsProps) => {
   const feeDetails = useFeeDealTicketDetails(order, market, marketData);
   const details = getFeeDetailsValues({
     ...feeDetails,
-    margin,
-    totalMargin,
-    balance,
+    ...args,
   });
   return (
     <div>
-      {details.map(({ label, value, labelDescription, symbol }) => (
+      {details.map(({ label, value, labelDescription, symbol, indent }) => (
         <div
           key={typeof label === 'string' ? label : 'value-dropdown'}
-          className="text-xs mt-2 flex justify-between items-center gap-4 flex-wrap"
+          className={classnames(
+            'text-xs mt-2 flex justify-between items-center gap-4 flex-wrap',
+            { 'ml-2': indent }
+          )}
         >
           <div>
             <Tooltip description={labelDescription}>

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -42,6 +42,9 @@ import {
 
 import { OrderTimeInForce, OrderType } from '@vegaprotocol/types';
 import { useOrderForm } from '../../hooks/use-order-form';
+import { useDataProvider } from '@vegaprotocol/react-helpers';
+
+import { marketMarginDataProvider } from '@vegaprotocol/positions';
 
 export interface DealTicketProps {
   market: Market;
@@ -100,6 +103,12 @@ export const DealTicket = ({
     );
 
   const { margin, totalMargin } = useInitialMargin(market.id, normalizedOrder);
+
+  const { data: currentMargins } = useDataProvider({
+    dataProvider: marketMarginDataProvider,
+    variables: { marketId: market.id, partyId: pubKey || '' },
+    skip: !pubKey,
+  });
 
   useEffect(() => {
     if (!pubKey) {
@@ -296,9 +305,12 @@ export const DealTicket = ({
           order={normalizedOrder}
           market={market}
           marketData={marketData}
-          margin={margin}
-          totalMargin={totalMargin}
-          balance={marginAccountBalance}
+          estimatedInitialMargin={margin}
+          estimatedTotalInitialMargin={totalMargin}
+          currentInitialMargin={currentMargins?.initialLevel}
+          currentMaintenanceMargin={currentMargins?.maintenanceLevel}
+          marginAccountBalance={marginAccountBalance}
+          generalAccountBalance={generalAccountBalance}
         />
       </form>
     </TinyScroll>

--- a/libs/deal-ticket/src/constants.ts
+++ b/libs/deal-ticket/src/constants.ts
@@ -10,12 +10,36 @@ export const EST_MARGIN_TOOLTIP_TEXT = (settlementAsset: string) =>
 export const EST_TOTAL_MARGIN_TOOLTIP_TEXT = t(
   'Estimated total margin that will cover open position, active orders and this order.'
 );
-export const MARGIN_ACCOUNT_TOOLTIP_TEXT = t('Margin account balance');
+export const MARGIN_ACCOUNT_TOOLTIP_TEXT = t('Margin account balance.');
 export const MARGIN_DIFF_TOOLTIP_TEXT = (settlementAsset: string) =>
   t(
     "The additional margin required for your new position (taking into account volume and open orders), compared to your current margin. Measured in the market's settlement asset (%s).",
     [settlementAsset]
   );
+export const DEDUCTION_FROM_COLLATERAL_TOOLTIP_TEXT = (
+  settlementAsset: string
+) =>
+  t(
+    'To cover the required margin, this amount will be drawn from your general (%s) account.',
+    [settlementAsset]
+  );
+
+export const TOTAL_MARGIN_AVAILABLE = (
+  generalAccountBalance: string,
+  marginAccountBalance: string,
+  marginMaintenance: string,
+  settlementAsset: string
+) =>
+  t(
+    'Total margin available = general %s balance (%s) + margin balance (%s) - maintenance level (%s).',
+    [
+      settlementAsset,
+      `${generalAccountBalance} ${settlementAsset}`,
+      `${marginAccountBalance} ${settlementAsset}`,
+      `${marginMaintenance} ${settlementAsset}`,
+    ]
+  );
+
 export const CONTRACTS_MARGIN_TOOLTIP_TEXT = t(
   'The number of contracts determines how many units of the futures contract to buy or sell. For example, this is similar to buying one share of a listed company. The value of 1 contract is equivalent to the price of the contract. For example, if the current price is $50, then one contract is worth $50.'
 );
@@ -40,7 +64,7 @@ export const EST_SLIPPAGE = t(
 );
 
 export const ERROR_SIZE_DECIMAL = t(
-  'The size field accepts up to X decimal places'
+  'The size field accepts up to X decimal places.'
 );
 
 export enum MarketModeValidationType {

--- a/libs/deal-ticket/src/hooks/use-initial-margin.ts
+++ b/libs/deal-ticket/src/hooks/use-initial-margin.ts
@@ -65,5 +65,11 @@ export const useInitialMargin = (
       sellMargin > buyMargin ? sellMargin.toString() : buyMargin.toString();
   }
 
-  return useMemo(() => ({ totalMargin, margin }), [totalMargin, margin]);
+  return useMemo(
+    () => ({
+      totalMargin,
+      margin,
+    }),
+    [totalMargin, margin]
+  );
 };

--- a/libs/positions/src/lib/positions-manager.tsx
+++ b/libs/positions/src/lib/positions-manager.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { AsyncRenderer } from '@vegaprotocol/ui-toolkit';
 import type { Position } from '../';
 import { usePositionsData, PositionsTable } from '../';
-import type { FilterChangedEvent } from 'ag-grid-community';
 import type { AgGridReact } from 'ag-grid-react';
 import * as Schema from '@vegaprotocol/types';
 import { useVegaTransactionStore } from '@vegaprotocol/wallet';
@@ -23,8 +22,8 @@ export const PositionsManager = ({
   noBottomPlaceholder,
 }: PositionsManagerProps) => {
   const gridRef = useRef<AgGridReact | null>(null);
-  const [dataCount, setDataCount] = useState(0);
   const { data, error, loading, reload } = usePositionsData(partyId, gridRef);
+  const [dataCount, setDataCount] = useState(data?.length ?? 0);
   const create = useVegaTransactionStore((store) => store.create);
   const onClose = ({
     marketId,
@@ -67,10 +66,7 @@ export const PositionsManager = ({
     setId,
     disabled: noBottomPlaceholder,
   });
-  useEffect(() => {
-    setDataCount(gridRef.current?.api?.getModel().getRowCount() ?? 0);
-  }, [data]);
-  const onFilterChanged = useCallback((event: FilterChangedEvent) => {
+  const updateRowCount = useCallback(() => {
     setDataCount(gridRef.current?.api?.getModel().getRowCount() ?? 0);
   }, []);
   return (
@@ -83,7 +79,8 @@ export const PositionsManager = ({
         suppressLoadingOverlay
         suppressNoRowsOverlay
         isReadOnly={isReadOnly}
-        onFilterChanged={onFilterChanged}
+        onFilterChanged={updateRowCount}
+        onRowDataUpdated={updateRowCount}
         {...bottomPlaceholderProps}
       />
       <div className="pointer-events-none absolute inset-0">


### PR DESCRIPTION
# Related issues 🔗

Closes #3215

# Description

<img width="159" alt="image" src="https://user-images.githubusercontent.com/1754247/228870188-7c8801d9-7e3a-459d-b4dd-3b28b93292eb.png">


Values calculated as follows:

Margin required = estimatedTotalInitialMargin - currentInitialMargin

Total margin available = generalAccountBalance + marginAccountBalance - currentMaintenanceMarginLevel

Deduction from collateral = estimatedTotalInitialMargin - marginAccountBalance
Deduction value is displayed as 0 if it is  lower than 0