### PR TITLE
fix(trading): hide download or export all when no entries

### DIFF
--- a/libs/ledger/src/lib/ledger-export-link.tsx
+++ b/libs/ledger/src/lib/ledger-export-link.tsx
@@ -52,7 +52,7 @@ export const LedgerExportLink = ({
     );
   }, [assetId, assets]);
 
-  if (!protohost) {
+  if (!protohost || !entries || entries.length === 0) {
     return null;
   }
   return (


### PR DESCRIPTION
# Related issues 🔗

Closes #3893 

# Description ℹ️

Hide download or export all when no ledger entries.

# Demo 📺

<img width="1675" alt="Screenshot 2023-05-23 at 09 51 28" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/cffa78c2-c915-4c38-8df2-bc6dafedfb66">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
