### PR TITLE
feat(governance): full width Governance and Explorer header

### DIFF
--- a/apps/explorer/src/app/routes/layout.tsx
+++ b/apps/explorer/src/app/routes/layout.tsx
@@ -38,14 +38,16 @@ const DialogsContainer = () => {
 export const Layout = () => {
   const isHome = Boolean(useMatch(Routes.HOME));
   const { ANNOUNCEMENTS_CONFIG_URL } = useEnvironment();
+  const fixedWidthClasses = 'w-full max-w-[1500px] mx-auto';
+
   return (
     <>
       <div
         className={classNames(
-          'max-w-[1500px] min-h-[100vh]',
+          'min-h-[100vh]',
           'mx-auto my-0',
           'grid grid-rows-[auto_1fr_auto] grid-cols-1',
-          'border-vega-light-200 dark:border-vega-dark-200 lg:border-l lg:border-r',
+          'border-vega-light-200 dark:border-vega-dark-200',
           'antialiased text-black dark:text-white',
           'overflow-hidden relative'
         )}
@@ -59,13 +61,13 @@ export const Layout = () => {
           )}
           <Header />
         </div>
-        <div>
+        <div className={fixedWidthClasses}>
           <main className="p-4">
             {!isHome && <BreadcrumbsContainer className="mb-4" />}
             <Outlet />
           </main>
         </div>
-        <div>
+        <div className={fixedWidthClasses}>
           <Footer />
         </div>
       </div>

--- a/apps/explorer/src/app/routes/layout.tsx
+++ b/apps/explorer/src/app/routes/layout.tsx
@@ -44,7 +44,7 @@ export const Layout = () => {
     <>
       <div
         className={classNames(
-          'min-h-screen'
+          'min-h-screen',
           'mx-auto my-0',
           'grid grid-rows-[auto_1fr_auto] grid-cols-1',
           'border-vega-light-200 dark:border-vega-dark-200',

--- a/apps/explorer/src/app/routes/layout.tsx
+++ b/apps/explorer/src/app/routes/layout.tsx
@@ -44,7 +44,7 @@ export const Layout = () => {
     <>
       <div
         className={classNames(
-          'min-h-[100vh]',
+          'min-h-screen'
           'mx-auto my-0',
           'grid grid-rows-[auto_1fr_auto] grid-cols-1',
           'border-vega-light-200 dark:border-vega-dark-200',

--- a/apps/governance/src/components/page-templates/app-layout.tsx
+++ b/apps/governance/src/components/page-templates/app-layout.tsx
@@ -1,15 +1,19 @@
 import classNames from 'classnames';
 import { useVegaWallet } from '@vegaprotocol/wallet';
 import type { ReactNode } from 'react';
+import { AnnouncementBanner } from '@vegaprotocol/announcements';
+import { Nav } from '../nav';
+import { Networks, useEnvironment } from '@vegaprotocol/environment';
+import React from 'react';
 
 interface AppLayoutProps {
   children: ReactNode;
 }
 export const AppLayout = ({ children }: AppLayoutProps) => {
+  const { VEGA_ENV, ANNOUNCEMENTS_CONFIG_URL } = useEnvironment();
   const { isReadOnly } = useVegaWallet();
   const AppLayoutClasses = classNames(
-    'app w-full max-w-[1500px] mx-auto grid min-h-full',
-    'border-neutral-700 lg:border-l lg:border-r',
+    'app w-full max-w-[1500px] mx-auto grid',
     'lg:text-body-large',
     {
       'grid-rows-[repeat(2,min-content)_1fr_min-content]': !isReadOnly,
@@ -17,5 +21,18 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
     }
   );
 
-  return <div className={AppLayoutClasses}>{children}</div>;
+  return (
+    <div className="min-h-full">
+      <div className="lg:text-body-large">
+        {ANNOUNCEMENTS_CONFIG_URL && (
+          <AnnouncementBanner
+            app="governance"
+            configUrl={ANNOUNCEMENTS_CONFIG_URL}
+          />
+        )}
+        <Nav theme={VEGA_ENV === Networks.TESTNET ? 'yellow' : 'dark'} />
+      </div>
+      <div className={AppLayoutClasses}>{children}</div>
+    </div>
+  );
 };

--- a/apps/governance/src/components/page-templates/template-sidebar.tsx
+++ b/apps/governance/src/components/page-templates/template-sidebar.tsx
@@ -1,10 +1,6 @@
-import { Networks, useEnvironment } from '@vegaprotocol/environment';
 import { ViewingAsBanner } from '@vegaprotocol/ui-toolkit';
-import { AnnouncementBanner } from '@vegaprotocol/announcements';
 import { useVegaWallet } from '@vegaprotocol/wallet';
 import React from 'react';
-
-import { Nav } from '../nav';
 
 export interface TemplateSidebarProps {
   children: React.ReactNode;
@@ -12,17 +8,9 @@ export interface TemplateSidebarProps {
 }
 
 export function TemplateSidebar({ children, sidebar }: TemplateSidebarProps) {
-  const { VEGA_ENV, ANNOUNCEMENTS_CONFIG_URL } = useEnvironment();
   const { isReadOnly, pubKey, disconnect } = useVegaWallet();
   return (
     <>
-      {ANNOUNCEMENTS_CONFIG_URL && (
-        <AnnouncementBanner
-          app="governance"
-          configUrl={ANNOUNCEMENTS_CONFIG_URL}
-        />
-      )}
-      <Nav theme={VEGA_ENV === Networks.TESTNET ? 'yellow' : 'dark'} />
       {isReadOnly ? (
         <ViewingAsBanner pubKey={pubKey} disconnect={disconnect} />
       ) : null}


### PR DESCRIPTION
# Related issues 🔗

Closes #3199

# Description ℹ️

Configures Governance and Explorer to make use of the full width nav and announcement banner components 

# Demo 📺

<img width="1693" alt="Screenshot 2023-04-13 at 15 28 03" src="https://user-images.githubusercontent.com/2410498/231792949-5fb73be4-0e28-4a31-84cc-bcfe6e9417c0.png">

<img width="3359" alt="Screenshot 2023-04-13 at 15 28 24" src="https://user-images.githubusercontent.com/2410498/231792901-5e56cf0f-4d2f-4c59-9702-1b2e4d712900.png">
