### PR TITLE
chore(trading): dont show upgrade banner unless APP_VERSION is set

### DIFF
--- a/apps/trading/.env
+++ b/apps/trading/.env
@@ -13,6 +13,3 @@ NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
 NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/main/announcements.json
 NX_WALLETCONNECT_PROJECT_ID=fe8091dc35738863e509fc4947525c72
-
-# TAG name of the current app version - TODO: bump to the latest upon release
-NX_APP_VERSION=v0.20.7-core-0.71.4

--- a/apps/trading/.env.mainnet
+++ b/apps/trading/.env.mainnet
@@ -13,3 +13,5 @@ NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/mainnet/announcements.json
 NX_VEGA_INCIDENT_URL=https://blog.vega.xyz/tagged/vega-incident-reports
 NX_VEGA_CONSOLE_URL=https://vega.trading
+# TAG name of the current app version - TODO: bump to the latest upon release
+NX_APP_VERSION=v0.20.8-core-0.71.4

--- a/apps/trading/components/banner/upgrade-banner.tsx
+++ b/apps/trading/components/banner/upgrade-banner.tsx
@@ -36,6 +36,8 @@ export const UpgradeBanner = ({ showVersionChange }: UpgradeBannerProps) => {
     return valid && valid.length > 0 ? valid[0] : undefined;
   }, [VEGA_ENV, data]);
 
+  if (!APP_VERSION) return null;
+
   if (!visible || !latest || latest.tagName === APP_VERSION) return null;
 
   const versionChange = (
@@ -65,7 +67,7 @@ export const UpgradeBanner = ({ showVersionChange }: UpgradeBannerProps) => {
         {t('Bookmark')}{' '}
         <ExternalLink href={CANONICAL_URL}>{t('vega.trading')}</ExternalLink>
         <CopyWithTooltip text={CANONICAL_URL}>
-          <button title={t('Copy %s', CANONICAL_URL)} className="text-white">
+          <button title={t('Copy %s', CANONICAL_URL)}>
             <span className="sr-only">{t('Copy %s', CANONICAL_URL)}</span>
             <VegaIcon size={14} name={VegaIconNames.COPY} />
           </button>


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

- Only renders the upgrade banner if NX_APP_VERSION is set
- Fixes color of copy icon in banner
