### PR TITLE
feat(governance): add time zone abbreviation data to proposal form - mainnet

### DIFF
--- a/apps/token/src/lib/date-formats.ts
+++ b/apps/token/src/lib/date-formats.ts
@@ -1,2 +1,17 @@
+import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
+
 export const DATE_FORMAT_DETAILED = 'dd MMMM yyyy HH:mm';
 export const DATE_FORMAT_LONG = 'dd MMM yyyy';
+
+/** Format a user's local date and time with the time zone abbreviation */
+export const formatDateWithLocalTimezone = (
+  date: Date,
+  formatStr = 'dd MMMM yyyy HH:mm (z)'
+) => {
+  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localDatetime = utcToZonedTime(date, userTimeZone);
+
+  return tzFormat(localDatetime, formatStr, {
+    timeZone: userTimeZone,
+  });
+};

--- a/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
+++ b/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
@@ -2,7 +2,10 @@ import { format, isFuture } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
 import { KeyValueTable, KeyValueTableRow } from '@vegaprotocol/ui-toolkit';
-import { DATE_FORMAT_DETAILED } from '../../../../lib/date-formats';
+import {
+  DATE_FORMAT_DETAILED,
+  formatDateWithLocalTimezone,
+} from '../../../../lib/date-formats';
 import type { Proposals_proposals } from '../../proposals/__generated__/Proposals';
 import { CurrentProposalState } from '../current-proposal-state';
 
@@ -29,13 +32,13 @@ export const ProposalChangeTable = ({ proposal }: ProposalChangeTableProps) => {
         {isFuture(new Date(terms.closingDatetime))
           ? t('closesOn')
           : t('closedOn')}
-        {format(new Date(terms.closingDatetime), DATE_FORMAT_DETAILED)}
+        {formatDateWithLocalTimezone(new Date(terms.closingDatetime))}
       </KeyValueTableRow>
       <KeyValueTableRow>
         {isFuture(new Date(terms.enactmentDatetime || 0))
           ? t('proposedEnactment')
           : t('enactedOn')}
-        {format(new Date(terms.enactmentDatetime || 0), DATE_FORMAT_DETAILED)}
+        {formatDateWithLocalTimezone(new Date(terms.enactmentDatetime || 0))}
       </KeyValueTableRow>
       <KeyValueTableRow>
         {t('proposedBy')}
@@ -43,7 +46,7 @@ export const ProposalChangeTable = ({ proposal }: ProposalChangeTableProps) => {
       </KeyValueTableRow>
       <KeyValueTableRow>
         {t('proposedOn')}
-        {format(new Date(proposal.datetime), DATE_FORMAT_DETAILED)}
+        {formatDateWithLocalTimezone(new Date(proposal.datetime))}
       </KeyValueTableRow>
       {proposal.rejectionReason ? (
         <KeyValueTableRow>

--- a/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
+++ b/apps/token/src/routes/governance/components/proposal-change-table/proposal-change-table.tsx
@@ -1,9 +1,8 @@
-import { format, isFuture } from 'date-fns';
+import { isFuture } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
 import { KeyValueTable, KeyValueTableRow } from '@vegaprotocol/ui-toolkit';
 import {
-  DATE_FORMAT_DETAILED,
   formatDateWithLocalTimezone,
 } from '../../../../lib/date-formats';
 import type { Proposals_proposals } from '../../proposals/__generated__/Proposals';

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "classnames": "^2.3.1",
     "core-js": "^3.6.5",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^2.0.0",
     "duration-js": "^4.0.0",
     "env-cmd": "^10.1.0",
     "ethers": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10909,6 +10909,11 @@ dataloader@2.1.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
   integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
 
+date-fns-tz@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
# Related issues 🔗

Closes #3574

Before:
<img width="873" alt="Screenshot 2023-05-02 at 16 24 09" src="https://user-images.githubusercontent.com/2410498/235712206-d6be73e7-e80b-43d3-969c-86a2b9618a20.png">

After (notice the BST beside datetime):
<img width="878" alt="Screenshot 2023-05-02 at 16 23 53" src="https://user-images.githubusercontent.com/2410498/235712280-891c6ae2-0765-4edf-83c4-59ec0753cf2c.png">

