### PR TITLE
fix(governance): validator tables - user staking fixes

### DIFF
--- a/apps/governance/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/consensus-validators-table.tsx
@@ -211,7 +211,7 @@ export const ConsensusValidatorsTable = ({
               : undefined,
             [ValidatorFields.PENDING_USER_STAKE]: pendingUserStake,
             [ValidatorFields.USER_STAKE_SHARE]: userStakeShare
-              ? stakedTotalPercentage(userStakeShare)
+              ? formatNumberPercentage(new BigNumber(userStakeShare))
               : undefined,
           };
         }

--- a/apps/governance/src/routes/staking/home/validator-tables/shared.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/shared.tsx
@@ -59,9 +59,9 @@ export const addUserDataToValidator = (
       : undefined,
     [ValidatorFields.USER_STAKE_SHARE]:
       currentEpochUserStaking && Number(currentEpochUserStaking.amount) > 0
-        ? new BigNumber(currentEpochUserStaking.amount).dividedBy(
-            new BigNumber(currentUserStakeAvailable)
-          )
+        ? new BigNumber(currentEpochUserStaking.amount)
+            .dividedBy(new BigNumber(currentUserStakeAvailable))
+            .times(100)
         : undefined,
   };
 };

--- a/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
@@ -26,7 +26,11 @@ import {
 import type { AgGridReact } from 'ag-grid-react';
 import type { ColDef } from 'ag-grid-community';
 import type { ValidatorsTableProps } from './shared';
-import { formatNumber, toBigNum } from '@vegaprotocol/utils';
+import {
+  formatNumber,
+  formatNumberPercentage,
+  toBigNum,
+} from '@vegaprotocol/utils';
 
 interface StandbyPendingValidatorsTableProps extends ValidatorsTableProps {
   stakeNeededForPromotion: string | undefined;
@@ -163,7 +167,7 @@ export const StandbyPendingValidatorsTable = ({
               : undefined,
             [ValidatorFields.PENDING_USER_STAKE]: pendingUserStake,
             [ValidatorFields.USER_STAKE_SHARE]: userStakeShare
-              ? stakedTotalPercentage(userStakeShare)
+              ? formatNumberPercentage(new BigNumber(userStakeShare))
               : undefined,
           };
         }


### PR DESCRIPTION
# Related issues 🔗

Closes #3532 
Closes #3286

# Description ℹ️

When originally built, 'my stake' data for the validator tables made use of a version of the staking query that didn't require delegations pagination. When the query was changed, this query didn't get updated.

Also fixes the display of the user stake share percentage
