### PR TITLE
chore(explorer): update be env for validator testnet

### DIFF
--- a/apps/explorer/.env.validators-testnet
+++ b/apps/explorer/.env.validators-testnet
@@ -8,7 +8,7 @@ NX_ETHERSCAN_URL=https://sepolia.etherscan.io
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.json
 
 NX_VEGA_GOVERNANCE_URL=https://validator-testnet.governance.vega.xyz
-NX_TENDERMINT_URL=https://tm-be.validators-testnet.vega.rocks
+NX_TENDERMINT_URL=https://tm.be.validators-testnet.vega.rocks
 NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.rocks/rest
 NX_TENDERMINT_WEBSOCKET_URL=wss://be.validators-testnet.vega.xyz/websocket
 NX_VEGA_EXPLORER_URL=https://validator-testnet.explorer.vega.xyz/

--- a/apps/explorer/.env.validators-testnet
+++ b/apps/explorer/.env.validators-testnet
@@ -11,4 +11,4 @@ NX_VEGA_GOVERNANCE_URL=https://validator-testnet.governance.vega.xyz
 NX_TENDERMINT_URL=https://tm.be.validators-testnet.vega.rocks
 NX_BLOCK_EXPLORER=https://be.validators-testnet.vega.rocks/rest
 NX_TENDERMINT_WEBSOCKET_URL=wss://be.validators-testnet.vega.xyz/websocket
-NX_VEGA_EXPLORER_URL=https://validator-testnet.explorer.vega.xyz/
+NX_VEGA_EXPLORER_URL=https://explorer.validators-testnet.vega.rocks/


### PR DESCRIPTION
The DNS changed recently. This fixes the Blocks view on the validator-testnet deployment.