### PR TITLE
fix(governance): homepage proposals ordering fixed

### DIFF
--- a/apps/governance/src/routes/home/index.tsx
+++ b/apps/governance/src/routes/home/index.tsx
@@ -209,7 +209,10 @@ const GovernanceHome = ({ name }: RouteChildProps) => {
     [proposalsData]
   );
 
-  const sortedProposals = useMemo(() => orderByDate(proposals), [proposals]);
+  const sortedProposals = useMemo(
+    () => orderByDate(proposals).reverse(),
+    [proposals]
+  );
 
   const protocolUpgradeProposals = useMemo(
     () =>


### PR DESCRIPTION
# Related issues 🔗

Closes #3855

# Description ℹ️

After a recent change to ordering on the proposals list, the homepage proposals had inadvertently been changed too. This now correctly sets them to latest closing date first
