### PR TITLE
fix(governance): tranches data

### DIFF
--- a/apps/governance/src/lib/tranches/tranches-store.tsx
+++ b/apps/governance/src/lib/tranches/tranches-store.tsx
@@ -50,7 +50,16 @@ export const useTranches = create<TranchesStore>()((set) => ({
         ?.map((t) => {
           const tranche_progress =
             t.duration !== 0 ? (now - t.cliff_start) / t.duration : 0;
-          const lockedDecimal = tranche_progress < 0 ? 1 : 1 - tranche_progress;
+          const lockedDecimal =
+            t.duration !== 0
+              ? tranche_progress < 0
+                ? 1
+                : 1 - tranche_progress
+              : now < t.cliff_start
+              ? 1
+              : 0;
+          const clampedLockedDecimal = Math.max(0, Math.min(1, lockedDecimal));
+
           return {
             tranche_id: t.tranche_id,
             tranche_start: secondsToDate(t.cliff_start),
@@ -60,7 +69,7 @@ export const useTranches = create<TranchesStore>()((set) => ({
               toBigNum(t.current_balance, decimals)
             ),
             locked_amount: toBigNum(t.initial_balance, decimals).times(
-              lockedDecimal
+              clampedLockedDecimal
             ),
             users: t.users,
           };

--- a/apps/governance/src/lib/tranches/tranches-store.tsx
+++ b/apps/governance/src/lib/tranches/tranches-store.tsx
@@ -50,14 +50,20 @@ export const useTranches = create<TranchesStore>()((set) => ({
         ?.map((t) => {
           const tranche_progress =
             t.duration !== 0 ? (now - t.cliff_start) / t.duration : 0;
-          const lockedDecimal =
-            t.duration !== 0
-              ? tranche_progress < 0
-                ? 1
-                : 1 - tranche_progress
-              : now < t.cliff_start
-              ? 1
-              : 0;
+          let lockedDecimal;
+          if (t.duration !== 0) {
+            if (tranche_progress < 0) {
+              lockedDecimal = 1;
+            } else {
+              lockedDecimal = 1 - tranche_progress;
+            }
+          } else {
+            if (now < t.cliff_start) {
+              lockedDecimal = 1;
+            } else {
+              lockedDecimal = 0;
+            }
+          }
           const clampedLockedDecimal = Math.max(0, Math.min(1, lockedDecimal));
 
           return {

--- a/apps/governance/src/routes/redemption/tranche-item.tsx
+++ b/apps/governance/src/routes/redemption/tranche-item.tsx
@@ -54,22 +54,16 @@ export const TrancheItem = ({
           {formatNumber(total, 2)}
         </span>
       </div>
-      <table className="w-full">
-        <tbody>
-          <tr>
-            <td>{t('Starts unlocking')}</td>
-            <td className="text-right">
-              {format(tranche.tranche_start, DATE_FORMAT_LONG)}
-            </td>
-          </tr>
-          <tr>
-            <td>{t('Fully unlocked')}</td>
-            <td className="text-right">
-              {format(tranche.tranche_end, DATE_FORMAT_LONG)}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="grid grid-cols-2 my-2">
+        <div>
+          <span>{t('Starts unlocking')}:</span>{' '}
+          <span>{format(tranche.tranche_start, DATE_FORMAT_LONG)}</span>
+        </div>
+        <div className="justify-self-end">
+          <span>{t('Fully unlocked')}:</span>{' '}
+          <span>{format(tranche.tranche_end, DATE_FORMAT_LONG)}</span>
+        </div>
+      </div>
       <LockedProgress
         locked={locked}
         unlocked={unlocked}


### PR DESCRIPTION
# Related issues 🔗

Closes #3690

# Description ℹ️

Tranche progress calculation required a couple of tweaks:

- Items in the past could have a 'lockedDecimal' greater than 1, resulting in incorrect totals being calculated (negative totals)
- Tranches that finish immediately were being treated as if they were always locked. Added some logic to check if their cliff_start value was in the past, giving them an unlocked value if so.

I also tweaked the layout of the tranche item to make the values more readable. See the 'unlocking starts' and 'fully unlocked' values below:

before:

<img width="1061" alt="Screenshot 2023-05-10 at 16 21 10" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/26f498a4-3e56-493f-bc02-45da1456e923">

after:

<img width="1076" alt="Screenshot 2023-05-10 at 16 22 01" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/db53015c-68d1-4c8e-8cc3-e4abe2c820ab">

