### PR TITLE
fix(governance): ensure no negative overstaked penalty

### DIFF
--- a/apps/governance-e2e/src/integration/view/rewards.cy.ts
+++ b/apps/governance-e2e/src/integration/view/rewards.cy.ts
@@ -63,7 +63,6 @@ context(
       });
 
       it('should have option to go to last and newest page', function () {
-        waitForBeginningOfEpoch();
         cy.getByTestId('goto-last-page').click();
         cy.getByTestId('epoch-total-rewards-table')
           .last()

--- a/apps/governance/src/routes/staking/shared.ts
+++ b/apps/governance/src/routes/staking/shared.ts
@@ -60,9 +60,14 @@ export const getOverstakingPenalty = (
   }
 
   return formatNumberPercentage(
-    new BigNumber(1)
-      .minus(new BigNumber(validatorScore).dividedBy(new BigNumber(stakeScore)))
-      .times(100),
+    BigNumber.max(
+      new BigNumber(1)
+        .minus(
+          new BigNumber(validatorScore).dividedBy(new BigNumber(stakeScore))
+        )
+        .times(100),
+      new BigNumber(0)
+    ),
     2
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #3696

# Description ℹ️

Larger changes to how penalties are calculated vs what to show in the table may come later, but for now, just ensure that there's no rendered negative overstaking penalty, as that's just silly.
