### PR TITLE
fix(trading): skip market data query if market not present

### DIFF
--- a/apps/trading/components/market-mark-price/market-mark-price.tsx
+++ b/apps/trading/components/market-mark-price/market-mark-price.tsx
@@ -26,7 +26,7 @@ export const MarketMarkPrice = ({
     {
       dataProvider: marketDataProvider,
       variables: { marketId: marketId || '' },
-      skip: !inView,
+      skip: !inView || !marketId,
     },
     THROTTLE_UPDATE_TIME
   );


### PR DESCRIPTION
Fixes sending query to marketConnection with empty market ID on /#/markets page