### PR TITLE
chore: ugprade react-helpers to 0.2.0 and ui-toolkit to 0.11.0

### DIFF
--- a/libs/react-helpers/package.json
+++ b/libs/react-helpers/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/react-helpers",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/libs/ui-toolkit/package.json
+++ b/libs/ui-toolkit/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/ui-toolkit",
-  "version": "0.10.0"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
ui-toolkit@0.10.0 has an issue because it references react-helpers exports not present in 0.1.0 of that package. Bumping _both_ to a working pair.
