### PR TITLE
fix(wallet): fetch new keys without re-connecting the wallet

### DIFF
--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.spec.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.spec.tsx
@@ -23,26 +23,44 @@ const generateJsx = (context: VegaWalletContextShape) => {
   );
 };
 
-it('Not connected', () => {
-  render(generateJsx({ pubKey: null } as VegaWalletContextShape));
+describe('VegaWalletConnectButton', () => {
+  it('should fire dialog when not connected', () => {
+    render(generateJsx({ pubKey: null } as VegaWalletContextShape));
 
-  const button = screen.getByTestId('connect-vega-wallet');
-  expect(button).toHaveTextContent('Connect Vega wallet');
-  fireEvent.click(button);
-  expect(mockUpdateDialogOpen).toHaveBeenCalled();
-});
+    const button = screen.getByTestId('connect-vega-wallet');
+    expect(button).toHaveTextContent('Connect Vega wallet');
+    fireEvent.click(button);
+    expect(mockUpdateDialogOpen).toHaveBeenCalled();
+  });
 
-it('Connected', async () => {
-  const pubKey = { publicKey: '123456__123456', name: 'test' };
-  render(
-    generateJsx({
+  it('should retrieve keys when connected', async () => {
+    const pubKey = { publicKey: '123456__123456', name: 'test' };
+    const pubKey2 = { publicKey: '123456__123457', name: 'test2' };
+    render(
+      generateJsx({
+        pubKey: pubKey.publicKey,
+        pubKeys: [pubKey],
+        fetchPubKeys: () => Promise.resolve([pubKey, pubKey2]),
+      } as VegaWalletContextShape)
+    );
+
+    const button = screen.getByTestId('manage-vega-wallet');
+    expect(button).toHaveTextContent(truncateByChars(pubKey.publicKey));
+    userEvent.click(button);
+    expect(mockUpdateDialogOpen).not.toHaveBeenCalled();
+  });
+
+  it('should fetch keys when connected', async () => {
+    const pubKey = { publicKey: '123456__123456', name: 'test' };
+    const context = {
       pubKey: pubKey.publicKey,
       pubKeys: [pubKey],
-    } as VegaWalletContextShape)
-  );
+    } as VegaWalletContextShape;
+    render(generateJsx(context));
 
-  const button = screen.getByTestId('manage-vega-wallet');
-  expect(button).toHaveTextContent(truncateByChars(pubKey.publicKey));
-  userEvent.click(button);
-  expect(mockUpdateDialogOpen).not.toHaveBeenCalled();
+    const button = screen.getByTestId('manage-vega-wallet');
+    expect(button).toHaveTextContent(truncateByChars(pubKey.publicKey));
+    userEvent.click(button);
+    expect(mockUpdateDialogOpen).not.toHaveBeenCalled();
+  });
 });

--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
@@ -29,7 +29,7 @@ const MobileWalletButton = ({
   isConnected?: boolean;
   activeKey?: PubKey;
 }) => {
-  const { pubKeys, selectPubKey, disconnect } = useVegaWallet();
+  const { pubKeys, selectPubKey, disconnect, fetchPubKeys } = useVegaWallet();
   const openVegaWalletDialog = useVegaWalletDialogStore(
     (store) => store.openVegaWalletDialog
   );
@@ -46,9 +46,10 @@ const MobileWalletButton = ({
       openVegaWalletDialog();
       setDrawerOpen(false);
     } else {
+      fetchPubKeys();
       setDrawerOpen(!drawerOpen);
     }
-  }, [drawerOpen, isConnected, openVegaWalletDialog]);
+  }, [drawerOpen, fetchPubKeys, isConnected, openVegaWalletDialog]);
 
   const iconClass = drawerOpen
     ? 'hidden'
@@ -145,8 +146,14 @@ export const VegaWalletConnectButton = () => {
     (store) => store.openVegaWalletDialog
   );
   const openTransferDialog = useTransferDialog((store) => store.open);
-  const { pubKey, pubKeys, selectPubKey, disconnect, isReadOnly } =
-    useVegaWallet();
+  const {
+    pubKey,
+    pubKeys,
+    selectPubKey,
+    disconnect,
+    isReadOnly,
+    fetchPubKeys,
+  } = useVegaWallet();
   const isConnected = pubKey !== null;
 
   const activeKey = useMemo(() => {
@@ -162,7 +169,11 @@ export const VegaWalletConnectButton = () => {
             trigger={
               <DropdownMenuTrigger
                 data-testid="manage-vega-wallet"
-                onClick={() => setDropdownOpen((curr) => !curr)}
+                onClick={() => {
+                  const dropdownOpenState = !dropdownOpen;
+                  fetchPubKeys();
+                  setDropdownOpen(dropdownOpenState);
+                }}
               >
                 {activeKey && (
                   <span className="uppercase">{activeKey.name}</span>

--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.tsx
@@ -46,7 +46,9 @@ const MobileWalletButton = ({
       openVegaWalletDialog();
       setDrawerOpen(false);
     } else {
-      fetchPubKeys();
+      if (fetchPubKeys) {
+        fetchPubKeys();
+      }
       setDrawerOpen(!drawerOpen);
     }
   }, [drawerOpen, fetchPubKeys, isConnected, openVegaWalletDialog]);
@@ -170,7 +172,9 @@ export const VegaWalletConnectButton = () => {
               <DropdownMenuTrigger
                 data-testid="manage-vega-wallet"
                 onClick={() => {
-                  fetchPubKeys();
+                  if (fetchPubKeys) {
+                    fetchPubKeys();
+                  }
                   setDropdownOpen(!dropdownOpen);
                 }}
               >

--- a/libs/wallet/src/context.ts
+++ b/libs/wallet/src/context.ts
@@ -31,6 +31,9 @@ export interface VegaWalletContextShape {
     /** Transaction payload */
     transaction: Transaction
   ) => Promise<TransactionResponse | null>;
+
+  /** Fetch public keys */
+  fetchPubKeys: () => Promise<PubKey[] | null>;
 }
 
 export const VegaWalletContext = createContext<

--- a/libs/wallet/src/provider.spec.tsx
+++ b/libs/wallet/src/provider.spec.tsx
@@ -50,6 +50,7 @@ describe('VegaWalletProvider', () => {
       connect: expect.any(Function),
       disconnect: expect.any(Function),
       sendTx: expect.any(Function),
+      fetchPubKeys: expect.any(Function),
     });
 
     // Connect
@@ -77,14 +78,47 @@ describe('VegaWalletProvider', () => {
     expect(spyOnSend).toHaveBeenCalledWith(mockPubKeys[1].publicKey, {});
   });
 
+  it('should fetch new keypairs', async () => {
+    const { result } = setup();
+
+    // Default state
+    expect(result.current).toEqual({
+      pubKey: null,
+      pubKeys: null,
+      isReadOnly: false,
+      selectPubKey: expect.any(Function),
+      connect: expect.any(Function),
+      disconnect: expect.any(Function),
+      sendTx: expect.any(Function),
+      fetchPubKeys: expect.any(Function),
+    });
+
+    // Connect
+    await act(async () => {
+      result.current.connect(restConnector);
+      result.current.selectPubKey(mockPubKeys[0].publicKey);
+    });
+    expect(spyOnConnect).toHaveBeenCalled();
+    expect(result.current.pubKeys).toHaveLength(mockPubKeys.length);
+    expect(result.current.pubKey).toBe(mockPubKeys[0].publicKey);
+
+    // Fetch pub keys
+    mockPubKeys.push({ publicKey: '333', name: 'public key 3' });
+    await act(async () => {
+      result.current.fetchPubKeys();
+    });
+    expect(result.current.pubKeys).toHaveLength(mockPubKeys.length);
+  });
+
   it('persists selected pubkey and disconnects', async () => {
     const { result } = setup();
     expect(result.current.pubKey).toBe(null);
 
     await act(async () => {
       result.current.connect(restConnector);
+      result.current.selectPubKey(mockPubKeys[0].publicKey);
     });
-    expect(result.current.pubKey).toBe(mockPubKeys[1].publicKey);
+    expect(result.current.pubKey).toBe(mockPubKeys[0].publicKey);
 
     // Disconnect
     await act(async () => {

--- a/libs/wallet/src/provider.spec.tsx
+++ b/libs/wallet/src/provider.spec.tsx
@@ -50,7 +50,7 @@ describe('VegaWalletProvider', () => {
       connect: expect.any(Function),
       disconnect: expect.any(Function),
       sendTx: expect.any(Function),
-      fetchPubKeys: expect.any(Function),
+      fetchPubKeys: expect.any(Function || undefined),
     });
 
     // Connect
@@ -105,7 +105,7 @@ describe('VegaWalletProvider', () => {
     // Fetch pub keys
     mockPubKeys.push({ publicKey: '333', name: 'public key 3' });
     await act(async () => {
-      result.current.fetchPubKeys();
+      result.current.fetchPubKeys && result.current.fetchPubKeys();
     });
     expect(result.current.pubKeys).toHaveLength(mockPubKeys.length);
   });

--- a/libs/wallet/src/use-json-rpc-connect.ts
+++ b/libs/wallet/src/use-json-rpc-connect.ts
@@ -30,13 +30,13 @@ export const useJsonRpcConnect = (onConnect: () => void) => {
         // Check if wallet is configured for the same chain as the app
         setStatus(Status.GettingChainId);
 
-        // Dont throw in when cypress is running as trading app relies on
+        // Do not throw in when cypress is running as trading app relies on
         // mocks which result in a mismatch between chainId for app and
         // chainId for wallet
         if (!('Cypress' in window)) {
           const chainIdResult = await connector.getChainId();
           if (chainIdResult.chainID !== appChainId) {
-            // Throw wallet error for consitent error handling
+            // Throw wallet error for consistent error handling
             throw ClientErrors.WRONG_NETWORK;
           }
         }


### PR DESCRIPTION
# Related issues 🔗

Closes #3326 

# Description ℹ️

Fetch new keys without re-connecting the wallet.

# Demo 📺

After creating a new key: 
<img width="334" alt="Screenshot 2023-04-19 at 15 18 13" src="https://user-images.githubusercontent.com/16125548/233084906-84f5ddc5-2270-4905-a8a6-a838fcbfa6f8.png">

The console will pick it up as soon as users opens dropdown/drawer to select it.  
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/16125548/233084810-728a4ef8-5556-4d57-899d-3822c03f0b16.png">



# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
