### PR TITLE
chore(utils): remove ethers deps from ui-toolkit

### DIFF
--- a/apps/governance/src/hooks/use-get-user-balances.ts
+++ b/apps/governance/src/hooks/use-get-user-balances.ts
@@ -22,9 +22,9 @@ export const useGetUserBalances = (account: string | undefined) => {
       ]);
 
       const balance = toBigNum(b, decimals);
-      const walletBalance = toBigNum(w, decimals);
+      const walletBalance = toBigNum(w.toString(), decimals);
       const lien = toBigNum(stats.lien, decimals);
-      const allowance = toBigNum(a, decimals);
+      const allowance = toBigNum(a.toString(), decimals);
 
       return {
         balanceFormatted: balance,

--- a/apps/governance/src/hooks/use-get-user-balances.ts
+++ b/apps/governance/src/hooks/use-get-user-balances.ts
@@ -21,9 +21,9 @@ export const useGetUserBalances = (account: string | undefined) => {
         token.allowance(account, config.staking_bridge_contract.address),
       ]);
 
-      const balance = toBigNum(b, decimals);
+      const balance = toBigNum(b.toString(), decimals);
       const walletBalance = toBigNum(w.toString(), decimals);
-      const lien = toBigNum(stats.lien, decimals);
+      const lien = toBigNum(stats.lien.toString(), decimals);
       const allowance = toBigNum(a.toString(), decimals);
 
       return {

--- a/apps/governance/src/hooks/use-refresh-associated-balances.ts
+++ b/apps/governance/src/hooks/use-refresh-associated-balances.ts
@@ -21,8 +21,14 @@ export function useRefreshAssociatedBalances() {
         ]);
 
       updateBalances({
-        walletAssociatedBalance: toBigNum(walletAssociatedBalance, decimals),
-        vestingAssociatedBalance: toBigNum(vestingAssociatedBalance, decimals),
+        walletAssociatedBalance: toBigNum(
+          walletAssociatedBalance.toString(),
+          decimals
+        ),
+        vestingAssociatedBalance: toBigNum(
+          vestingAssociatedBalance.toString(),
+          decimals
+        ),
       });
     },
     [staking, vesting, updateBalances, decimals]

--- a/apps/governance/src/hooks/use-refresh-balances.ts
+++ b/apps/governance/src/hooks/use-refresh-balances.ts
@@ -32,9 +32,9 @@ export const useRefreshBalances = (address: string) => {
         ]);
 
       const balance = toBigNum(b, decimals);
-      const walletBalance = toBigNum(w, decimals);
+      const walletBalance = toBigNum(w.toString(), decimals);
       const lien = toBigNum(stats.lien, decimals);
-      const allowance = toBigNum(a, decimals);
+      const allowance = toBigNum(a.toString(), decimals);
       const walletAssociatedBalance = toBigNum(walletStakeBalance, decimals);
       const vestingAssociatedBalance = toBigNum(vestingStakeBalance, decimals);
 

--- a/apps/governance/src/hooks/use-refresh-balances.ts
+++ b/apps/governance/src/hooks/use-refresh-balances.ts
@@ -31,12 +31,18 @@ export const useRefreshBalances = (address: string) => {
           pubKey ? vesting.stake_balance(address, pubKey) : null,
         ]);
 
-      const balance = toBigNum(b, decimals);
+      const balance = toBigNum(b.toString(), decimals);
       const walletBalance = toBigNum(w.toString(), decimals);
-      const lien = toBigNum(stats.lien, decimals);
+      const lien = toBigNum(stats.lien.toString(), decimals);
       const allowance = toBigNum(a.toString(), decimals);
-      const walletAssociatedBalance = toBigNum(walletStakeBalance, decimals);
-      const vestingAssociatedBalance = toBigNum(vestingStakeBalance, decimals);
+      const walletAssociatedBalance = toBigNum(
+        walletStakeBalance ? walletStakeBalance.toString() : 0,
+        decimals
+      );
+      const vestingAssociatedBalance = toBigNum(
+        vestingStakeBalance ? vestingStakeBalance.toString() : 0,
+        decimals
+      );
 
       updateBalances({
         balanceFormatted: balance,

--- a/apps/governance/src/routes/redemption/hooks.ts
+++ b/apps/governance/src/routes/redemption/hooks.ts
@@ -34,8 +34,9 @@ export const useUserTrancheBalances = (address: string | undefined) => {
         vesting.get_vested_for_tranche(address, tId),
       ]);
 
-      const total = toBigNum(t, decimals);
-      const vested = toBigNum(v, decimals);
+      // Convert t and v EthersBigNumbers to regular BigNumbers
+      const total = toBigNum(t.toString(), decimals);
+      const vested = toBigNum(v.toString(), decimals);
 
       return {
         id: tId,

--- a/apps/governance/src/routes/staking/associate/wallet-associate.tsx
+++ b/apps/governance/src/routes/staking/associate/wallet-associate.tsx
@@ -54,7 +54,7 @@ export const WalletAssociate = ({
           address,
           ethereumConfig.staking_bridge_contract.address
         );
-        const allowance = toBigNum(a, decimals);
+        const allowance = toBigNum(a.toString(), decimals);
         setAllowance(allowance);
       }
     };

--- a/libs/react-helpers/.eslintrc.json
+++ b/libs/react-helpers/.eslintrc.json
@@ -11,7 +11,9 @@
           "@vegaprotocol/data-provider",
           "graphql",
           "graphql-tag",
-          "graphql-ws"
+          "graphql-ws",
+          "ethers",
+          "@ethersproject"
         ]
       }
     },

--- a/libs/smart-contracts/src/contracts/staking-bridge.ts
+++ b/libs/smart-contracts/src/contracts/staking-bridge.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import abi from '../abis/staking_abi.json';
 import { calcGasBuffer, prepend0x } from '../utils';
+import type { BigNumber as EthersBigNum } from 'ethers';
 
 export class StakingBridge {
   public contract: ethers.Contract;
@@ -51,7 +52,7 @@ export class StakingBridge {
   staking_token() {
     return this.contract.staking_token();
   }
-  stake_balance(target: string, vegaPublicKey: string) {
+  stake_balance(target: string, vegaPublicKey: string): Promise<EthersBigNum> {
     return this.contract.stake_balance(target, prepend0x(vegaPublicKey));
   }
   total_staked() {

--- a/libs/smart-contracts/src/contracts/token-vesting.ts
+++ b/libs/smart-contracts/src/contracts/token-vesting.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import abi from '../abis/vesting_abi.json';
 import { calcGasBuffer, prepend0x } from '../utils';
+import type { BigNumber as EthersBigNum } from 'ethers';
 
 export class TokenVesting {
   public contract: ethers.Contract;
@@ -29,13 +30,15 @@ export class TokenVesting {
       gasLimit,
     });
   }
-  stake_balance(address: string, vegaPublicKey: string) {
+  stake_balance(address: string, vegaPublicKey: string): Promise<EthersBigNum> {
     return this.contract.stake_balance(address, prepend0x(vegaPublicKey));
   }
   total_staked() {
     return this.contract.total_staked();
   }
-  user_stats(address: string) {
+  user_stats(
+    address: string
+  ): Promise<{ lien: EthersBigNum; total_in_all_tranches: EthersBigNum }> {
     return this.contract.user_stats(address);
   }
   get_tranche_balance(address: string, trancheId: number) {
@@ -44,7 +47,7 @@ export class TokenVesting {
   get_vested_for_tranche(address: string, trancheId: number) {
     return this.contract.get_vested_for_tranche(address, trancheId);
   }
-  user_total_all_tranches(address: string) {
+  user_total_all_tranches(address: string): Promise<EthersBigNum> {
     return this.contract.user_total_all_tranches(address);
   }
   async withdraw_from_tranche(trancheId: number) {

--- a/libs/utils/.eslintrc.json
+++ b/libs/utils/.eslintrc.json
@@ -11,7 +11,9 @@
           "@vegaprotocol/data-provider",
           "graphql",
           "graphql-tag",
-          "graphql-ws"
+          "graphql-ws",
+          "ethers",
+          "@ethersproject"
         ]
       }
     },

--- a/libs/utils/src/lib/format/number.ts
+++ b/libs/utils/src/lib/format/number.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from 'bignumber.js';
-import { BigNumber as EthersBigNumber } from 'ethers';
 import isNil from 'lodash/isNil';
 import memoize from 'lodash/memoize';
 
@@ -15,16 +14,14 @@ export function toDecimal(numberOfDecimals: number) {
 }
 
 export function toBigNum(
-  rawValue: string | number | EthersBigNumber,
+  rawValue: string | number,
   decimals: number
 ): BigNumber {
-  return new BigNumber(
-    rawValue instanceof EthersBigNumber ? rawValue.toString() : rawValue || 0
-  ).dividedBy(Math.pow(10, decimals));
+  return new BigNumber(rawValue || 0).dividedBy(Math.pow(10, decimals));
 }
 
 export function addDecimal(
-  value: string | number | EthersBigNumber,
+  value: string | number,
   decimals: number,
   decimalPrecision = decimals
 ): string {

--- a/libs/utils/src/lib/validate/common.spec.ts
+++ b/libs/utils/src/lib/validate/common.spec.ts
@@ -1,0 +1,33 @@
+import { ethereumAddress, vegaPublicKey } from './common';
+
+it('ethereumAddress', () => {
+  const errorMessage = 'Invalid Ethereum address';
+
+  const validAddress = '0x72c22822A19D20DE7e426fB84aa047399Ddd8853';
+  expect(ethereumAddress(validAddress)).toEqual(true);
+
+  const invalidChars = '0xzzc22822A19D20DE7e426fB84aa047399Ddd8853';
+  expect(ethereumAddress(invalidChars)).toEqual(errorMessage);
+
+  const tooManyChars = '0x72c22822A19D20DE7e426fB84aa047399Ddd88531111111';
+  expect(ethereumAddress(tooManyChars)).toEqual(errorMessage);
+
+  const no0x = '1x72c22822A19D20DE7e426fB84aa047399Ddd8853';
+  expect(ethereumAddress(no0x)).toEqual(errorMessage);
+});
+
+it('vegaPublicKey', () => {
+  const errorMessage = 'Invalid Vega key';
+
+  const validKey =
+    '70d14a321e02e71992fd115563df765000ccc4775cbe71a0e2f9ff5a3b9dc680';
+  expect(vegaPublicKey(validKey)).toEqual(true);
+
+  const invalidChars =
+    'zzz14a321e02e71992fd115563df765000ccc4775cbe71a0e2f9ff5a3b9dc680';
+  expect(vegaPublicKey(invalidChars)).toEqual(errorMessage);
+
+  const tooManyChars =
+    '70d14a321e02e71992fd115563df765000ccc4775cbe71a0e2f9ff5a3b9dc680111111';
+  expect(vegaPublicKey(tooManyChars)).toEqual(errorMessage);
+});

--- a/libs/utils/src/lib/validate/common.ts
+++ b/libs/utils/src/lib/validate/common.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js';
-import { ethers } from 'ethers';
 import { t } from '@vegaprotocol/i18n';
 
 export const required = (value: string) => {
@@ -10,14 +9,14 @@ export const required = (value: string) => {
 };
 
 export const ethereumAddress = (value: string) => {
-  if (!ethers.utils.isAddress(value)) {
+  if (!/^0x[0-9a-fA-F]{40}$/i.test(value)) {
     return t('Invalid Ethereum address');
   }
   return true;
 };
 
 export const vegaPublicKey = (value: string) => {
-  if (value.length !== 64 || !/^[A-Fa-f0-9]*$/i.test(value)) {
+  if (!/^[A-Fa-f0-9]{64}$/i.test(value)) {
     return t('Invalid Vega key');
   }
   return true;


### PR DESCRIPTION
# Related issues 🔗

Depends on #3626 
Partially address #3124 

# Description ℹ️

Removes dependency on `ethers` from utils and react-helpers

# Technical 👨‍🔧

- Removes use of ethers.utils.isAddress
- Adds test coverage
