### PR TITLE
fix(explorer): set explorer url env var in explorer

### DIFF
--- a/apps/explorer/.env.capsule
+++ b/apps/explorer/.env.capsule
@@ -4,6 +4,7 @@ NX_TENDERMINT_WEBSOCKET_URL=wss://localhost:26617/websocket
 NX_VEGA_ENV=CUSTOM
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/test/announcements.json
+NX_VEGA_EXPLORER_URL=/
 
 # App flags
 NX_EXPLORER_TXS_LIST=0

--- a/apps/explorer/.env.devnet
+++ b/apps/explorer/.env.devnet
@@ -9,3 +9,4 @@ NX_VEGA_GOVERNANCE_URL=https://dev.token.vega.xyz
 NX_VEGA_URL=https://api.devnet1.vega.xyz/graphql
 NX_VEGA_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/devnet1/vegawallet-devnet1.toml
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.json
+NX_VEGA_EXPLORER_URL=/

--- a/apps/explorer/.env.mainnet
+++ b/apps/explorer/.env.mainnet
@@ -7,3 +7,4 @@ NX_BLOCK_EXPLORER=https://be.explorer.vega.xyz/rest/
 NX_ETHERSCAN_URL=https://etherscan.io
 NX_VEGA_GOVERNANCE_URL=https://token.vega.xyz
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/mainnet/announcements.json
+NX_VEGA_EXPLORER_URL=https://explorer.vega.xyz/

--- a/apps/explorer/.env.testnet
+++ b/apps/explorer/.env.testnet
@@ -9,3 +9,4 @@ NX_HOSTED_WALLET_URL=https://wallet.testnet.vega.xyz
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_VEGA_GOVERNANCE_URL=https://token.fairground.wtf
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.json
+NX_VEGA_EXPLORER_URL=https://explorer.fairground.wtf

--- a/apps/explorer/.env.validator-testnet
+++ b/apps/explorer/.env.validator-testnet
@@ -11,3 +11,4 @@ NX_VEGA_GOVERNANCE_URL=https://validator-testnet.governance.vega.xyz
 NX_TENDERMINT_URL=https://tm-be.validators-testnet.vega.rocks
 NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.rocks/rest
 NX_TENDERMINT_WEBSOCKET_URL=wss://be.validators-testnet.vega.xyz/websocket
+NX_VEGA_EXPLORER_URL=https://validator-testnet.explorer.vega.xyz/

--- a/apps/explorer/.env.vegacapsule
+++ b/apps/explorer/.env.vegacapsule
@@ -5,3 +5,4 @@ NX_VEGA_ENV=CUSTOM
 NX_BLOCK_EXPLORER=
 NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/test/announcements.json
+NX_VEGA_EXPLORER_URL=/


### PR DESCRIPTION
# Related issues 🔗

Closes #3620

# Description ℹ️

When Explorer got the Market Info panels from Trading, we neglected to set the environment variable that tells the component
where there block explorer for the current network is. For most instances, in explorer, this can be /. This PR sets a
few more explicitly.
