### PR TITLE
chore(governance): fix failing validator tests

### DIFF
--- a/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
@@ -7,6 +7,7 @@ import {
   waitForSpinner,
   navigateTo,
   navigation,
+  turnTelemetryOff,
 } from '../../support/common.functions';
 import {
   clickOnValidatorFromList,
@@ -56,6 +57,7 @@ context(
     // 2001-STKE-002, 2001-STKE-032
     before('visit staking tab and connect vega wallet', function () {
       cy.visit('/');
+      cy.validatorsSelfDelegate();
       ethereumWalletConnect();
       // this is a workaround for #2422 which can be removed once issue is resolved
       cy.associateTokensToVegaWallet('4');
@@ -67,6 +69,7 @@ context(
         'teardown wallet & drill into a specific validator',
         function () {
           cy.clearLocalStorage();
+          turnTelemetryOff();
           cy.reload();
           waitForSpinner();
           cy.connectVegaWallet();
@@ -252,10 +255,10 @@ context(
           waitForBeginningOfEpoch();
           cy.getByTestId(stakeValidatorListStakePercentage).should(
             'have.text',
-            '100%'
+            '50.02%'
           );
           navigateTo(navigation.validators);
-          validateValidatorListTotalStakeAndShare('0', '2.00', '100.00%');
+          validateValidatorListTotalStakeAndShare('0', '3,002.00', '50.02%');
         }
       );
 

--- a/apps/governance-e2e/src/integration/view/validators.cy.ts
+++ b/apps/governance-e2e/src/integration/view/validators.cy.ts
@@ -29,7 +29,10 @@ const performancePenaltyToolTip = '[data-testid="performance-penalty-tooltip"]';
 const overstakedPenaltyToolTip = '[data-testid="overstaked-penalty-tooltip"]';
 const totalPenaltyToolTip = '[data-testid="total-penalty-tooltip"]';
 const epochCountDown = '[data-testid="epoch-countdown"]';
-const stakeNumberRegex = /^\d*\.?\d*$/;
+const stakeNumberRegex = /^\d{1,3}(,\d{3})*(\.\d+)?$/;
+
+// If running locally, validators need to have self-stake to be displayed
+// Run cy.validatorsSelfDelegate() in before hook
 
 context('Validators Page - verify elements on page', function () {
   before('navigate to validators page', function () {
@@ -84,13 +87,13 @@ context('Validators Page - verify elements on page', function () {
 
           cy.get(stakedByOperatorToolTip)
             .invoke('text')
-            .should('contain', 'Staked by operator: 0.00');
+            .should('contain', 'Staked by operator: 3,000.00');
           cy.get(stakedByDelegatesToolTip)
             .invoke('text')
             .should('contain', 'Staked by delegates: 0.00');
           cy.get(totalStakedToolTip)
             .invoke('text')
-            .should('contain', 'Total stake: 0.00');
+            .should('contain', 'Total stake: 3,000.00');
         });
 
         it('Should be able to see validator normalised voting power', function () {
@@ -106,10 +109,10 @@ context('Validators Page - verify elements on page', function () {
 
           cy.get(unnormalisedVotingPowerToolTip)
             .invoke('text')
-            .should('contain', 'Unnormalised voting power: 0.00%');
+            .should('contain', 'Unnormalised voting power: 20.00%');
           cy.get(normalisedVotingPowerToolTip)
             .invoke('text')
-            .should('contain', 'Normalised voting power: 0.10%');
+            .should('contain', 'Normalised voting power: 50.00%');
         });
 
         // 2002-SINC-018
@@ -126,13 +129,13 @@ context('Validators Page - verify elements on page', function () {
 
           cy.get(performancePenaltyToolTip)
             .invoke('text')
-            .should('contain', 'Performance penalty: 100.00%');
+            .should('contain', 'Performance penalty: 0.00%');
           cy.get(overstakedPenaltyToolTip)
             .invoke('text')
-            .should('contain', 'Overstaked penalty:'); // value not asserted due to #2886
+            .should('contain', 'Overstaked penalty: 60.00%'); // value not asserted due to #2886
           cy.get(totalPenaltyToolTip)
             .invoke('text')
-            .should('contain', 'Total penalties: 0.00%');
+            .should('contain', 'Total penalties: 60.00%');
         });
 
         it('Should be able to see validator pending stake', function () {


### PR DESCRIPTION
There are failing e2e tests in governance due to a change in filtering validators where validators with no self stake are not displayed.

Add workaround to self-stake validators at start of test run as well as update to tests
