### PR TITLE
chore(trading): prevent node poll if query fails

### DIFF
--- a/libs/environment/src/components/node-switcher/row-data.spec.tsx
+++ b/libs/environment/src/components/node-switcher/row-data.spec.tsx
@@ -26,7 +26,7 @@ const statsQueryMock: MockedResponse<StatisticsQuery> = {
   result: {
     data: {
       statistics: {
-        blockHeight: '1234', // the actual value used in the component is the from the header store
+        blockHeight: '1234', // the actual value used in the component is the value from the header store
         vegaTime: new Date().toISOString(),
         chainId: 'test-chain-id',
       },

--- a/libs/environment/src/components/node-switcher/row-data.spec.tsx
+++ b/libs/environment/src/components/node-switcher/row-data.spec.tsx
@@ -319,7 +319,7 @@ describe('RowData', () => {
     });
 
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(POLL_INTERVAL);
     });
 
     // statsQueryMock2 should be rendered
@@ -329,7 +329,7 @@ describe('RowData', () => {
     });
 
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(POLL_INTERVAL);
     });
 
     // statsQueryMock3 should FAIL!
@@ -342,7 +342,7 @@ describe('RowData', () => {
     // rendered even though its successful, because the poll
     // should have been stopped
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(POLL_INTERVAL);
     });
 
     // should still render the result of statsQueryMock3


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Prevents polling in the node switcher if a stats query fails for a given node. This should help with the number of Sentry alerts
