### PR TITLE
chore(trading): make limit default order type

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
@@ -20,8 +20,8 @@ interface TypeSelectorProps {
 }
 
 const toggles = [
-  { label: t('Market'), value: Schema.OrderType.TYPE_MARKET },
   { label: t('Limit'), value: Schema.OrderType.TYPE_LIMIT },
+  { label: t('Market'), value: Schema.OrderType.TYPE_MARKET },
 ];
 
 export const TypeSelector = ({

--- a/libs/orders/src/lib/order-hooks/use-order-store.ts
+++ b/libs/orders/src/lib/order-hooks/use-order-store.ts
@@ -109,9 +109,9 @@ export const useOrder = (marketId: string) => {
 
 export const getDefaultOrder = (marketId: string): OrderObj => ({
   marketId,
-  type: OrderType.TYPE_MARKET,
+  type: OrderType.TYPE_LIMIT,
   side: Side.SIDE_BUY,
-  timeInForce: OrderTimeInForce.TIME_IN_FORCE_IOC,
+  timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,
   size: '0',
   price: '0',
   expiresAt: undefined,


### PR DESCRIPTION
# Related issues 🔗

Closes #3586 

# Description ℹ️

* swapped order type toggle
* made "Limit" default (with GTC)

# Demo 📺

![image](https://user-images.githubusercontent.com/1980305/236415128-c4e91465-0499-4202-822f-2828326e45a0.png)
