### PR TITLE
fix(trading): redirect to markets all page if no market found

### DIFF
--- a/apps/trading-e2e/src/integration/home.cy.ts
+++ b/apps/trading-e2e/src/integration/home.cy.ts
@@ -140,8 +140,8 @@ describe('home', { tags: '@regression' }, () => {
       cy.wait('@MarketsData');
     });
 
-    it('redirects to a the empty market page and displays welcome notice', () => {
-      cy.url().should('eq', Cypress.config().baseUrl + `/#/markets`);
+    it('redirects to market/all and displays welcome notice', () => {
+      cy.url().should('eq', Cypress.config().baseUrl + `/#/markets/all`);
       cy.getByTestId('welcome-notice-title').should(
         'contain.text',
         'Welcome to Console'

--- a/apps/trading/client-pages/home/home.tsx
+++ b/apps/trading/client-pages/home/home.tsx
@@ -30,7 +30,7 @@ export const Home = () => {
           replace: true,
         });
       } else {
-        navigate(Links[Routes.MARKET]());
+        navigate(Links[Routes.MARKETS]());
       }
     }
   }, [marketId, data, navigate, update]);


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

If not markets are found redirect  to the markets all page, so we aren't on an empty market page