### PR TITLE
fix(ui-toolkit): add keys to healthbar segments

### DIFF
--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vegaprotocol/i18n",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs"
 }

--- a/libs/react-helpers/package.json
+++ b/libs/react-helpers/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/react-helpers",
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/libs/tailwindcss-config/package.json
+++ b/libs/tailwindcss-config/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/tailwindcss-config",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/types",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/libs/ui-toolkit/package.json
+++ b/libs/ui-toolkit/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/ui-toolkit",
-  "version": "0.12.1"
+  "version": "0.12.2"
 }

--- a/libs/ui-toolkit/src/components/healthbar/healthbar.tsx
+++ b/libs/ui-toolkit/src/components/healthbar/healthbar.tsx
@@ -181,6 +181,7 @@ export const HealthBar = ({
                   prevLevel={prevLevel}
                   decimals={0}
                   intent={intent}
+                  key={'healthbar-segment-' + index}
                 />
               ) : null;
             })}

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vegaprotocol/utils",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs"
 }


### PR DESCRIPTION
Adds keys to the segments output by the healthbar component.

Version bumps for ui-toolkit and it's dependent packages so we can use this fix on the website.
