### PR TITLE
fix(governance): useWeb3ConnectStore instead of app state for eth connect d…

### DIFF
--- a/apps/governance/src/components/eth-connect-prompt/eth-connect-promp.tsx
+++ b/apps/governance/src/components/eth-connect-prompt/eth-connect-promp.tsx
@@ -1,23 +1,14 @@
 import { Button } from '@vegaprotocol/ui-toolkit';
 import { useTranslation } from 'react-i18next';
-
-import {
-  AppStateActionType,
-  useAppState,
-} from '../../contexts/app-state/app-state-context';
+import { useWeb3ConnectStore } from '@vegaprotocol/web3';
 
 export const EthConnectPrompt = () => {
   const { t } = useTranslation();
-  const { appDispatch } = useAppState();
+  const { open } = useWeb3ConnectStore();
   return (
     <Button
       variant="default"
-      onClick={() =>
-        appDispatch({
-          type: AppStateActionType.SET_ETH_WALLET_OVERLAY,
-          isOpen: true,
-        })
-      }
+      onClick={open}
       fill={true}
       data-testid="connect-to-eth-btn"
     >

--- a/apps/governance/src/components/eth-wallet-container/eth-wallet-container.tsx
+++ b/apps/governance/src/components/eth-wallet-container/eth-wallet-container.tsx
@@ -2,10 +2,7 @@ import { Button } from '@vegaprotocol/ui-toolkit';
 import { useWeb3React } from '@web3-react/core';
 import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  AppStateActionType,
-  useAppState,
-} from '../../contexts/app-state/app-state-context';
+import { useWeb3ConnectStore } from '@vegaprotocol/web3';
 
 export const EthWalletContainer = ({
   children,
@@ -14,21 +11,12 @@ export const EthWalletContainer = ({
 }) => {
   const { account } = useWeb3React();
   const { t } = useTranslation();
-  const { appDispatch } = useAppState();
+  const { open } = useWeb3ConnectStore();
 
   if (!account) {
     return (
       <div className="w-full text-center">
-        <Button
-          onClick={() =>
-            appDispatch({
-              type: AppStateActionType.SET_ETH_WALLET_OVERLAY,
-              isOpen: true,
-            })
-          }
-        >
-          {t('connectEthWallet')}
-        </Button>
+        <Button onClick={open}>{t('connectEthWallet')}</Button>
       </div>
     );
   }

--- a/apps/governance/src/components/eth-wallet/eth-wallet.tsx
+++ b/apps/governance/src/components/eth-wallet/eth-wallet.tsx
@@ -27,7 +27,11 @@ import {
 import { Loader } from '@vegaprotocol/ui-toolkit';
 import colors from 'tailwindcss/colors';
 import { useBalances } from '../../lib/balances/balances-store';
-import { useEthereumConfig, useWeb3Disconnect } from '@vegaprotocol/web3';
+import {
+  useEthereumConfig,
+  useWeb3ConnectStore,
+  useWeb3Disconnect,
+} from '@vegaprotocol/web3';
 import { getChainName } from '@vegaprotocol/web3';
 
 const removeLeadingAddressSymbol = (key: string) => {
@@ -189,6 +193,7 @@ export const EthWallet = () => {
   const pendingTxs = usePendingTransactions();
   const disconnect = useWeb3Disconnect(connector);
   const { config } = useEthereumConfig();
+  const { open } = useWeb3ConnectStore();
 
   return (
     <WalletCard>
@@ -233,12 +238,7 @@ export const EthWallet = () => {
           ) : (
             <Button
               fill={true}
-              onClick={() =>
-                appDispatch({
-                  type: AppStateActionType.SET_ETH_WALLET_OVERLAY,
-                  isOpen: true,
-                })
-              }
+              onClick={open}
               data-testid="connect-to-eth-wallet-button"
             >
               {t('connectEthWalletToAssociate')}

--- a/apps/governance/src/components/web3-connector/web3-connector.tsx
+++ b/apps/governance/src/components/web3-connector/web3-connector.tsx
@@ -25,20 +25,26 @@ export function Web3Connector({
   connectors,
   chainId,
 }: Web3ConnectorProps) {
-  const { appState, appDispatch } = useAppState();
+  const { open, close, isOpen } = useWeb3ConnectStore();
+
   const setDialogOpen = useCallback(
     (isOpen: boolean) => {
-      appDispatch({ type: AppStateActionType.SET_ETH_WALLET_OVERLAY, isOpen });
+      if (isOpen) {
+        open();
+      } else {
+        close();
+      }
     },
-    [appDispatch]
+    [open, close]
   );
+
   const appChainId = Number(chainId);
   return (
     <>
       <Web3Content appChainId={appChainId}>{children}</Web3Content>
       <Web3ConnectDialog
         connectors={connectors}
-        dialogOpen={appState.ethConnectOverlay}
+        dialogOpen={isOpen}
         setDialogOpen={setDialogOpen}
         desiredChainId={appChainId}
       />

--- a/apps/governance/src/contexts/app-state/app-state-context.ts
+++ b/apps/governance/src/contexts/app-state/app-state-context.ts
@@ -34,9 +34,6 @@ export interface AppState {
   /** Whether or not the manage VEGA wallet overlay is open */
   vegaWalletManageOverlay: boolean;
 
-  /** Whether or not the connect to Ethereum wallet overlay is open */
-  ethConnectOverlay: boolean;
-
   /**  Whether or not the transaction modal is open */
   transactionOverlay: boolean;
   /**
@@ -57,7 +54,6 @@ export enum AppStateActionType {
   REFRESH_BALANCES,
   SET_VEGA_WALLET_OVERLAY,
   SET_VEGA_WALLET_MANAGE_OVERLAY,
-  SET_ETH_WALLET_OVERLAY,
   SET_DRAWER,
   REFRESH_ASSOCIATED_BALANCES,
   SET_ASSOCIATION_BREAKDOWN,
@@ -79,10 +75,6 @@ export type AppStateAction =
     }
   | {
       type: AppStateActionType.SET_VEGA_WALLET_MANAGE_OVERLAY;
-      isOpen: boolean;
-    }
-  | {
-      type: AppStateActionType.SET_ETH_WALLET_OVERLAY;
       isOpen: boolean;
     }
   | {

--- a/apps/governance/src/contexts/app-state/app-state-provider.tsx
+++ b/apps/governance/src/contexts/app-state/app-state-provider.tsx
@@ -16,7 +16,6 @@ const initialAppState: AppState = {
   totalSupply: new BigNumber(0),
   vegaWalletOverlay: false,
   vegaWalletManageOverlay: false,
-  ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
   disconnectNotice: false,
@@ -43,12 +42,6 @@ function appStateReducer(state: AppState, action: AppStateAction): AppState {
         ...state,
         vegaWalletManageOverlay: action.isOpen,
         vegaWalletOverlay: action.isOpen ? false : state.vegaWalletOverlay,
-      };
-    }
-    case AppStateActionType.SET_ETH_WALLET_OVERLAY: {
-      return {
-        ...state,
-        ethConnectOverlay: action.isOpen,
       };
     }
     case AppStateActionType.SET_DRAWER: {

--- a/apps/governance/src/routes/proposals/components/list-asset/list-asset.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/list-asset/list-asset.spec.tsx
@@ -53,7 +53,6 @@ const mockAppState: AppState = {
   totalSupply: new BigNumber(65000000),
   vegaWalletOverlay: false,
   vegaWalletManageOverlay: false,
-  ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
   disconnectNotice: false,

--- a/apps/governance/src/routes/proposals/hooks/use-vote-information.spec.ts
+++ b/apps/governance/src/routes/proposals/hooks/use-vote-information.spec.ts
@@ -16,7 +16,6 @@ const mockAppState: AppState = {
   totalSupply: mockTotalSupply,
   vegaWalletOverlay: false,
   vegaWalletManageOverlay: false,
-  ethConnectOverlay: false,
   transactionOverlay: false,
   bannerMessage: '',
   disconnectNotice: false,


### PR DESCRIPTION
…ialog

# Related issues 🔗

Closes #3576

# Description ℹ️

Governance was using internal app state to control the isOpen state of the eth connect dialog. This was at odds with the shared withdrawal form, which relies on the shared useWeb3ConnectStore. 
