### PR TITLE
fix(governance): claim not encoding ascii correctly

### DIFF
--- a/libs/smart-contracts/src/contracts/claim.ts
+++ b/libs/smart-contracts/src/contracts/claim.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { hexlify } from 'ethers/lib/utils';
+import { hexlify, toUtf8Bytes } from 'ethers/lib/utils';
 import abi from '../abis/claim_abi.json';
 import { calcGasBuffer } from '../utils';
 
@@ -70,7 +70,7 @@ export class Claim {
         tranche,
         expiry,
       },
-      hexlify(country),
+      hexlify(toUtf8Bytes(country)),
       target,
     ].filter(Boolean);
     const res = await this.contract.estimateGas[method](...args);
@@ -110,7 +110,9 @@ export class Claim {
    * @return {Promise<boolean>}
    */
   async isCountryBlocked(country: string): Promise<boolean> {
-    const isAllowed = await this.contract.allowed_countries(hexlify(country));
+    const isAllowed = await this.contract.allowed_countries(
+      hexlify(toUtf8Bytes(country))
+    );
     return !isAllowed;
   }
 }


### PR DESCRIPTION
# Related issues 🔗

Closes https://github.com/vegaprotocol/frontend-monorepo/issues/3725

# Description ℹ️

Hexlify does not accept arbitary strings so need to pass this to toUtf8Bytes first. Confirmed output the same with previous util function that was removed.