### PR TITLE
feat(governance): avoid showing untitled proposals

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.spec.tsx
@@ -124,7 +124,7 @@ describe('Proposal header', () => {
       })
     );
     expect(screen.getByTestId('proposal-title')).toHaveTextContent(
-      'Unknown proposal'
+      'New asset proposal'
     );
     expect(screen.getByTestId('proposal-type')).toHaveTextContent('New asset');
     expect(screen.getByTestId('proposal-details')).toHaveTextContent(

--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
@@ -21,6 +21,7 @@ export const ProposalHeader = ({
 
   let details: ReactNode;
   let proposalType = '';
+  let fallbackTitle = '';
 
   const title = proposal?.rationale.title.trim();
 
@@ -29,6 +30,7 @@ export const ProposalHeader = ({
   switch (change?.__typename) {
     case 'NewMarket': {
       proposalType = 'NewMarket';
+      fallbackTitle = t('NewMarketProposal');
       details = (
         <>
           <span>
@@ -50,6 +52,7 @@ export const ProposalHeader = ({
     }
     case 'UpdateMarket': {
       proposalType = 'UpdateMarket';
+      fallbackTitle = t('UpdateMarketProposal');
       details = (
         <>
           <span>{t('Market change')}:</span>{' '}
@@ -60,6 +63,7 @@ export const ProposalHeader = ({
     }
     case 'NewAsset': {
       proposalType = 'NewAsset';
+      fallbackTitle = t('NewAssetProposal');
       details = (
         <>
           <span>{t('Symbol')}:</span> <Lozenge>{change.symbol}.</Lozenge>{' '}
@@ -81,6 +85,7 @@ export const ProposalHeader = ({
     }
     case 'UpdateNetworkParameter': {
       proposalType = 'NetworkParameter';
+      fallbackTitle = t('NetworkParameterProposal');
       details = (
         <>
           <span>{t('Change')}:</span>{' '}
@@ -95,11 +100,13 @@ export const ProposalHeader = ({
     }
     case 'NewFreeform': {
       proposalType = 'Freeform';
+      fallbackTitle = t('FreeformProposal');
       details = <span />;
       break;
     }
     case 'UpdateAsset': {
       proposalType = 'UpdateAsset';
+      fallbackTitle = t('UpdateAssetProposal');
       details = (
         <>
           <span>{t('AssetID')}:</span>{' '}
@@ -115,10 +122,14 @@ export const ProposalHeader = ({
       <div data-testid="proposal-title">
         {isListItem ? (
           <header>
-            <SubHeading title={titleContent || t('Unknown proposal')} />
+            <SubHeading
+              title={titleContent || fallbackTitle || t('Unknown proposal')}
+            />
           </header>
         ) : (
-          <Heading title={titleContent || t('Unknown proposal')} />
+          <Heading
+            title={titleContent || fallbackTitle || t('Unknown proposal')}
+          />
         )}
       </div>
 

--- a/apps/governance/src/routes/proposals/propose/freeform/propose-freeform.tsx
+++ b/apps/governance/src/routes/proposals/propose/freeform/propose-freeform.tsx
@@ -49,6 +49,7 @@ export const ProposeFreeform = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<FreeformProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -85,7 +86,13 @@ export const ProposeFreeform = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),

--- a/apps/governance/src/routes/proposals/propose/network-parameter/propose-network-parameter.tsx
+++ b/apps/governance/src/routes/proposals/propose/network-parameter/propose-network-parameter.tsx
@@ -89,6 +89,7 @@ export const ProposeNetworkParameter = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<NetworkParameterProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -148,7 +149,13 @@ export const ProposeNetworkParameter = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),

--- a/apps/governance/src/routes/proposals/propose/new-asset/propose-new-asset.tsx
+++ b/apps/governance/src/routes/proposals/propose/new-asset/propose-new-asset.tsx
@@ -61,6 +61,7 @@ export const ProposeNewAsset = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<NewAssetProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -117,7 +118,13 @@ export const ProposeNewAsset = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),

--- a/apps/governance/src/routes/proposals/propose/new-market/propose-new-market.tsx
+++ b/apps/governance/src/routes/proposals/propose/new-market/propose-new-market.tsx
@@ -59,6 +59,7 @@ export const ProposeNewMarket = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<NewMarketProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -107,7 +108,13 @@ export const ProposeNewMarket = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),

--- a/apps/governance/src/routes/proposals/propose/update-asset/propose-update-asset.tsx
+++ b/apps/governance/src/routes/proposals/propose/update-asset/propose-update-asset.tsx
@@ -59,6 +59,7 @@ export const ProposeUpdateAsset = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<UpdateAssetProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -107,7 +108,13 @@ export const ProposeUpdateAsset = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),

--- a/apps/governance/src/routes/proposals/propose/update-market/propose-update-market.tsx
+++ b/apps/governance/src/routes/proposals/propose/update-market/propose-update-market.tsx
@@ -106,6 +106,7 @@ export const ProposeUpdateMarket = () => {
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<UpdateMarketProposalFormFields>();
   const { finalizedProposal, submit, Dialog } = useProposalSubmit();
 
@@ -157,7 +158,13 @@ export const ProposeUpdateMarket = () => {
     await submit(assembleProposal(fields));
   };
 
-  const viewJson = () => {
+  const viewJson = async () => {
+    const isValid = await trigger();
+
+    if (!isValid) {
+      return;
+    }
+
     const formData = watch();
     downloadJson(
       JSON.stringify(assembleProposal(formData)),


### PR DESCRIPTION
# Related issues 🔗

Closes #3835

# Description ℹ️

A proposal had been submitted without a title, resulting in the fallback 'unknown proposal' title. To improve this, I've:

- Set useForm's validation to run when the 'download proposal json' button is clicked (i.e. they'll get notified of required fields) and the button won't work until they're filled in
- Set up some better fallbacks if a user has removed the title from their json (now shows 'New market proposal', 'Update asset proposal' etc instead of 'unknown proposal'

<img width="1139" alt="Screenshot 2023-05-19 at 14 46 57" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/d0e9cbc9-571d-43b2-b98f-b4973a350a32">

<img width="1116" alt="Screenshot 2023-05-19 at 14 49 04" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/168b4895-c1a6-449e-a792-56d0e2bb0621">

