### PR TITLE
fix(governance): reward aggregation for validator types

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
@@ -79,7 +79,24 @@ export const generateEpochIndividualRewardsList = ({
       epoch?.rewards.push(asset);
     }
 
-    asset.rewardTypes[rewardType] = { amount, percentageOfTotal };
+    if (!asset.rewardTypes[rewardType]) {
+      asset.rewardTypes[rewardType] = { amount, percentageOfTotal };
+    } else {
+      const previousAmount = asset.rewardTypes[rewardType]?.amount;
+      const previousPercentageOfTotal =
+        asset.rewardTypes[rewardType]?.percentageOfTotal;
+
+      asset.rewardTypes[rewardType] = {
+        amount: previousAmount
+          ? new BigNumber(previousAmount).plus(amount).toString()
+          : amount,
+        percentageOfTotal: previousPercentageOfTotal
+          ? new BigNumber(previousPercentageOfTotal)
+              .plus(percentageOfTotal)
+              .toString()
+          : percentageOfTotal,
+      };
+    }
 
     // totalAmount is the sum of all rewardTypes amounts
     asset.totalAmount = Object.values(asset.rewardTypes).reduce(


### PR DESCRIPTION
# Related issues 🔗

Closes #3760

# Description ℹ️

Consensus, standby and pending validators have separate rewards returned per epoch. Previously we'd only been working with consensus validators, and we'd not aggregated. This created a confusing mix of randomly rendered results. 
