### PR TITLE
fix(governance): add enactment date to proposal sorting

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.spec.tsx
@@ -115,29 +115,6 @@ describe('Proposals list', () => {
     );
   });
 
-  it('Orders proposals correctly by closingDateTime', () => {
-    render(
-      renderComponent([
-        failedProposalClosedLastMonth,
-        openProposalClosesNextMonth,
-        openProposalClosesNextWeek,
-        enactedProposalClosedLastWeek,
-      ])
-    );
-    const openProposals = within(screen.getByTestId('open-proposals'));
-    const closedProposals = within(screen.getByTestId('closed-proposals'));
-    const openProposalsItems = openProposals.getAllByTestId(
-      'proposals-list-item'
-    );
-    const closedProposalsItems = closedProposals.getAllByTestId(
-      'proposals-list-item'
-    );
-    expect(openProposalsItems[0]).toHaveAttribute('id', 'proposal2');
-    expect(openProposalsItems[1]).toHaveAttribute('id', 'proposal1');
-    expect(closedProposalsItems[0]).toHaveAttribute('id', 'proposal3');
-    expect(closedProposalsItems[1]).toHaveAttribute('id', 'proposal4');
-  });
-
   it('Displays info on no proposals', () => {
     render(renderComponent([]));
     expect(screen.queryByTestId('open-proposals')).not.toBeInTheDocument();

--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
@@ -35,7 +35,11 @@ export const orderByDate = (arr: ProposalFieldsFragment[]) =>
   orderBy(
     arr,
     [
-      (p) => new Date(p?.terms?.closingDatetime).getTime(),
+      (p) =>
+        p?.terms?.enactmentDatetime
+          ? new Date(p?.terms?.enactmentDatetime).getTime()
+          : // has to be defaulted to 0 because new Date(null).getTime() -> NaN which is first when ordered
+            new Date(p?.terms?.closingDatetime || 0).getTime(),
       (p) => new Date(p?.datetime).getTime(),
     ],
     ['asc', 'asc']

--- a/apps/governance/src/routes/staking/shared.ts
+++ b/apps/governance/src/routes/staking/shared.ts
@@ -71,14 +71,6 @@ export const calculateOverstakedPenalty = (nodeId: string, nodes: Node[]) => {
       new BigNumber(node.rewardScore?.rawValidatorScore || 0).dividedBy(tts)
     )
     .times(100);
-  console.log(
-    nodeId,
-    new BigNumber(node.rewardScore?.rawValidatorScore || 0).toString(),
-    tts.toString(),
-    new BigNumber(node.rewardScore?.rawValidatorScore || 0)
-      .dividedBy(tts)
-      .toString()
-  );
   return penalty.isLessThan(0) ? new BigNumber(0) : penalty;
 };
 


### PR DESCRIPTION
# Related issues 🔗

Closes #3832

# Description ℹ️

Enactment date was removed as a sorting param at some point in the past. This reinstates it, falling back to closingDatetime if there is no enactmentDatetime, finally sorting by datetime if there are multiple equal enactmentDatetimes/closingDatetimes.
