### PR TITLE
fix(governance): clear wallet state if user changes to a non existent party

### DIFF
--- a/apps/governance/src/app.tsx
+++ b/apps/governance/src/app.tsx
@@ -52,6 +52,7 @@ import {
 } from './components/telemetry-dialog/telemetry-dialog';
 import { useLocalStorage } from '@vegaprotocol/react-helpers';
 import { useTranslation } from 'react-i18next';
+import { isPartyNotFoundError } from './lib/party';
 
 const cache: InMemoryCacheConfig = {
   typePolicies: {
@@ -219,9 +220,8 @@ const AppContainer = () => {
           const transaction = event.transaction;
 
           if (
-            (errorIsString && error.includes('failed to get party ID')) ||
-            (errorIsObject &&
-              error?.message?.includes('failed to get party ID'))
+            (errorIsString && isPartyNotFoundError({ message: error })) ||
+            (errorIsObject && isPartyNotFoundError(error))
           ) {
             // This error is caused by a pubkey making an API request before
             // it has interacted with the chain. This isn't needed in Sentry.

--- a/apps/governance/src/components/vega-wallet/hooks.ts
+++ b/apps/governance/src/components/vega-wallet/hooks.ts
@@ -26,6 +26,7 @@ import type {
   WalletDelegationFieldsFragment,
 } from './__generated__/Delegations';
 import { DelegationsDocument } from './__generated__/Delegations';
+import { isPartyNotFoundError } from '../../lib/party';
 
 export const usePollForDelegations = () => {
   const { token: vegaToken } = useContracts();
@@ -75,6 +76,9 @@ export const usePollForDelegations = () => {
           })
           .then((res) => {
             if (!mounted) return;
+
+            console.log(res.error);
+
             const canonisedDelegations = removePaginationWrapper(
               res.data.party?.delegationsConnection?.edges
             );
@@ -203,6 +207,15 @@ export const usePollForDelegations = () => {
             setDelegatedNodes(delegatedAmounts);
           })
           .catch((err: Error) => {
+            // if party isn't found, dont log to Sentry, just clear state as, user
+            // will not have any delagations or accounts
+            if (isPartyNotFoundError(err)) {
+              setDelegations([]);
+              setAccounts([]);
+              setDelegatedNodes([]);
+              setCurrentStakeAvailable(new BigNumber(0));
+              return;
+            }
             Sentry.captureException(err);
             // If query fails stop interval. Its almost certain that the query
             // will just continue to fail

--- a/apps/governance/src/components/vega-wallet/hooks.ts
+++ b/apps/governance/src/components/vega-wallet/hooks.ts
@@ -77,8 +77,6 @@ export const usePollForDelegations = () => {
           .then((res) => {
             if (!mounted) return;
 
-            console.log(res.error);
-
             const canonisedDelegations = removePaginationWrapper(
               res.data.party?.delegationsConnection?.edges
             );

--- a/apps/governance/src/lib/party.ts
+++ b/apps/governance/src/lib/party.ts
@@ -1,0 +1,8 @@
+export const PARTY_NOT_FOUND = 'failed to get party for ID';
+
+export const isPartyNotFoundError = (error: { message: string }) => {
+  if (error.message.includes(PARTY_NOT_FOUND)) {
+    return true;
+  }
+  return false;
+};

--- a/apps/governance/src/routes/staking/node/nodes-container.tsx
+++ b/apps/governance/src/routes/staking/node/nodes-container.tsx
@@ -9,6 +9,7 @@ import { usePreviousEpochQuery } from '../__generated__/PreviousEpoch';
 import type { ReactElement } from 'react';
 import type { StakingQuery } from '../__generated__/Staking';
 import type { PreviousEpochQuery } from '../__generated__/PreviousEpoch';
+import { isPartyNotFoundError } from '../../../lib/party';
 
 // TODO should only request a single node. When migrating from deprecated APIs we should address this.
 
@@ -50,7 +51,7 @@ export const NodeContainer = ({
 
   useRefreshAfterEpoch(data?.epoch.timestamps.expiry, refetch);
 
-  if (error && !error.message.includes('failed to get party for ID')) {
+  if (error && !isPartyNotFoundError(error)) {
     return (
       <Callout intent={Intent.Danger} title={t('Something went wrong')}>
         <pre>


### PR DESCRIPTION
# Related issues 🔗

Closes #3085 

# Description ℹ️

- If query errors check, if its a party not found error, if it is clear wallet state
- de-dupe magic strings for error checking