### PR TITLE
feat(governance): eth chain should not inhibit usage

### DIFF
--- a/apps/governance/src/components/disconnected-notice/disconnected-notice.spec.tsx
+++ b/apps/governance/src/components/disconnected-notice/disconnected-notice.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { DisconnectedNotice } from './disconnected-notice';
+
+describe('DisconnectedNotice', () => {
+  it('renders Notification when isDisconnected is true and correctNetworkChainId is valid', () => {
+    render(
+      <DisconnectedNotice isDisconnected={true} correctNetworkChainId={'1'} />
+    );
+    const disconnectedNotice = screen.getByTestId('disconnected-notice');
+    expect(disconnectedNotice).toBeInTheDocument();
+  });
+
+  it("doesn't render Notification when isDisconnected is false", () => {
+    render(
+      <DisconnectedNotice isDisconnected={false} correctNetworkChainId={'1'} />
+    );
+    const disconnectedNotice = screen.queryByTestId('disconnected-notice');
+    expect(disconnectedNotice).not.toBeInTheDocument();
+  });
+
+  it("doesn't render Notification when correctNetworkChainId is undefined", () => {
+    render(
+      <DisconnectedNotice
+        isDisconnected={true}
+        correctNetworkChainId={undefined}
+      />
+    );
+    const disconnectedNotice = screen.queryByTestId('disconnected-notice');
+    expect(disconnectedNotice).not.toBeInTheDocument();
+  });
+
+  it("doesn't render Notification when correctNetworkChainId is null", () => {
+    render(
+      <DisconnectedNotice isDisconnected={true} correctNetworkChainId={null} />
+    );
+    const disconnectedNotice = screen.queryByTestId('disconnected-notice');
+    expect(disconnectedNotice).not.toBeInTheDocument();
+  });
+});

--- a/apps/governance/src/components/disconnected-notice/disconnected-notice.tsx
+++ b/apps/governance/src/components/disconnected-notice/disconnected-notice.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+import { Intent, Notification } from '@vegaprotocol/ui-toolkit';
+
+interface DisconnectedNoticeProps {
+  isDisconnected: boolean;
+  correctNetworkChainId?: string | null;
+}
+
+export const DisconnectedNotice = ({
+  isDisconnected,
+  correctNetworkChainId,
+}: DisconnectedNoticeProps) => {
+  const { t } = useTranslation();
+
+  if (
+    !isDisconnected ||
+    correctNetworkChainId === undefined ||
+    correctNetworkChainId === null
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="col-span-full" data-testid="disconnected-notice">
+      <Notification
+        message={t('disconnectedNotice', {
+          correctNetwork: correctNetworkChainId,
+        })}
+        intent={Intent.Danger}
+      />
+    </div>
+  );
+};

--- a/apps/governance/src/components/disconnected-notice/index.tsx
+++ b/apps/governance/src/components/disconnected-notice/index.tsx
@@ -1,0 +1,1 @@
+export * from './disconnected-notice';

--- a/apps/governance/src/components/eth-wallet/eth-wallet.tsx
+++ b/apps/governance/src/components/eth-wallet/eth-wallet.tsx
@@ -2,7 +2,7 @@ import { useWeb3React } from '@web3-react/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Button } from '@vegaprotocol/ui-toolkit';
+import { Button, Notification, Intent } from '@vegaprotocol/ui-toolkit';
 
 import {
   AppStateActionType,
@@ -26,7 +26,8 @@ import {
 import { Loader } from '@vegaprotocol/ui-toolkit';
 import colors from 'tailwindcss/colors';
 import { useBalances } from '../../lib/balances/balances-store';
-import { useWeb3Disconnect } from '@vegaprotocol/web3';
+import { useEthereumConfig, useWeb3Disconnect } from '@vegaprotocol/web3';
+import { getChainName } from '@vegaprotocol/web3';
 
 const removeLeadingAddressSymbol = (key: string) => {
   if (key && key.length > 2 && key.slice(0, 2) === '0x') {
@@ -182,16 +183,27 @@ const ConnectedKey = () => {
 
 export const EthWallet = () => {
   const { t } = useTranslation();
-  const { appDispatch } = useAppState();
+  const { appDispatch, appState } = useAppState();
   const { account, connector } = useWeb3React();
   const pendingTxs = usePendingTransactions();
   const disconnect = useWeb3Disconnect(connector);
+  const { config } = useEthereumConfig();
 
   return (
     <WalletCard>
       <section data-testid="ethereum-wallet">
         <WalletCardHeader>
           <h1 className="m-0 uppercase">{t('ethereumKey')}</h1>
+          {appState.disconnectNotice && (
+            <div className="col-span-full">
+              <Notification
+                message={t('disconnectedNotice', {
+                  correctNetwork: getChainName(Number(config?.chain_id)),
+                })}
+                intent={Intent.Danger}
+              />
+            </div>
+          )}
           {account && (
             <div className="place-self-end font-mono">
               <div

--- a/apps/governance/src/components/eth-wallet/eth-wallet.tsx
+++ b/apps/governance/src/components/eth-wallet/eth-wallet.tsx
@@ -2,7 +2,8 @@ import { useWeb3React } from '@web3-react/core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Button, Notification, Intent } from '@vegaprotocol/ui-toolkit';
+import { Button } from '@vegaprotocol/ui-toolkit';
+import { DisconnectedNotice } from '../disconnected-notice';
 
 import {
   AppStateActionType,
@@ -194,16 +195,10 @@ export const EthWallet = () => {
       <section data-testid="ethereum-wallet">
         <WalletCardHeader>
           <h1 className="m-0 uppercase">{t('ethereumKey')}</h1>
-          {appState.disconnectNotice && (
-            <div className="col-span-full">
-              <Notification
-                message={t('disconnectedNotice', {
-                  correctNetwork: getChainName(Number(config?.chain_id)),
-                })}
-                intent={Intent.Danger}
-              />
-            </div>
-          )}
+          <DisconnectedNotice
+            isDisconnected={appState.disconnectNotice}
+            correctNetworkChainId={getChainName(Number(config?.chain_id))}
+          />
           {account && (
             <div className="place-self-end font-mono">
               <div

--- a/apps/governance/src/components/web3-connector/web3-connector.tsx
+++ b/apps/governance/src/components/web3-connector/web3-connector.tsx
@@ -88,10 +88,8 @@ export const Web3Content = ({ children, appChainId }: Web3ContentProps) => {
         if (previousChainId !== undefined && !appState.disconnectNotice) {
           showDisconnectNotice(true);
         }
-      } else {
-        if (appState.disconnectNotice) {
-          showDisconnectNotice(false);
-        }
+      } else if (appState.disconnectNotice) {
+        showDisconnectNotice(false);
       }
     }
   }, [

--- a/apps/governance/src/contexts/app-state/app-state-context.ts
+++ b/apps/governance/src/contexts/app-state/app-state-context.ts
@@ -43,6 +43,11 @@ export interface AppState {
    * Message to display in a banner at the top of the screen, currently always shown as a warning/error
    */
   bannerMessage: string;
+  /**
+   * Displays a notice to the user that they have been disconnected because they've changed their
+   * ethereum network to an incompatible one.
+   */
+  disconnectNotice: boolean;
 }
 
 export enum AppStateActionType {
@@ -58,6 +63,7 @@ export enum AppStateActionType {
   SET_ASSOCIATION_BREAKDOWN,
   SET_TRANSACTION_OVERLAY,
   SET_BANNER_MESSAGE,
+  SET_DISCONNECT_NOTICE,
 }
 
 export type AppStateAction =
@@ -90,6 +96,10 @@ export type AppStateAction =
   | {
       type: AppStateActionType.SET_BANNER_MESSAGE;
       message: string;
+    }
+  | {
+      type: AppStateActionType.SET_DISCONNECT_NOTICE;
+      isVisible: boolean;
     };
 
 type AppStateContextShape = {

--- a/apps/governance/src/contexts/app-state/app-state-provider.tsx
+++ b/apps/governance/src/contexts/app-state/app-state-provider.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { BigNumber } from '../../lib/bignumber';
-import { AppStateActionType, AppStateContext } from './app-state-context';
 import type { AppState, AppStateAction } from './app-state-context';
+import { AppStateActionType, AppStateContext } from './app-state-context';
 
 interface AppStateProviderProps {
   children: React.ReactNode;
@@ -19,6 +19,7 @@ const initialAppState: AppState = {
   ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
+  disconnectNotice: false,
 };
 
 function appStateReducer(state: AppState, action: AppStateAction): AppState {
@@ -66,6 +67,12 @@ function appStateReducer(state: AppState, action: AppStateAction): AppState {
       return {
         ...state,
         bannerMessage: action.message,
+      };
+    }
+    case AppStateActionType.SET_DISCONNECT_NOTICE: {
+      return {
+        ...state,
+        disconnectNotice: action.isVisible,
       };
     }
   }

--- a/apps/governance/src/i18n/translations/dev.json
+++ b/apps/governance/src/i18n/translations/dev.json
@@ -790,5 +790,6 @@
   "approval (% validator voting power)": "approval (% validator voting power)",
   "67% voting power required": "67% voting power required",
   "Token": "Token",
-  "associateVegaNow": "Associate $VEGA now"
+  "associateVegaNow": "Associate $VEGA now",
+  "disconnectedNotice": "You have been disconnected. Connect your ETH wallet to the {{correctNetwork}} network to use this app."
 }

--- a/apps/governance/src/routes/proposals/components/list-asset/list-asset.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/list-asset/list-asset.spec.tsx
@@ -56,6 +56,7 @@ const mockAppState: AppState = {
   ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
+  disconnectNotice: false,
 };
 
 jest.mock('../../../contexts/app-state/app-state-context', () => ({

--- a/apps/governance/src/routes/proposals/hooks/use-vote-information.spec.ts
+++ b/apps/governance/src/routes/proposals/hooks/use-vote-information.spec.ts
@@ -19,6 +19,7 @@ const mockAppState: AppState = {
   ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
+  disconnectNotice: false,
 };
 
 jest.mock('../../../contexts/app-state/app-state-context', () => ({


### PR DESCRIPTION
# Related issues 🔗

Closes #2996

# Description ℹ️

If a user connects their eth wallet to an unsupported network, they are disconnected automatically, and a notice is displayed in the eth wallet area of the sidebar, but they are otherwise not inhibited in their use of the app. If they wish to initiate a transaction, they can reconnect their wallet, which should automatically connect them to the correct network.

# Demo 📺

<img width="509" alt="Screenshot 2023-04-28 at 17 31 50" src="https://user-images.githubusercontent.com/2410498/235205168-12a3988f-ebe9-4b61-968c-9ea39af14929.png">
