### PR TITLE
chore(ci): fix nightly test runner

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -20,7 +20,7 @@ jobs:
         project: ${{ fromJSON(inputs.projects) }}
     name: ${{ matrix.project }}
     runs-on: self-hosted-runner
-    timeout-minutes: 120
+    timeout-minutes: 60
     steps:
       # Checks if skip cache was requested
       - name: Set skip-nx-cache flag

--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -20,7 +20,7 @@ jobs:
         project: ${{ fromJSON(inputs.projects) }}
     name: ${{ matrix.project }}
     runs-on: self-hosted-runner
-    timeout-minutes: 40
+    timeout-minutes: 120
     steps:
       # Checks if skip cache was requested
       - name: Set skip-nx-cache flag
@@ -98,4 +98,4 @@ jobs:
         if: ${{ failure() }}
         with:
           name: test-report-${{ matrix.project }}
-          path: frontend-monorepo/apps/trading-e2e/cypress/reports
+          path: frontend-monorepo/apps/${{ matrix.project }}/cypress/reports

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ cypress.env.json
 .next
 
 #cypress
-/apps/trading-e2e/cypress/reports/
+/apps/**/cypress/reports/

--- a/apps/explorer-e2e/cypress.config.js
+++ b/apps/explorer-e2e/cypress.config.js
@@ -1,10 +1,11 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  projectId: 'et4snf',
+  reporter: '../../node_modules/cypress-mochawesome-reporter',
 
   e2e: {
     setupNodeEvents(on, config) {
+      require('cypress-mochawesome-reporter/plugin')(on);
       require('@cypress/grep/src/plugin')(config);
       return config;
     },

--- a/apps/explorer-e2e/src/support/index.js
+++ b/apps/explorer-e2e/src/support/index.js
@@ -15,5 +15,6 @@
 
 import '@vegaprotocol/cypress';
 import './common.functions.js';
+import 'cypress-mochawesome-reporter/register';
 import registerCypressGrep from '@cypress/grep';
 registerCypressGrep();

--- a/apps/governance-e2e/cypress.config.js
+++ b/apps/governance-e2e/cypress.config.js
@@ -1,10 +1,11 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  projectId: 'et4snf',
+  reporter: '../../node_modules/cypress-mochawesome-reporter',
 
   e2e: {
     setupNodeEvents(on, config) {
+      require('cypress-mochawesome-reporter/plugin')(on);
       require('@cypress/grep/src/plugin')(config);
       return config;
     },

--- a/apps/governance-e2e/src/integration/view/rewards.cy.ts
+++ b/apps/governance-e2e/src/integration/view/rewards.cy.ts
@@ -63,7 +63,6 @@ context(
       });
 
       it('should have option to go to last and newest page', function () {
-        waitForBeginningOfEpoch();
         cy.getByTestId('goto-last-page').click();
         cy.getByTestId('epoch-total-rewards-table')
           .last()

--- a/apps/governance-e2e/src/support/index.js
+++ b/apps/governance-e2e/src/support/index.js
@@ -8,6 +8,7 @@ import './wallet-eth.functions.ts';
 import './wallet-teardown.functions.ts';
 import './wallet-vega.functions.ts';
 import './proposal.functions.ts';
+import 'cypress-mochawesome-reporter/register';
 import registerCypressGrep from '@cypress/grep';
 import { aliasGQLQuery } from '@vegaprotocol/cypress';
 import { chainIdQuery, statisticsQuery } from '@vegaprotocol/mock';


### PR DESCRIPTION
# Related issues 🔗

The Governance tests in nightly run are timing out as they can take longer than 40 minutes.

Also fixed the test reporter which now works on governance and explorer and also removed redundant project id used by Cypress
