### PR TITLE
fix(explorer): add envs back to env

### DIFF
--- a/apps/explorer/.env
+++ b/apps/explorer/.env
@@ -13,6 +13,7 @@ NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_ORACLE_PROOFS_URL=https://raw.githubusercontent.com/vegaprotocol/well-known/main/__generated__/oracle-proofs.json
 NX_VEGA_GOVERNANCE_URL=https://stagnet1.governance.vega.xyz
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.jsoo
+NX_VEGA_NETWORKS='{"TESTNET":"https://explorer.fairground.wtf","MAINNET":"https://explorer.vega.xyz"}'
 
 # App flags
 NX_EXPLORER_ASSETS=1

--- a/apps/explorer/.env.stagnet1
+++ b/apps/explorer/.env.stagnet1
@@ -1,1 +1,2 @@
 # .env is stagnet1, so there are no overrides required
+NX_VEGA_NETWORKS='{"TESTNET":"https://explorer.fairground.wtf","MAINNET":"https://explorer.vega.xyz","STAGNET3":"https://stagnet3.explorer.vega.xyz"}'


### PR DESCRIPTION
# Related issues 🔗

Closes #3673 

# Description ℹ️

Recent explorer deploys were missing links in the environment switcher. This PR reinstates two of them.
