### PR TITLE
fix(governance): fix time delay notice for withdrawal of 0.00 assets

### DIFF
--- a/libs/smart-contracts/src/contracts/collateral-bridge.ts
+++ b/libs/smart-contracts/src/contracts/collateral-bridge.ts
@@ -44,7 +44,7 @@ export class CollateralBridge {
   is_asset_listed(address: string) {
     return this.contract.is_asset_listed(address);
   }
-  get_withdraw_threshold(assetSource: string) {
+  get_withdraw_threshold(assetSource: string): Promise<BigNumber> {
     return this.contract.get_withdraw_threshold(assetSource);
   }
   default_withdraw_delay() {

--- a/libs/withdraws/src/lib/withdraw-form.tsx
+++ b/libs/withdraws/src/lib/withdraw-form.tsx
@@ -70,13 +70,14 @@ const WithdrawDelayNotification = ({
   return (
     <Notification
       intent={Intent.Warning}
+      key={symbol}
       testId={
-        threshold.isFinite()
-          ? 'amount-withdrawal-delay-notification'
-          : 'withdrawals-delay-notification'
+        threshold.isEqualTo(0)
+          ? 'withdrawals-delay-notification'
+          : 'amount-withdrawal-delay-notification'
       }
       message={[
-        !threshold.isFinite()
+        threshold.isEqualTo(0)
           ? t('All %s withdrawals are subject to a %s delay.', replacements)
           : t('Withdrawals of %s %s or more will be delayed for %s.', [
               formatNumber(threshold, decimals),

--- a/libs/withdraws/src/lib/withdraw-form.tsx
+++ b/libs/withdraws/src/lib/withdraw-form.tsx
@@ -167,10 +167,7 @@ export const WithdrawForm = ({
   };
 
   const showWithdrawDelayNotification =
-    delay &&
-    selectedAsset &&
-    (!threshold.isFinite() ||
-      new BigNumber(amount).isGreaterThanOrEqualTo(threshold));
+    delay && selectedAsset && new BigNumber(amount).isGreaterThan(threshold);
 
   return (
     <>

--- a/libs/withdraws/src/lib/withdraw-manager.spec.tsx
+++ b/libs/withdraws/src/lib/withdraw-manager.spec.tsx
@@ -120,7 +120,7 @@ describe('WithdrawManager', () => {
   it('shows withdraw delay notification if amount greater than threshold', async () => {
     render(generateJsx(props));
     fireEvent.change(screen.getByLabelText('Amount'), {
-      target: { value: '1000' },
+      target: { value: '1001' },
     });
     expect(
       await screen.findByTestId('amount-withdrawal-delay-notification')
@@ -131,7 +131,7 @@ describe('WithdrawManager', () => {
     withdrawAsset.threshold = new BigNumber(0);
     render(generateJsx(props));
     fireEvent.change(screen.getByLabelText('Amount'), {
-      target: { value: '0.00' },
+      target: { value: '0.01' },
     });
     expect(
       await screen.findByTestId('withdrawals-delay-notification')

--- a/libs/withdraws/src/lib/withdraw-manager.spec.tsx
+++ b/libs/withdraws/src/lib/withdraw-manager.spec.tsx
@@ -128,10 +128,10 @@ describe('WithdrawManager', () => {
   });
 
   it('shows withdraw delay notification if threshold is 0', async () => {
-    withdrawAsset.threshold = new BigNumber(Infinity);
+    withdrawAsset.threshold = new BigNumber(0);
     render(generateJsx(props));
     fireEvent.change(screen.getByLabelText('Amount'), {
-      target: { value: '0.01' },
+      target: { value: '0.00' },
     });
     expect(
       await screen.findByTestId('withdrawals-delay-notification')


### PR DESCRIPTION
# Related issues 🔗

Closes #3553

# Description ℹ️

The withdrawal form message was configured to show a different message if the threshold for a withdrawal delay was 0, but it wasn't working. Subsequently, you'd see the scenario detailed in #3553. 
