### PR TITLE
fix(governance): adjust proposals sort order

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.spec.tsx
@@ -14,7 +14,7 @@ import {
   lastMonth,
   nextMonth,
 } from '../../test-helpers/mocks';
-import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
+import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 
 const openProposalClosesNextMonth = generateProposal({
   id: 'proposal1',
@@ -54,7 +54,7 @@ const failedProposalClosedLastMonth = generateProposal({
   },
 });
 
-const renderComponent = (proposals: ProposalQuery['proposal'][]) => (
+const renderComponent = (proposals: ProposalFieldsFragment[]) => (
   <Router>
     <MockedProvider mocks={[networkParamsQueryMock]}>
       <AppStateProvider>
@@ -132,10 +132,10 @@ describe('Proposals list', () => {
     const closedProposalsItems = closedProposals.getAllByTestId(
       'proposals-list-item'
     );
-    expect(openProposalsItems[0]).toHaveAttribute('id', 'proposal1');
-    expect(openProposalsItems[1]).toHaveAttribute('id', 'proposal2');
-    expect(closedProposalsItems[0]).toHaveAttribute('id', 'proposal4');
-    expect(closedProposalsItems[1]).toHaveAttribute('id', 'proposal3');
+    expect(openProposalsItems[0]).toHaveAttribute('id', 'proposal2');
+    expect(openProposalsItems[1]).toHaveAttribute('id', 'proposal1');
+    expect(closedProposalsItems[0]).toHaveAttribute('id', 'proposal3');
+    expect(closedProposalsItems[1]).toHaveAttribute('id', 'proposal4');
   });
 
   it('Displays info on no proposals', () => {

--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
@@ -9,20 +9,23 @@ import Routes from '../../../routes';
 import { Button, VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 import { Link } from 'react-router-dom';
 import { ExternalLink } from '@vegaprotocol/ui-toolkit';
-import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
 import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 import type { ProtocolUpgradeProposalFieldsFragment } from '@vegaprotocol/proposals';
 import { DocsLinks, ExternalLinks } from '@vegaprotocol/environment';
+import {
+  orderByDateAsc,
+  orderByDateDesc,
+} from '../../proposals/proposals-container';
 
 interface ProposalsListProps {
-  proposals: Array<ProposalFieldsFragment | ProposalQuery['proposal']>;
+  proposals: Array<ProposalFieldsFragment>;
   protocolUpgradeProposals: ProtocolUpgradeProposalFieldsFragment[];
   lastBlockHeight?: string;
 }
 
 interface SortedProposalsProps {
-  open: Array<ProposalFieldsFragment | ProposalQuery['proposal']>;
-  closed: Array<ProposalFieldsFragment | ProposalQuery['proposal']>;
+  open: Array<ProposalFieldsFragment>;
+  closed: Array<ProposalFieldsFragment>;
 }
 
 interface SortedProtocolUpgradeProposalsProps {
@@ -52,6 +55,11 @@ export const ProposalsList = ({
     }
   );
 
+  const orderedProposals = {
+    open: orderByDateAsc(sortedProposals?.open),
+    closed: orderByDateDesc(sortedProposals.closed),
+  };
+
   const sortedProtocolUpgradeProposals = protocolUpgradeProposals.reduce(
     (acc: SortedProtocolUpgradeProposalsProps, proposal) => {
       if (Number(proposal?.upgradeBlockHeight) > Number(lastBlockHeight)) {
@@ -67,9 +75,7 @@ export const ProposalsList = ({
     }
   );
 
-  const filterPredicate = (
-    p: ProposalFieldsFragment | ProposalQuery['proposal']
-  ) =>
+  const filterPredicate = (p: ProposalFieldsFragment) =>
     p?.id?.includes(filterString) ||
     p?.party?.id?.toString().includes(filterString);
 
@@ -111,7 +117,7 @@ export const ProposalsList = ({
       )}
       <section className="-mx-4 p-4 mb-8 bg-vega-dark-100">
         <SubHeading title={t('openProposals')} />
-        {sortedProposals.open.length > 0 ||
+        {orderedProposals.open.length > 0 ||
         sortedProtocolUpgradeProposals.open.length > 0 ? (
           <ul data-testid="open-proposals">
             {sortedProtocolUpgradeProposals.open.map((proposal) => (
@@ -120,7 +126,7 @@ export const ProposalsList = ({
                 proposal={proposal}
               />
             ))}
-            {sortedProposals.open.filter(filterPredicate).map((proposal) => (
+            {orderedProposals.open.filter(filterPredicate).map((proposal) => (
               <ProposalsListItem key={proposal?.id} proposal={proposal} />
             ))}
           </ul>
@@ -132,7 +138,7 @@ export const ProposalsList = ({
       </section>
       <section>
         <SubHeading title={t('closedProposals')} />
-        {sortedProposals.closed.length > 0 ||
+        {orderedProposals.closed.length > 0 ||
         sortedProtocolUpgradeProposals.closed.length > 0 ? (
           <ul data-testid="closed-proposals">
             {sortedProtocolUpgradeProposals.closed.map((proposal) => (
@@ -142,7 +148,7 @@ export const ProposalsList = ({
               />
             ))}
 
-            {sortedProposals.closed.filter(filterPredicate).map((proposal) => (
+            {orderedProposals.closed.filter(filterPredicate).map((proposal) => (
               <ProposalsListItem key={proposal?.id} proposal={proposal} />
             ))}
           </ul>

--- a/apps/governance/src/routes/proposals/proposal/proposal-container.tsx
+++ b/apps/governance/src/routes/proposals/proposal/proposal-container.tsx
@@ -13,7 +13,7 @@ export const ProposalContainer = () => {
   const {
     state: { loading: restLoading, error: restError, data: restData },
   } = useFetch(`${ENV.rest}governance?proposalId=${params.proposalId}`);
-  console.log(restLoading, restError, restData);
+
   const { data, loading, error, refetch } = useProposalQuery({
     fetchPolicy: 'network-only',
     errorPolicy: 'ignore',
@@ -27,7 +27,11 @@ export const ProposalContainer = () => {
   }, [refetch]);
 
   return (
-    <AsyncRenderer loading={loading} error={error} data={data}>
+    <AsyncRenderer
+      loading={loading || !!restLoading}
+      error={error || restError}
+      data={data}
+    >
       {data?.proposal ? (
         <Proposal proposal={data.proposal} restData={restData} />
       ) : (

--- a/apps/governance/src/routes/proposals/proposals/proposals-container.tsx
+++ b/apps/governance/src/routes/proposals/proposals/proposals-container.tsx
@@ -17,7 +17,7 @@ import orderBy from 'lodash/orderBy';
 import type { ProtocolUpgradeProposalFieldsFragment } from '@vegaprotocol/proposals';
 import { useProtocolUpgradeProposalsQuery } from '@vegaprotocol/proposals';
 
-const orderByDate = (arr: ProposalFieldsFragment[]) =>
+export const orderByDateAsc = (arr: ProposalFieldsFragment[]) =>
   orderBy(
     arr,
     [
@@ -25,6 +25,16 @@ const orderByDate = (arr: ProposalFieldsFragment[]) =>
       (p) => new Date(p?.datetime).getTime(),
     ],
     ['asc', 'asc']
+  );
+
+export const orderByDateDesc = (arr: ProposalFieldsFragment[]) =>
+  orderBy(
+    arr,
+    [
+      (p) => new Date(p?.terms?.closingDatetime).getTime(),
+      (p) => new Date(p?.datetime).getTime(),
+    ],
+    ['desc', 'desc']
   );
 
 const orderByUpgradeBlockHeight = (
@@ -39,13 +49,9 @@ const orderByUpgradeBlockHeight = (
 export function getNotRejectedProposals<T extends ProposalFieldsFragment>(
   data?: NodeConnection<NodeEdge<T>> | null
 ): T[] {
-  return flow([
-    (data) =>
-      getNodes<ProposalFieldsFragment>(data, (p) =>
-        p ? p.state !== ProposalState.STATE_REJECTED : false
-      ),
-    orderByDate,
-  ])(data);
+  return getNodes(data, (p) =>
+    p ? p.state !== ProposalState.STATE_REJECTED : false
+  );
 }
 
 export function getNotRejectedProtocolUpgradeProposals<

--- a/apps/governance/src/routes/proposals/rejected/rejected-proposals-container.tsx
+++ b/apps/governance/src/routes/proposals/rejected/rejected-proposals-container.tsx
@@ -16,11 +16,10 @@ const orderByDate = (arr: ProposalFieldsFragment[]) =>
   orderBy(
     arr,
     [
-      (p) => new Date(p?.terms?.enactmentDatetime || 0).getTime(), // has to be defaulted to 0 because new Date(null).getTime() -> NaN which is first when ordered.
-      (p) => new Date(p?.terms?.closingDatetime).getTime(),
+      (p) => new Date(p?.terms?.closingDatetime || 0).getTime(), // has to be defaulted to 0 because new Date(null).getTime() -> NaN which is first when ordered.
       (p) => p.id,
     ],
-    ['desc', 'desc', 'desc']
+    ['desc', 'desc']
   );
 
 export function getRejectedProposals<T extends ProposalFieldsFragment>(

--- a/apps/governance/src/routes/proposals/test-helpers/generate-proposals.ts
+++ b/apps/governance/src/routes/proposals/test-helpers/generate-proposals.ts
@@ -5,12 +5,12 @@ import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
 
 import type { PartialDeep } from 'type-fest';
-import type { ProposalQuery } from '../proposal/__generated__/Proposal';
+import type { ProposalFieldsFragment } from '../proposals/__generated__/Proposals';
 
 export function generateProposal(
-  override: PartialDeep<ProposalQuery['proposal']> = {}
-): ProposalQuery['proposal'] {
-  const defaultProposal: ProposalQuery['proposal'] = {
+  override: PartialDeep<ProposalFieldsFragment> = {}
+): ProposalFieldsFragment {
+  const defaultProposal: ProposalFieldsFragment = {
     __typename: 'Proposal',
     id: faker.datatype.uuid(),
     rationale: {
@@ -57,15 +57,16 @@ export function generateProposal(
     },
   };
 
-  return mergeWith<
-    ProposalQuery['proposal'],
-    PartialDeep<ProposalQuery['proposal']>
-  >(defaultProposal, override, (objValue, srcValue) => {
-    if (!isArray(objValue)) {
-      return;
+  return mergeWith<ProposalFieldsFragment, PartialDeep<ProposalFieldsFragment>>(
+    defaultProposal,
+    override,
+    (objValue, srcValue) => {
+      if (!isArray(objValue)) {
+        return;
+      }
+      return srcValue;
     }
-    return srcValue;
-  });
+  );
 }
 
 type Vote = Pick<Schema.Vote, '__typename' | 'value' | 'party' | 'datetime'>;


### PR DESCRIPTION
# Related issues 🔗

Closes #3823

# Description ℹ️

Before (note closed proposals date):

<img width="1103" alt="Screenshot 2023-05-19 at 12 17 59" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/75b53442-d76d-4fb6-9236-1d3108911154">

After: 

<img width="1093" alt="Screenshot 2023-05-19 at 12 17 50" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/b570f377-5df4-487b-828f-94819a93525c">

Also simplified proposal type definitions

