### PR TITLE
fix(trading): fix docs resources

### DIFF
--- a/apps/trading/components/navbar/navbar.tsx
+++ b/apps/trading/components/navbar/navbar.tsx
@@ -23,6 +23,7 @@ import {
 } from '@vegaprotocol/ui-toolkit';
 
 import { Links, Routes } from '../../pages/client-router';
+import { createDocsLinks } from '@vegaprotocol/utils';
 
 export const Navbar = ({
   theme = 'system',
@@ -37,6 +38,7 @@ export const Navbar = ({
   const tradingPath = marketId
     ? Links[Routes.MARKET](marketId)
     : Links[Routes.MARKET]();
+
   return (
     <Navigation
       appName="Console"
@@ -89,7 +91,9 @@ export const Navbar = ({
             <NavigationContent>
               <NavigationList>
                 <NavigationItem>
-                  <NavExternalLink href={VEGA_DOCS_URL}>
+                  <NavExternalLink
+                    href={createDocsLinks(VEGA_DOCS_URL).NEW_TO_VEGA}
+                  >
                     {t('Docs')}
                   </NavExternalLink>
                 </NavigationItem>

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -21,7 +21,6 @@ const EmptyLinks: DAppLinks = {
   [Networks.STAGNET3]: '',
   [Networks.TESTNET]: '',
   [Networks.MAINNET]: '',
-  [Networks.MIRROR]: '',
 };
 
 const ExplorerLinks = {

--- a/libs/utils/src/lib/links.ts
+++ b/libs/utils/src/lib/links.ts
@@ -3,6 +3,7 @@
  */
 
 export const createDocsLinks = (docsUrl: string) => ({
+  NEW_TO_VEGA: `${docsUrl}/concepts/new-to-vega`,
   AUCTION_TYPE_OPENING: `${docsUrl}/concepts/trading-on-vega/trading-modes#auction-type-opening`,
   AUCTION_TYPE_LIQUIDITY_MONITORING: `${docsUrl}/concepts/trading-on-vega/trading-modes#auction-type-liquidity-monitoring`,
   AUCTION_TYPE_PRICE_MONITORING: `${docsUrl}/concepts/trading-on-vega/trading-modes#auction-type-price-monitoring`,


### PR DESCRIPTION
# Related issues 🔗

Closes #3384 

# Description ℹ️

Fix docs resources in navbar.
Directs you to [docs](https://docs.vega.xyz/testnet/concepts/new-to-vega) depending on env.

# Demo 📺

![image](https://user-images.githubusercontent.com/16125548/230102609-211fc4d8-0b2f-4e4e-a5ab-45da338b9147.png)

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
