### PR TITLE
fix(explorer): wrap routes in suspense

### DIFF
--- a/apps/explorer/src/app/app.tsx
+++ b/apps/explorer/src/app/app.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_CACHE_CONFIG } from '@vegaprotocol/apollo-client';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './routes/router-config';
 import { t } from '@vegaprotocol/i18n';
+import { Suspense } from 'react';
 
 const splashLoading = (
   <Splash>
@@ -32,7 +33,9 @@ function App() {
           skeleton={<div>{t('Loading')}</div>}
           failure={<AppFailure title={t(`Node: ${VEGA_URL} is unsuitable`)} />}
         >
-          <RouterProvider router={router} fallbackElement={splashLoading} />
+          <Suspense fallback={splashLoading}>
+            <RouterProvider router={router} fallbackElement={splashLoading} />
+          </Suspense>
         </NodeGuard>
         <NodeSwitcherDialog
           open={nodeSwitcherOpen}


### PR DESCRIPTION
# Related issues 🔗

Closes #3891. Closes #3774.

# Description ℹ️

The new nested routing on accounts triggered a React error when navigated in a specific path. The quick fix is to wrap the whole router in React.Suspense with a loading fallback, but this feels like a temporary fix. #3895 is a follow up ticket.
