### PR TITLE
build(explorer): update validator testnet be url

### DIFF
--- a/apps/explorer/.env.validator-testnet
+++ b/apps/explorer/.env.validator-testnet
@@ -9,5 +9,5 @@ NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/annou
 
 NX_VEGA_GOVERNANCE_URL=https://validator-testnet.governance.vega.xyz
 NX_TENDERMINT_URL=https://tm-be.validators-testnet.vega.rocks
-NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.rocks/
+NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.rocks/rest
 NX_TENDERMINT_WEBSOCKET_URL=wss://be.validators-testnet.vega.xyz/websocket


### PR DESCRIPTION
The environment file for validator testnet contains an old URL that no longer works. This updates it.

- Update block explorer api url

# Related issues 🔗

Closes #3356

Will require a merge to `releases/validator-testnet` to be complete