### PR TITLE
fix(explorer): fix asset links and deterministic order details

### DIFF
--- a/apps/explorer/src/app/components/links/asset-link/asset-link.tsx
+++ b/apps/explorer/src/app/components/links/asset-link/asset-link.tsx
@@ -43,7 +43,7 @@ export const AssetLink = ({
         if (asDialog) {
           open(assetId, e.target as HTMLElement);
         } else {
-          navigate(`${Routes.ASSETS}/${asset?.id}`);
+          navigate(`/${Routes.ASSETS}/${asset?.id}`);
         }
       }}
       {...props}

--- a/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
@@ -9,7 +9,7 @@ import SizeInMarket from '../size-in-market/size-in-market';
 export interface DeterministicOrderDetailsProps {
   id: string;
   // Version to fetch, with 0 being 'latest' and 1 being 'first'. Defaults to 0
-  version?: number;
+  version?: number | null;
 }
 
 export const wrapperClasses =
@@ -28,7 +28,7 @@ export const wrapperClasses =
  */
 const DeterministicOrderDetails = ({
   id,
-  version = 0,
+  version = null,
 }: DeterministicOrderDetailsProps) => {
   const { data, error } = useExplorerDeterministicOrderQuery({
     variables: { orderId: id, version },

--- a/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
+++ b/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
@@ -71,7 +71,7 @@ export const PartyAccounts = ({ accounts }: PartyAccountsProps) => {
                 />
               </td>
               <td className="text-md">
-                <AssetLink assetId={account.asset.id} />
+                <AssetLink assetId={account.asset.id} asDialog={true} />
               </td>
             </TableRow>
           );


### PR DESCRIPTION
- fix(explorer): asset link component could render incorrect links
- fix(explorer): pass null instead of 0 to get latest order version

# Related issues 🔗

Closes #3566.

# Description ℹ️

Fixes two minor bugs - one where the asset link on the party page was incorrect, and one where the order component was
using an API parameter that became unsupported in the last release.

