### PR TITLE
fix(ui-toolkit): box size being wrong for multiline check boxes

### DIFF
--- a/libs/ui-toolkit/src/components/checkbox/checkbox.tsx
+++ b/libs/ui-toolkit/src/components/checkbox/checkbox.tsx
@@ -57,7 +57,7 @@ export const Checkbox = ({
       </CheckboxPrimitive.Root>
       <label
         htmlFor={name}
-        className={classNames('text-sm', {
+        className={classNames('text-sm flex-1', {
           'dark:text-neutral-400 text-neutral-600': disabled,
         })}
       >


### PR DESCRIPTION
# Related issues 🔗

Before:

<img width="339" alt="Screenshot 2023-04-24 at 12 24 20" src="https://user-images.githubusercontent.com/26136207/233982743-526a9abf-71f4-49bf-a080-c1a79df62ced.png">

After:

<img width="336" alt="Screenshot 2023-04-24 at 12 23 54" src="https://user-images.githubusercontent.com/26136207/233982696-0ea1704a-defe-4d70-98bc-a74fa2f999be.png">
