### PR TITLE
fix(explorer): number formatting for updateasset proposals

### DIFF
--- a/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
+++ b/apps/explorer/src/app/routes/network-parameters/network-parameters.tsx
@@ -53,6 +53,8 @@ const BIG_NUMBER_PARAMS = [
   'governance.proposal.asset.minProposerBalance',
   'governance.proposal.market.minProposerBalance',
   'governance.proposal.market.minVoterBalance',
+  'governance.proposal.updateAsset.minProposerBalance',
+  'governance.proposal.updateAsset.minVoterBalance',
 ];
 
 export const NetworkParameterRow = ({


### PR DESCRIPTION
# Related issues 🔗

Closes #3629

# Description ℹ️

Governance token balances for the updateAsset related proposals were displaying incorrectly. This PR brings them in line with other proposal types.


<img width="671" alt="Screenshot 2023-05-07 at 13 09 30" src="https://user-images.githubusercontent.com/6678/236676623-f9a99fc5-a721-4fb1-baaa-183b0bc01669.png">

