### PR TITLE
feat(governance): opt in/out telemetry

### DIFF
--- a/apps/governance/src/app.tsx
+++ b/apps/governance/src/app.tsx
@@ -43,6 +43,7 @@ import type { InMemoryCacheConfig } from '@apollo/client';
 import { WithdrawalDialog } from '@vegaprotocol/withdraws';
 import { SplashLoader } from './components/splash-loader';
 import { ToastsManager } from './toasts-manager';
+import { TelemetryDialog } from './components/telemetry-dialog/telemetry-dialog';
 
 const cache: InMemoryCacheConfig = {
   typePolicies: {
@@ -149,6 +150,7 @@ const Web3Container = ({
                   <VegaWalletDialogs />
                   <TransactionModal />
                   <WithdrawalDialog />
+                  <TelemetryDialog />
                 </>
               </BalanceManager>
             </AppLoader>

--- a/apps/governance/src/app.tsx
+++ b/apps/governance/src/app.tsx
@@ -43,7 +43,11 @@ import type { InMemoryCacheConfig } from '@apollo/client';
 import { WithdrawalDialog } from '@vegaprotocol/withdraws';
 import { SplashLoader } from './components/splash-loader';
 import { ToastsManager } from './toasts-manager';
-import { TelemetryDialog } from './components/telemetry-dialog/telemetry-dialog';
+import {
+  TelemetryDialog,
+  TELEMETRY_ON,
+} from './components/telemetry-dialog/telemetry-dialog';
+import { useLocalStorage } from '@vegaprotocol/react-helpers';
 
 const cache: InMemoryCacheConfig = {
   typePolicies: {
@@ -179,9 +183,10 @@ const AppContainer = () => {
   const { config, loading, error } = useEthereumConfig();
   const { VEGA_ENV, GIT_COMMIT_HASH, GIT_BRANCH, ETHEREUM_PROVIDER_URL } =
     useEnvironment();
+  const [telemetryOn] = useLocalStorage(TELEMETRY_ON);
 
   useEffect(() => {
-    if (ENV.dsn) {
+    if (ENV.dsn && telemetryOn) {
       Sentry.init({
         dsn: ENV.dsn,
         integrations: [new Integrations.BrowserTracing()],
@@ -205,7 +210,7 @@ const AppContainer = () => {
       Sentry.setTag('branch', GIT_BRANCH);
       Sentry.setTag('commit', GIT_COMMIT_HASH);
     }
-  }, [GIT_COMMIT_HASH, GIT_BRANCH, VEGA_ENV]);
+  }, [GIT_COMMIT_HASH, GIT_BRANCH, VEGA_ENV, telemetryOn]);
 
   return (
     <Router>

--- a/apps/governance/src/components/nav/nav.tsx
+++ b/apps/governance/src/components/nav/nav.tsx
@@ -11,11 +11,26 @@ import {
   NavigationLink,
   NavigationList,
   NavigationTrigger,
+  Icon,
 } from '@vegaprotocol/ui-toolkit';
 import { EthWallet } from '../eth-wallet';
 import { VegaWallet } from '../vega-wallet';
 import { useLocation, useMatch } from 'react-router-dom';
 import { useEffect } from 'react';
+import { useTelemetryDialog } from '../telemetry-dialog/telemetry-dialog';
+
+export const SettingsLink = () => {
+  const { open, isOpen, close } = useTelemetryDialog();
+  return (
+    <button
+      type="button"
+      onClick={() => (isOpen ? close() : open())}
+      aria-label="Open Telemetry Settings"
+    >
+      <Icon name="cog" className="w-5 h-5 mr-2" />
+    </button>
+  );
+};
 
 export const Nav = ({ theme }: Pick<NavigationProps, 'theme'>) => {
   const { t } = useTranslation();
@@ -42,7 +57,12 @@ export const Nav = ({ theme }: Pick<NavigationProps, 'theme'>) => {
   ));
 
   return (
-    <Navigation appName="Governance" theme={theme} breakpoints={[458, 959]}>
+    <Navigation
+      appName="Governance"
+      theme={theme}
+      breakpoints={[458, 959]}
+      actions={<SettingsLink />}
+    >
       <NavigationList
         className="[.drawer-content_&]:border-b [.drawer-content_&]:border-b-vega-light-200 dark:[.drawer-content_&]:border-b-vega-dark-200 [.drawer-content_&]:pb-8 [.drawer-content_&]:mb-2"
         hide={[NavigationBreakpoint.Small]}

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  useTelemetryDialog,
+  TELEMETRY_DIALOG_PREVIOUSLY_OPENED,
+  TELEMETRY_ACCEPTED,
+} from './telemetry-dialog';
+
+describe('useTelemetryDialog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should have the correct initial state based on localStorage', () => {
+    localStorage.setItem(TELEMETRY_DIALOG_PREVIOUSLY_OPENED, 'true');
+    localStorage.setItem(TELEMETRY_ACCEPTED, 'true');
+
+    const { result } = renderHook(() => useTelemetryDialog());
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.telemetryAccepted).toBe(true);
+  });
+
+  it('should update localStorage and the telemetryAccepted state when setTelemetryAccepted is called', () => {
+    const { result } = renderHook(() => useTelemetryDialog());
+
+    act(() => {
+      result.current.setTelemetryAccepted(true);
+    });
+
+    expect(result.current.telemetryAccepted).toBe(true);
+    expect(localStorage.getItem(TELEMETRY_ACCEPTED)).toBe('true');
+  });
+
+  it('should update localStorage and the isOpen state when close is called', () => {
+    const { result } = renderHook(() => useTelemetryDialog());
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(localStorage.getItem(TELEMETRY_DIALOG_PREVIOUSLY_OPENED)).toBe(
+      'true'
+    );
+  });
+
+  it('should update the isOpen state when open is called', () => {
+    const { result } = renderHook(() => useTelemetryDialog());
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+});

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import {
   useTelemetryDialog,
   TELEMETRY_DIALOG_PREVIOUSLY_OPENED,
-  TELEMETRY_ACCEPTED,
+  TELEMETRY_ON,
 } from './telemetry-dialog';
 
 describe('useTelemetryDialog', () => {
@@ -12,7 +12,7 @@ describe('useTelemetryDialog', () => {
 
   it('should have the correct initial state based on localStorage', () => {
     localStorage.setItem(TELEMETRY_DIALOG_PREVIOUSLY_OPENED, 'true');
-    localStorage.setItem(TELEMETRY_ACCEPTED, 'true');
+    localStorage.setItem(TELEMETRY_ON, 'true');
 
     const { result } = renderHook(() => useTelemetryDialog());
 
@@ -28,7 +28,7 @@ describe('useTelemetryDialog', () => {
     });
 
     expect(result.current.telemetryAccepted).toBe(true);
-    expect(localStorage.getItem(TELEMETRY_ACCEPTED)).toBe('true');
+    expect(localStorage.getItem(TELEMETRY_ON)).toBe('true');
   });
 
   it('should update localStorage and the isOpen state when close is called', () => {

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.spec.tsx
@@ -53,4 +53,9 @@ describe('useTelemetryDialog', () => {
 
     expect(result.current.isOpen).toBe(true);
   });
+
+  it('should open the dialog if TELEMETRY_DIALOG_PREVIOUSLY_OPENED is not set', () => {
+    const { result } = renderHook(() => useTelemetryDialog());
+    expect(result.current.isOpen).toBe(true);
+  });
 });

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
@@ -1,8 +1,21 @@
+import { create } from 'zustand';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocalStorage } from '@vegaprotocol/react-helpers';
 import { Dialog, Icon, Button } from '@vegaprotocol/ui-toolkit';
 import { Networks, useEnvironment } from '@vegaprotocol/environment';
+
+type TelemetryDialogState = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+};
+
+const useTelemetryDialogStore = create<TelemetryDialogState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));
 
 export const TELEMETRY_DIALOG_PREVIOUSLY_OPENED =
   'telemetry_dialog_previously_opened';
@@ -20,9 +33,8 @@ export const useTelemetryDialog = () => {
 
   const defaultTelemetryAccepted = isMainnet ? 'false' : 'true';
 
-  const [isOpen, setIsOpen] = useState(
-    !JSON.parse(getPreviouslyOpened || 'false')
-  );
+  const { isOpen, open, close } = useTelemetryDialogStore();
+
   const [telemetryAccepted, setTelemetryAcceptedState] = useState(
     JSON.parse(getTelemetryAccepted || defaultTelemetryAccepted)
   );
@@ -39,13 +51,13 @@ export const useTelemetryDialog = () => {
 
   useEffect(() => {
     if (JSON.parse(getPreviouslyOpened || 'false') === false) {
-      setIsOpen(true);
+      open();
     }
-  }, [getPreviouslyOpened]);
+  }, [getPreviouslyOpened, open]);
 
   const handleClose = () => {
     setPreviouslyOpened('true');
-    setIsOpen(false);
+    close();
   };
 
   const handleSetTelemetryAccepted = (value: boolean) => {
@@ -55,7 +67,7 @@ export const useTelemetryDialog = () => {
 
   return {
     isOpen,
-    open: () => setIsOpen(true),
+    open: open,
     close: handleClose,
     telemetryAccepted,
     setTelemetryAccepted: handleSetTelemetryAccepted,
@@ -97,6 +109,7 @@ export const TelemetryDialog = () => {
             close();
           }}
           variant={telemetryAccepted ? 'default' : 'primary'}
+          data-testid="do-not-share-data-button"
         >
           {t('NoThanks')}
         </Button>
@@ -107,6 +120,7 @@ export const TelemetryDialog = () => {
             close();
           }}
           variant={telemetryAccepted ? 'primary' : 'default'}
+          data-testid="share-data-button"
         >
           {telemetryAccepted ? t('ContinueSharingData') : t('ShareData')}
         </Button>

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocalStorage } from '@vegaprotocol/react-helpers';
+import { Dialog, Icon, Button } from '@vegaprotocol/ui-toolkit';
+import { Networks, useEnvironment } from '@vegaprotocol/environment';
+
+export const TELEMETRY_DIALOG_PREVIOUSLY_OPENED =
+  'telemetry_dialog_previously_opened';
+export const TELEMETRY_ACCEPTED = 'telemetry_accepted';
+
+export const useTelemetryDialog = () => {
+  const [getPreviouslyOpened, setPreviouslyOpened] = useLocalStorage(
+    TELEMETRY_DIALOG_PREVIOUSLY_OPENED
+  );
+  const [getTelemetryAccepted, setTelemetryAccepted] =
+    useLocalStorage(TELEMETRY_ACCEPTED);
+
+  const { VEGA_ENV } = useEnvironment();
+  const isMainnet = VEGA_ENV === Networks.MAINNET;
+
+  const defaultTelemetryAccepted = isMainnet ? 'false' : 'true';
+
+  const [isOpen, setIsOpen] = useState(
+    !JSON.parse(getPreviouslyOpened || 'false')
+  );
+  const [telemetryAccepted, setTelemetryAcceptedState] = useState(
+    JSON.parse(getTelemetryAccepted || defaultTelemetryAccepted)
+  );
+
+  useEffect(() => {
+    if (getTelemetryAccepted === null || getTelemetryAccepted === undefined) {
+      // Sets an initial value in local storage based on the network
+      setTelemetryAccepted(defaultTelemetryAccepted);
+    } else {
+      // Ensures the component state is in sync with local storage
+      setTelemetryAcceptedState(JSON.parse(getTelemetryAccepted));
+    }
+  }, [getTelemetryAccepted, setTelemetryAccepted, defaultTelemetryAccepted]);
+
+  useEffect(() => {
+    if (JSON.parse(getPreviouslyOpened || 'false') === false) {
+      setIsOpen(true);
+    }
+  }, [getPreviouslyOpened]);
+
+  const handleClose = () => {
+    setPreviouslyOpened('true');
+    setIsOpen(false);
+  };
+
+  const handleSetTelemetryAccepted = (value: boolean) => {
+    setTelemetryAccepted(JSON.stringify(value));
+    setTelemetryAcceptedState(value);
+  };
+
+  return {
+    isOpen,
+    open: () => setIsOpen(true),
+    close: handleClose,
+    telemetryAccepted,
+    setTelemetryAccepted: handleSetTelemetryAccepted,
+  };
+};
+
+export const TelemetryDialog = () => {
+  const { t } = useTranslation();
+  const { isOpen, open, close, telemetryAccepted, setTelemetryAccepted } =
+    useTelemetryDialog();
+  return (
+    <Dialog
+      title={t('ImproveVegaGovernance')}
+      open={isOpen}
+      onChange={(isOpen) => (isOpen ? open() : close())}
+      size="small"
+    >
+      <div className="mt-6">{t('TelemetryModalIntro')}</div>
+      <div className="flex items-center mt-6">
+        <Icon name="eye-off" className="mr-6" size={6} />
+        <div className="flex flex-col gap-1">
+          <div className="font-semibold">{t('Anonymous')}</div>
+          <div>{t('YourIdentityAnonymous')}</div>
+        </div>
+      </div>
+
+      <div className="flex items-center mt-6">
+        <Icon name="cog" className="mr-6" size={6} />
+        <div className="flex flex-col gap-1">
+          <div className="font-semibold">{t('Optional')}</div>
+          <div>{t('OptOutOfTelemetry')}</div>
+        </div>
+      </div>
+
+      <div className="flex items-center mt-10 gap-4">
+        <Button
+          onClick={() => {
+            setTelemetryAccepted(false);
+            close();
+          }}
+          variant={telemetryAccepted ? 'default' : 'primary'}
+        >
+          {t('NoThanks')}
+        </Button>
+
+        <Button
+          onClick={() => {
+            setTelemetryAccepted(true);
+            close();
+          }}
+          variant={telemetryAccepted ? 'primary' : 'default'}
+        >
+          {telemetryAccepted ? t('ContinueSharingData') : t('ShareData')}
+        </Button>
+      </div>
+    </Dialog>
+  );
+};

--- a/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
+++ b/apps/governance/src/components/telemetry-dialog/telemetry-dialog.tsx
@@ -19,14 +19,13 @@ const useTelemetryDialogStore = create<TelemetryDialogState>((set) => ({
 
 export const TELEMETRY_DIALOG_PREVIOUSLY_OPENED =
   'telemetry_dialog_previously_opened';
-export const TELEMETRY_ACCEPTED = 'telemetry_accepted';
+export const TELEMETRY_ON = 'telemetry_on';
 
 export const useTelemetryDialog = () => {
   const [getPreviouslyOpened, setPreviouslyOpened] = useLocalStorage(
     TELEMETRY_DIALOG_PREVIOUSLY_OPENED
   );
-  const [getTelemetryAccepted, setTelemetryAccepted] =
-    useLocalStorage(TELEMETRY_ACCEPTED);
+  const [getTelemetryOn, setTelemetryOn] = useLocalStorage(TELEMETRY_ON);
 
   const { VEGA_ENV } = useEnvironment();
   const isMainnet = VEGA_ENV === Networks.MAINNET;
@@ -36,18 +35,18 @@ export const useTelemetryDialog = () => {
   const { isOpen, open, close } = useTelemetryDialogStore();
 
   const [telemetryAccepted, setTelemetryAcceptedState] = useState(
-    JSON.parse(getTelemetryAccepted || defaultTelemetryAccepted)
+    JSON.parse(getTelemetryOn || defaultTelemetryAccepted)
   );
 
   useEffect(() => {
-    if (getTelemetryAccepted === null || getTelemetryAccepted === undefined) {
+    if (getTelemetryOn === null || getTelemetryOn === undefined) {
       // Sets an initial value in local storage based on the network
-      setTelemetryAccepted(defaultTelemetryAccepted);
+      setTelemetryOn(defaultTelemetryAccepted);
     } else {
       // Ensures the component state is in sync with local storage
-      setTelemetryAcceptedState(JSON.parse(getTelemetryAccepted));
+      setTelemetryAcceptedState(JSON.parse(getTelemetryOn));
     }
-  }, [getTelemetryAccepted, setTelemetryAccepted, defaultTelemetryAccepted]);
+  }, [getTelemetryOn, setTelemetryOn, defaultTelemetryAccepted]);
 
   useEffect(() => {
     if (JSON.parse(getPreviouslyOpened || 'false') === false) {
@@ -61,7 +60,7 @@ export const useTelemetryDialog = () => {
   };
 
   const handleSetTelemetryAccepted = (value: boolean) => {
-    setTelemetryAccepted(JSON.stringify(value));
+    setTelemetryOn(JSON.stringify(value));
     setTelemetryAcceptedState(value);
   };
 

--- a/apps/governance/src/i18n/translations/dev.json
+++ b/apps/governance/src/i18n/translations/dev.json
@@ -799,5 +799,14 @@
   "associateVegaNow": "Associate $VEGA now",
   "disconnectedNotice": "You have been disconnected. Connect your ETH wallet to the {{correctNetwork}} network to use this app.",
   "connectAVegaWalletToVote": "Connect a Vega wallet with $VEGA tokens to vote on a proposal.",
-  "findOutMoreAboutHowToVote": "Find out more about how to vote on Vega"
+  "findOutMoreAboutHowToVote": "Find out more about how to vote on Vega",
+  "ImproveVegaGovernance": "Improve Vega governance",
+  "TelemetryModalIntro": "Help us identify bugs and improve Vega Governance by sharing anonymous usage data.",
+  "Anonymous": "Anonymous",
+  "YourIdentityAnonymous": "Your identity is always anonymous on Vega",
+  "Optional": "Optional",
+  "OptOutOfTelemetry": "You can opt out any time via settings",
+  "NoThanks": "No thanks",
+  "ShareData": "Share data",
+  "ContinueSharingData": "Continue sharing data"
 }

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -409,7 +409,7 @@ export const DealTicket = ({
         <DealTicketButton
           disabled={Object.keys(errors).length >= 1 || isReadOnly}
           variant={
-            order.side === Schema.Side.SIDE_BUY ? 'ternary' : 'secondary'
+            order.side === Schema.Side.SIDE_BUY ? 'tertiary' : 'secondary'
           }
         />
         <DealTicketFeeDetails

--- a/libs/ui-toolkit/src/components/button/button.tsx
+++ b/libs/ui-toolkit/src/components/button/button.tsx
@@ -6,7 +6,7 @@ import type {
 import { forwardRef } from 'react';
 import classnames from 'classnames';
 
-export type ButtonVariant = 'default' | 'primary' | 'secondary' | 'ternary';
+export type ButtonVariant = 'default' | 'primary' | 'secondary' | 'tertiary';
 export type ButtonSize = 'lg' | 'md' | 'sm' | 'xs';
 
 const base =
@@ -36,7 +36,7 @@ const secondary = [
   'enabled:hover:bg-vega-pink enabled:hover:border-vega-pink',
   'enabled:active:bg-vega-pink enabled:active:border-vega-pink',
 ];
-const ternary = [
+const tertiary = [
   'text-white dark:text-black',
   'border-vega-green',
   'dark:bg-vega-green bg-vega-green-550',
@@ -59,7 +59,7 @@ const getClassname = ({
     [defaultClasses.join(' ')]: variant === 'default',
     [primary.join(' ')]: variant === 'primary',
     [secondary.join(' ')]: variant === 'secondary',
-    [ternary.join(' ')]: variant === 'ternary',
+    [tertiary.join(' ')]: variant === 'tertiary',
 
     [lg]: size === 'lg',
     [md]: size === 'md',


### PR DESCRIPTION
# Related issues 🔗

Closes #2988

# Description ℹ️

Displays a modal if the user hasn't seen it before, where they can set whether or not to allow telemetry. For mainnet, telemetry is off by default, for all other envs, it's on by default.

# Demo 📺

<img width="725" alt="Screenshot 2023-05-08 at 22 59 47" src="https://user-images.githubusercontent.com/2410498/236947729-eec33ccd-baf8-4d86-a373-ace6d08ef4e0.png">
<img width="705" alt="Screenshot 2023-05-08 at 22 59 37" src="https://user-images.githubusercontent.com/2410498/236947738-38f7c6d5-f962-4916-8af5-d16efb640d26.png">
<img width="401" alt="Screenshot 2023-05-08 at 22 59 28" src="https://user-images.githubusercontent.com/2410498/236947742-8c10eeee-ef55-43fc-855c-72c9289faba7.png">

