### PR TITLE
feat(trading): do not show oracle banner when data is loading

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -5,7 +5,7 @@ import { AssetDetailsTable, useAssetDataProvider } from '@vegaprotocol/assets';
 import { t } from '@vegaprotocol/i18n';
 import { marketDataProvider } from '../../market-data-provider';
 import { totalFeesPercentage } from '../../market-utils';
-import { Dialog, ExternalLink, Splash } from '@vegaprotocol/ui-toolkit';
+import { ExternalLink, Splash } from '@vegaprotocol/ui-toolkit';
 import {
   addDecimalsFormatNumber,
   formatNumber,
@@ -25,12 +25,9 @@ import { ConditionOperatorMapping } from '@vegaprotocol/types';
 import { MarketTradingModeMapping } from '@vegaprotocol/types';
 import { useEnvironment } from '@vegaprotocol/environment';
 import type { Provider } from '../../oracle-schema';
-import {
-  OracleBasicProfile,
-  OracleProfileTitle,
-  OracleFullProfile,
-} from '../../components';
-import { useOracleProofs, useOracleMarkets } from '../../hooks';
+import { OracleBasicProfile } from '../../components/oracle-basic-profile';
+import { useOracleProofs } from '../../hooks';
+import { OracleDialog } from '../oracle-dialog/oracle-dialog';
 import { useDataProvider } from '@vegaprotocol/data-provider';
 
 type PanelProps = Pick<
@@ -610,34 +607,6 @@ const NoOracleProof = ({
         type === 'settlementData' ? 'settlement data' : 'termination'
       )}
     </p>
-  );
-};
-
-export const OracleDialog = ({
-  provider,
-  dataSourceSpecId,
-  open,
-  onChange,
-}: {
-  dataSourceSpecId: string;
-  provider: Provider;
-  open: boolean;
-  onChange?: (isOpen: boolean) => void;
-}) => {
-  const oracleMarkets = useOracleMarkets(provider);
-  return (
-    <Dialog
-      title={<OracleProfileTitle provider={provider} />}
-      aria-labelledby="oracle-proof-dialog"
-      open={open}
-      onChange={onChange}
-    >
-      <OracleFullProfile
-        provider={provider}
-        dataSourceSpecId={dataSourceSpecId}
-        markets={oracleMarkets}
-      />
-    </Dialog>
   );
 };
 

--- a/libs/markets/src/lib/components/market-info/market-info.mock.ts
+++ b/libs/markets/src/lib/components/market-info/market-info.mock.ts
@@ -143,7 +143,7 @@ export const marketInfoQuery = (
                         __typename: 'Signer',
                         signer: {
                           __typename: 'PubKey',
-                          key: '69464e35bcb8e8a2900ca0f87acaf252d50cf2ab2fc73694845a16b7c8a0dc6f',
+                          key: '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61',
                         },
                       },
                     ],
@@ -164,7 +164,7 @@ export const marketInfoQuery = (
                         __typename: 'Signer',
                         signer: {
                           __typename: 'PubKey',
-                          key: '69464e35bcb8e8a2900ca0f87acaf252d50cf2ab2fc73694845a16b7c8a0dc6f',
+                          key: '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61',
                         },
                       },
                     ],

--- a/libs/markets/src/lib/components/markets-container/oracle-status.tsx
+++ b/libs/markets/src/lib/components/markets-container/oracle-status.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 import { useEnvironment } from '@vegaprotocol/environment';
-import { t } from '@vegaprotocol/i18n';
+import { Icon } from '@vegaprotocol/ui-toolkit';
+import type { IconName } from '@blueprintjs/icons';
 import { getMatchingOracleProvider, useOracleProofs } from '../../hooks';
 import type { Market } from '../../markets-provider';
+import { getVerifiedStatusIcon } from '../oracle-basic-profile';
 
 export const OracleStatus = ({
   dataSourceSpecForSettlementData,
@@ -23,22 +25,15 @@ export const OracleStatus = ({
         dataSourceSpecForTradingTermination.data,
         providers
       );
-      if (
-        (settlementDataProvider &&
-          settlementDataProvider.oracle.status !== 'GOOD') ||
-        (tradingTerminationDataProvider &&
-          tradingTerminationDataProvider.oracle.status !== 'GOOD')
-      ) {
-        return (
-          <span
-            className="ml-1"
-            role="img"
-            aria-label={t('oracle status not healthy')}
-          >
-            ⛔
-          </span>
-        );
+      let maliciousOracleProvider = null;
+      if (settlementDataProvider?.oracle.status !== 'GOOD') {
+        maliciousOracleProvider = settlementDataProvider;
+      } else if (tradingTerminationDataProvider?.oracle.status !== 'GOOD') {
+        maliciousOracleProvider = tradingTerminationDataProvider;
       }
+      if (!maliciousOracleProvider) return null;
+      const { icon } = getVerifiedStatusIcon(maliciousOracleProvider);
+      return <Icon size={3} name={icon as IconName} className="ml-1" />;
     }
     return null;
   }, [

--- a/libs/markets/src/lib/components/oracle-banner/oracle-banner.tsx
+++ b/libs/markets/src/lib/components/oracle-banner/oracle-banner.tsx
@@ -6,30 +6,20 @@ import {
   NotificationBanner,
   ButtonLink,
 } from '@vegaprotocol/ui-toolkit';
-import { OracleDialog } from '../market-info';
-
-export const oracleStatuses = {
-  UNKNOWN: t(
-    "This public key's proofs have not been verified yet, or no proofs have been provided yet."
-  ),
-  GOOD: t("This public key's proofs have been verified."),
-  SUSPICIOUS: t(
-    'This public key is suspected to be acting in bad faith, pending investigation.'
-  ),
-  MALICIOUS: t('This public key has been observed acting in bad faith.'),
-  RETIRED: t('This public key is no longer in use.'),
-  COMPROMISED: t(
-    'This public key is no longer in the control of its original owners.'
-  ),
-};
+import { OracleDialog } from '../oracle-dialog';
+import { oracleStatuses } from './oracle-statuses';
 
 export const OracleBanner = ({ marketId }: { marketId: string }) => {
   const [open, onChange] = useState(false);
-  const settlementOracle = useMarketOracle(marketId);
-  const tradingTerminationOracle = useMarketOracle(
-    marketId,
-    'dataSourceSpecForTradingTermination'
-  );
+  const { data: settlementOracle, loading: settlementOracleLoading } =
+    useMarketOracle(marketId);
+  const {
+    data: tradingTerminationOracle,
+    loading: tradingTerminationOracleLoading,
+  } = useMarketOracle(marketId, 'dataSourceSpecForTradingTermination');
+  if (settlementOracleLoading || tradingTerminationOracleLoading) {
+    return null;
+  }
   let maliciousOracle = null;
   if (settlementOracle?.provider.oracle.status !== 'GOOD') {
     maliciousOracle = settlementOracle;

--- a/libs/markets/src/lib/components/oracle-banner/oracle-banner.tsx
+++ b/libs/markets/src/lib/components/oracle-banner/oracle-banner.tsx
@@ -11,30 +11,18 @@ import { oracleStatuses } from './oracle-statuses';
 
 export const OracleBanner = ({ marketId }: { marketId: string }) => {
   const [open, onChange] = useState(false);
-  const { data: settlementOracle, loading: settlementOracleLoading } =
-    useMarketOracle(marketId);
-  const {
-    data: tradingTerminationOracle,
-    loading: tradingTerminationOracleLoading,
-  } = useMarketOracle(marketId, 'dataSourceSpecForTradingTermination');
-  if (settlementOracleLoading || tradingTerminationOracleLoading) {
-    return null;
-  }
+  const { data: settlementOracle } = useMarketOracle(marketId);
+  const { data: tradingTerminationOracle } = useMarketOracle(
+    marketId,
+    'dataSourceSpecForTradingTermination'
+  );
   let maliciousOracle = null;
   if (settlementOracle?.provider.oracle.status !== 'GOOD') {
     maliciousOracle = settlementOracle;
   } else if (tradingTerminationOracle?.provider.oracle.status !== 'GOOD') {
     maliciousOracle = tradingTerminationOracle;
   }
-
   if (!maliciousOracle) return null;
-  if (!settlementOracle && !tradingTerminationOracle) {
-    return (
-      <NotificationBanner intent={Intent.Primary}>
-        <div>{t('There is no oracle for this market.')} </div>
-      </NotificationBanner>
-    );
-  }
 
   const { provider } = maliciousOracle;
   return (

--- a/libs/markets/src/lib/components/oracle-banner/oracle-statuses.ts
+++ b/libs/markets/src/lib/components/oracle-banner/oracle-statuses.ts
@@ -1,0 +1,16 @@
+import { t } from '@vegaprotocol/i18n';
+
+export const oracleStatuses = {
+  UNKNOWN: t(
+    "This public key's proofs have not been verified yet, or no proofs have been provided yet."
+  ),
+  GOOD: t("This public key's proofs have been verified."),
+  SUSPICIOUS: t(
+    'This public key is suspected to be acting in bad faith, pending investigation.'
+  ),
+  MALICIOUS: t('This public key has been observed acting in bad faith.'),
+  RETIRED: t('This public key is no longer in use.'),
+  COMPROMISED: t(
+    'This public key is no longer in the control of its original owners.'
+  ),
+};

--- a/libs/markets/src/lib/components/oracle-dialog/index.tsx
+++ b/libs/markets/src/lib/components/oracle-dialog/index.tsx
@@ -1,0 +1,1 @@
+export * from './oracle-dialog';

--- a/libs/markets/src/lib/components/oracle-dialog/oracle-dialog.tsx
+++ b/libs/markets/src/lib/components/oracle-dialog/oracle-dialog.tsx
@@ -1,0 +1,35 @@
+import { Dialog } from '@vegaprotocol/ui-toolkit';
+import {
+  OracleProfileTitle,
+  OracleFullProfile,
+} from '../../components/oracle-full-profile';
+import { useOracleMarkets } from '../../hooks';
+import type { Provider } from '../../oracle-schema';
+
+export const OracleDialog = ({
+  provider,
+  dataSourceSpecId,
+  open,
+  onChange,
+}: {
+  dataSourceSpecId: string;
+  provider: Provider;
+  open: boolean;
+  onChange?: (isOpen: boolean) => void;
+}) => {
+  const oracleMarkets = useOracleMarkets(provider);
+  return (
+    <Dialog
+      title={<OracleProfileTitle provider={provider} />}
+      aria-labelledby="oracle-proof-dialog"
+      open={open}
+      onChange={onChange}
+    >
+      <OracleFullProfile
+        provider={provider}
+        dataSourceSpecId={dataSourceSpecId}
+        markets={oracleMarkets}
+      />
+    </Dialog>
+  );
+};

--- a/libs/markets/src/lib/components/oracle-full-profile/index.ts
+++ b/libs/markets/src/lib/components/oracle-full-profile/index.ts
@@ -1,2 +1,1 @@
-export * from './oracle-full-profile.stories';
 export * from './oracle-full-profile';

--- a/libs/markets/src/lib/components/oracle-full-profile/oracle-full-profile.tsx
+++ b/libs/markets/src/lib/components/oracle-full-profile/oracle-full-profile.tsx
@@ -9,7 +9,7 @@ import {
   VegaIcon,
   VegaIconNames,
 } from '@vegaprotocol/ui-toolkit';
-import { oracleStatuses } from '../oracle-banner';
+import { oracleStatuses } from '../oracle-banner/oracle-statuses';
 import type { IconName } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import { getLinkIcon, getVerifiedStatusIcon } from '../oracle-basic-profile';

--- a/libs/markets/src/lib/hooks/use-market-oracle.ts
+++ b/libs/markets/src/lib/hooks/use-market-oracle.ts
@@ -1,7 +1,7 @@
 import { useEnvironment } from '@vegaprotocol/environment';
 import { useOracleProofs } from './use-oracle-proofs';
-import { useDataProvider } from '@vegaprotocol/data-provider';
-import { marketInfoProvider } from '../components/market-info/market-info-data-provider';
+import { useMarket } from '../markets-provider';
+
 import { useMemo } from 'react';
 import type { Provider } from '../oracle-schema';
 import type { DataSourceSpecFragment } from '../__generated__/OracleMarketsSpec';
@@ -41,23 +41,30 @@ export const useMarketOracle = (
   dataSourceType:
     | 'dataSourceSpecForSettlementData'
     | 'dataSourceSpecForTradingTermination' = 'dataSourceSpecForSettlementData'
-) => {
+): {
+  data?: {
+    provider: NonNullable<ReturnType<typeof getMatchingOracleProvider>>;
+    dataSourceSpecId: string;
+  };
+  loading?: boolean;
+} => {
   const { ORACLE_PROOFS_URL } = useEnvironment();
-  const { data: marketInfo } = useDataProvider({
-    dataProvider: marketInfoProvider,
-    variables: { marketId },
-  });
-  const { data: providers } = useOracleProofs(ORACLE_PROOFS_URL);
+  const { data: market, loading: marketLoading } = useMarket(marketId);
+  const { data: providers, loading: providersLoading } =
+    useOracleProofs(ORACLE_PROOFS_URL);
   return useMemo(() => {
-    if (!providers || !marketInfo) {
-      return undefined;
+    if (marketLoading || providersLoading) {
+      return { loading: true };
+    }
+    if (!providers || !market) {
+      return { data: undefined };
     }
     const dataSourceSpec =
-      marketInfo.tradableInstrument.instrument.product[dataSourceType];
+      market.tradableInstrument.instrument.product[dataSourceType];
     const provider = getMatchingOracleProvider(dataSourceSpec.data, providers);
     if (provider) {
-      return { provider, dataSourceSpecId: dataSourceSpec.id };
+      return { data: { provider, dataSourceSpecId: dataSourceSpec.id } };
     }
-    return undefined;
-  }, [marketInfo, dataSourceType, providers]);
+    return { data: undefined };
+  }, [market, dataSourceType, providers, marketLoading, providersLoading]);
 };

--- a/libs/markets/src/lib/markets.mock.ts
+++ b/libs/markets/src/lib/markets.mock.ts
@@ -64,26 +64,44 @@ export const createMarketFragment = (
           },
           dataSourceSpecForTradingTermination: {
             __typename: 'DataSourceSpec',
-            id: 'oracleId',
+            id: 'f028fe5ea7de3890962a05a7163fdde562629af649ed81b8c8902fafb6eef04f',
             data: {
               __typename: 'DataSourceDefinition',
               sourceType: {
                 __typename: 'DataSourceDefinitionExternal',
                 sourceType: {
                   __typename: 'DataSourceSpecConfiguration',
+                  signers: [
+                    {
+                      __typename: 'Signer',
+                      signer: {
+                        __typename: 'PubKey',
+                        key: '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61',
+                      },
+                    },
+                  ],
                 },
               },
             },
           },
           dataSourceSpecForSettlementData: {
             __typename: 'DataSourceSpec',
-            id: 'oracleId',
+            id: 'f028fe5ea7de3890962a05a7163fdde562629af649ed81b8c8902fafb6eef04f',
             data: {
               __typename: 'DataSourceDefinition',
               sourceType: {
                 __typename: 'DataSourceDefinitionExternal',
                 sourceType: {
                   __typename: 'DataSourceSpecConfiguration',
+                  signers: [
+                    {
+                      __typename: 'Signer',
+                      signer: {
+                        __typename: 'PubKey',
+                        key: '6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61',
+                      },
+                    },
+                  ],
                 },
               },
             },


### PR DESCRIPTION
# Description ℹ️

Change source of data source specs from market info query to markets query in useMarketOracle hook.
If data needed in oracle banner is loading return null instead of no oracle notification

