### PR TITLE
fix(governance): point to correct data for displayed LP rewards

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.spec.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.spec.tsx
@@ -25,7 +25,7 @@ const mockData = {
           amount: '0',
           percentageOfTotal: '0',
         },
-        ACCOUNT_TYPE_FEES_LIQUIDITY: {
+        ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES: {
           amount: '0',
           percentageOfTotal: '0',
         },
@@ -55,7 +55,9 @@ describe('EpochIndividualRewardsTable', () => {
     expect(
       getByTestId('ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES')
     ).toBeInTheDocument();
-    expect(getByTestId('ACCOUNT_TYPE_FEES_LIQUIDITY')).toBeInTheDocument();
+    expect(
+      getByTestId('ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES')
+    ).toBeInTheDocument();
     expect(
       getByTestId('ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS')
     ).toBeInTheDocument();

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
@@ -24,7 +24,7 @@ describe('generateEpochIndividualRewardsList', () => {
   };
 
   const reward3: RewardFieldsFragment = {
-    rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+    rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
     amount: '200',
     percentageOfTotal: '0.2',
     receivedAt: new Date(),
@@ -34,7 +34,7 @@ describe('generateEpochIndividualRewardsList', () => {
   };
 
   const reward4: RewardFieldsFragment = {
-    rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+    rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
     amount: '100',
     percentageOfTotal: '0.1',
     receivedAt: new Date(),
@@ -44,7 +44,7 @@ describe('generateEpochIndividualRewardsList', () => {
   };
 
   const reward5: RewardFieldsFragment = {
-    rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+    rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
     amount: '150',
     percentageOfTotal: '0.15',
     receivedAt: new Date(),
@@ -105,7 +105,7 @@ describe('generateEpochIndividualRewardsList', () => {
               amount: '0',
               percentageOfTotal: '0',
             },
-            [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+            [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
               amount: '0',
               percentageOfTotal: '0',
             },
@@ -172,7 +172,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '200',
                 percentageOfTotal: '0.2',
               },
@@ -202,7 +202,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '0',
                 percentageOfTotal: '0',
               },
@@ -237,7 +237,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '100',
                 percentageOfTotal: '0.1',
               },
@@ -285,7 +285,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '150',
                 percentageOfTotal: '0.15',
               },
@@ -320,7 +320,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '200',
                 percentageOfTotal: '0.2',
               },
@@ -350,7 +350,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '0',
                 percentageOfTotal: '0',
               },
@@ -395,7 +395,7 @@ describe('generateEpochIndividualRewardsList', () => {
                 amount: '0',
                 percentageOfTotal: '0',
               },
-              [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+              [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
                 amount: '100',
                 percentageOfTotal: '0.1',
               },

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.spec.tsx
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.spec.tsx
@@ -29,7 +29,7 @@ const rewardsList = [
     amount: '0',
   },
   {
-    rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+    rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
     amount: '0',
   },
   {
@@ -78,7 +78,9 @@ describe('EpochTotalRewardsTable', () => {
     expect(
       getByTestId('ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES')
     ).toBeInTheDocument();
-    expect(getByTestId('ACCOUNT_TYPE_FEES_LIQUIDITY')).toBeInTheDocument();
+    expect(
+      getByTestId('ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES')
+    ).toBeInTheDocument();
     expect(
       getByTestId('ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS')
     ).toBeInTheDocument();

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.spec.ts
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.spec.ts
@@ -162,9 +162,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '0',
                       },
                     ],
@@ -227,7 +228,7 @@ describe('generateEpochAssetRewardsList', () => {
             node: {
               epoch: 2,
               assetId: '1',
-              rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+              rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
               amount: '5',
             },
           },
@@ -287,9 +288,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '0',
                       },
                     ],
@@ -351,9 +353,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '5',
                       },
                     ],
@@ -416,7 +419,7 @@ describe('generateEpochAssetRewardsList', () => {
             node: {
               epoch: 2,
               assetId: '1',
-              rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+              rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
               amount: '6',
             },
           },
@@ -424,7 +427,7 @@ describe('generateEpochAssetRewardsList', () => {
             node: {
               epoch: 2,
               assetId: '1',
-              rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+              rewardType: AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
               amount: '27',
             },
           },
@@ -497,9 +500,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '33',
                       },
                     ],
@@ -561,9 +565,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '0',
                       },
                     ],
@@ -637,9 +642,10 @@ describe('generateEpochAssetRewardsList', () => {
                       },
                     ],
                     [
-                      AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                      AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                       {
-                        rewardType: AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY,
+                        rewardType:
+                          AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
                         amount: '0',
                       },
                     ],

--- a/apps/governance/src/routes/rewards/shared-rewards-table-assets/shared-rewards-table-assets.tsx
+++ b/apps/governance/src/routes/rewards/shared-rewards-table-assets/shared-rewards-table-assets.tsx
@@ -26,7 +26,7 @@ export const RowAccountTypes = {
     columnTitle: 'rewardsColPriceMakingHeader',
     description: 'rewardsColPriceMakingTooltip',
   },
-  [AccountType.ACCOUNT_TYPE_FEES_LIQUIDITY]: {
+  [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
     columnTitle: 'rewardsColLiquidityProvisionHeader',
     description: 'rewardsColLiquidityProvisionTooltip',
   },


### PR DESCRIPTION
# Related issues 🔗

Closes #3572

# Description ℹ️

The fee we were originally displaying in the table appears to have been incorrect. This simply changes which fee we display
