### PR TITLE
fix(trading): fix order toast intent on amendments

### DIFF
--- a/apps/trading/lib/hooks/use-vega-transaction-toasts.spec.tsx
+++ b/apps/trading/lib/hooks/use-vega-transaction-toasts.spec.tsx
@@ -292,7 +292,7 @@ describe('getVegaTransactionContentIntent', () => {
       Intent.Success
     );
     expect(getVegaTransactionContentIntent(editOrder).intent).toBe(
-      Intent.Success
+      Intent.Primary
     );
     expect(getVegaTransactionContentIntent(cancelOrder).intent).toBe(
       Intent.Primary

--- a/apps/trading/lib/hooks/use-vega-transaction-toasts.tsx
+++ b/apps/trading/lib/hooks/use-vega-transaction-toasts.tsx
@@ -681,6 +681,9 @@ export const getVegaTransactionContentIntent = (tx: VegaStoredTxState) => {
 
   // Transaction can be successful but the order can be rejected by the network
   const intent =
-    (tx.order && getOrderToastIntent(tx.order.status)) || intentMap[tx.status];
+    (tx.order &&
+      !isOrderAmendmentTransaction(tx.body) &&
+      getOrderToastIntent(tx.order.status)) ||
+    intentMap[tx.status];
   return { intent, content };
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #3427 

# Description ℹ️

Bug being fixed: The toasts for order amendments were always green.



# Demo 📺

<img width="1679" alt="Screenshot 2023-04-13 at 15 09 26" src="https://user-images.githubusercontent.com/16125548/231754477-f4cbc5aa-f056-4b52-ab3c-e79a1b20e5b5.png">

# Technical 👨‍🔧

On order amendment the toast intent should be selected based on the transaction status. 
For order submission/cancellation the intent can be based on the tx status & order status.
