### PR TITLE
fix(trading): make light theme sell volume bar match candle color

### DIFF
--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -63,7 +63,7 @@ html [data-theme='light'] {
   --pennant-color-sell-stroke: theme('colors.vega.pink.400');
 
   --pennant-color-volume-buy: theme('colors.vega.green.400');
-  --pennant-color-volume-sell: theme('colors.vega.pink.500');
+  --pennant-color-volume-sell: theme('colors.vega.pink.400');
 
   /* depth chart */
   --pennant-color-depth-buy-fill: theme('colors.vega.green.400');


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Changes the sell volume bar color in light theme to match the candle

# Demo 📺
Before:

![Screenshot 2023-04-07 at 16 09 47](https://user-images.githubusercontent.com/6803987/230690865-65dce117-a2bf-4a7f-b476-a73acaec3549.jpg)

After:
![Screenshot 2023-04-07 at 16 13 24](https://user-images.githubusercontent.com/6803987/230690880-fcc1800d-77a4-422e-91d7-faf713dedc43.jpg)
