### PR TITLE
fix: use correct vote value string for casting vote

### DIFF
--- a/apps/token/src/routes/governance/components/vote-details/use-user-vote.tsx
+++ b/apps/token/src/routes/governance/components/vote-details/use-user-vote.tsx
@@ -95,12 +95,17 @@ export function useUserVote(
 
     setVoteState(VoteState.Requested);
 
+    const voteMapping = {
+      [VoteValue.Yes]: 'VALUE_YES',
+      [VoteValue.No]: 'VALUE_NO',
+    } as const;
+
     try {
       const variables = {
         pubKey: keypair.pub,
         propagate: true,
         voteSubmission: {
-          value: value,
+          value: voteMapping[value],
           proposalId,
         },
       };

--- a/libs/wallet/src/wallet-types.ts
+++ b/libs/wallet/src/wallet-types.ts
@@ -1,12 +1,6 @@
 import type { z } from 'zod';
 import type { GetKeysSchema, TransactionResponseSchema } from './connectors';
 import type { IterableElement } from 'type-fest';
-import type {
-  OrderTimeInForce,
-  OrderType,
-  Side,
-  VoteValue,
-} from '@vegaprotocol/types';
 
 interface BaseTransaction {
   pubKey: string;
@@ -28,12 +22,19 @@ export interface UndelegateSubmissionBody extends BaseTransaction {
   };
 }
 
+type OrderTimeInForce =
+  | 'TIME_IN_FORCE_FOK'
+  | 'TIME_IN_FORCE_GFA'
+  | 'TIME_IN_FORCE_GFN'
+  | 'TIME_IN_FORCE_GTC'
+  | 'TIME_IN_FORCE_GTT'
+  | 'TIME_IN_FORCE_IOC';
 export interface OrderSubmissionBody extends BaseTransaction {
   orderSubmission: {
     marketId: string;
     reference?: string;
-    type: OrderType;
-    side: Side;
+    type: 'TYPE_MARKET' | 'TYPE_LIMIT';
+    side: 'SIDE_BUY' | 'SIDE_SELL';
     timeInForce: OrderTimeInForce;
     size: string;
     price?: string;
@@ -62,7 +63,7 @@ export interface OrderAmendmentBody extends BaseTransaction {
 
 export interface VoteSubmissionBody extends BaseTransaction {
   voteSubmission: {
-    value: VoteValue;
+    value: 'VALUE_YES' | 'VALUE_NO';
     proposalId: string;
   };
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #3520 

# Description ℹ️

Fixes casting a vote being broken in the token app. 

# Technical 👨‍🔧

The wrong string was being passed in the transaction payload, not picked up on because the types were also incorrect
