### PR TITLE
fix(explorer): prevent render of signature component on some proposals

### DIFF
--- a/apps/explorer/src/app/components/txs/details/tx-proposal.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.spec.tsx
@@ -1,0 +1,56 @@
+import type { Proposal } from './tx-proposal';
+import { proposalRequiresSignatureBundle } from './tx-proposal';
+
+describe('proposalRequiresSignatureBundle', () => {
+  it('should return false for freeform proposals, which do not require a signature bundle to enact', () => {
+    const mock = {
+      terms: {
+        newFreeform: {},
+      },
+    };
+
+    expect(proposalRequiresSignatureBundle(mock)).toEqual(false);
+  });
+
+  it('should return false for newMarket proposals, which do not require a signature bundle to enact', () => {
+    const mock = {
+      terms: {
+        newMarket: {},
+      },
+    };
+
+    expect(proposalRequiresSignatureBundle(mock)).toEqual(false);
+  });
+
+  it('should return true for newAsset proposals, which do require a signature bundle to enact', () => {
+    const mock = {
+      terms: {
+        newAsset: {},
+      },
+    };
+
+    expect(proposalRequiresSignatureBundle(mock)).toEqual(true);
+  });
+
+  it('should return true for updateAsset proposals, which do require a signature bundle to enact', () => {
+    const mock = {
+      terms: {
+        updateAsset: {},
+      },
+    };
+
+    expect(proposalRequiresSignatureBundle(mock)).toEqual(true);
+  });
+
+  it('should return false when bad data is supplied', () => {
+    expect(
+      proposalRequiresSignatureBundle(false as unknown as Proposal)
+    ).toEqual(false);
+    expect(
+      proposalRequiresSignatureBundle(undefined as unknown as Proposal)
+    ).toEqual(false);
+    expect(
+      proposalRequiresSignatureBundle({ test: false } as unknown as Proposal)
+    ).toEqual(false);
+  });
+});

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -28,11 +28,16 @@ interface TxProposalProps {
  * @returns boolean True if a signature bundle is required. Used to fetch a signature bundle
  */
 export function proposalRequiresSignatureBundle(proposal?: Proposal): boolean {
+  const proposalsThatRequireBundles = ['newAsset', 'updateAsset'];
+
   if (!proposal?.terms) {
     return false;
   }
-  return !!['newAsset', 'updateAsset'].filter((requiredIfExists) =>
-    has(proposal.terms, requiredIfExists)
+
+  return (
+    proposalsThatRequireBundles.filter((requiredIfExists) =>
+      has(proposal.terms, requiredIfExists)
+    ).length > 0
   );
 }
 
@@ -81,6 +86,7 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
 
   const tx = proposal.terms?.newAsset || proposal.terms?.updateAsset;
 
+  // This component is not rendered if no bundle is required
   const SignatureBundleComponent = proposal.terms?.newAsset
     ? ProposalSignatureBundleNewAsset
     : ProposalSignatureBundleUpdateAsset;


### PR DESCRIPTION
# Related issues 🔗

Closes #3834

# Description ℹ️
A console error was being thrown on Explorer when viewing some proposal transactions. This was because the logic detecting if the proposal required a signature bundle was flawed. 

- Fix function that decides if signature bundle is required
