### PR TITLE
chore(market-depth): replace bid and ask columns with a single volume column when i…

### DIFF
--- a/libs/market-depth/src/lib/orderbook-row.tsx
+++ b/libs/market-depth/src/lib/orderbook-row.tsx
@@ -75,7 +75,56 @@ export const OrderbookRow = React.memo(
     );
   }
 );
-
 OrderbookRow.displayName = 'OrderbookRow';
 
-export default OrderbookRow;
+export const OrderbookContinuousRow = React.memo(
+  ({
+    ask,
+    bid,
+    cumulativeAsk,
+    cumulativeBid,
+    cumulativeRelativeAsk,
+    cumulativeRelativeBid,
+    decimalPlaces,
+    positionDecimalPlaces,
+    indicativeVolume,
+    price,
+    relativeAsk,
+    relativeBid,
+    onClick,
+  }: OrderbookRowProps) => {
+    const type = bid ? 'bid' : 'ask';
+    const value = bid || ask;
+    const relativeValue = bid ? relativeBid : relativeAsk;
+    return (
+      <>
+        <VolCell
+          testId={`bid-ask-vol-${price}`}
+          value={value}
+          valueFormatted={addDecimalsFixedFormatNumber(
+            value,
+            positionDecimalPlaces
+          )}
+          relativeValue={relativeValue}
+          type={type}
+        />
+        <PriceCell
+          testId={`price-${price}`}
+          value={BigInt(price)}
+          onClick={() => onClick && onClick(addDecimal(price, decimalPlaces))}
+          valueFormatted={addDecimalsFixedFormatNumber(price, decimalPlaces)}
+        />
+        <CumulativeVol
+          testId={`cumulative-vol-${price}`}
+          positionDecimalPlaces={positionDecimalPlaces}
+          bid={cumulativeBid}
+          ask={cumulativeAsk}
+          relativeAsk={cumulativeRelativeAsk}
+          relativeBid={cumulativeRelativeBid}
+          indicativeVolume={indicativeVolume}
+        />
+      </>
+    );
+  }
+);
+OrderbookContinuousRow.displayName = 'OrderbookContinuousRow';

--- a/libs/market-depth/src/lib/orderbook.spec.tsx
+++ b/libs/market-depth/src/lib/orderbook.spec.tsx
@@ -224,4 +224,37 @@ describe('Orderbook', () => {
     expect(onResolutionChange.mock.calls[0][0]).toBe(10);
     expect(onClickSpy).toBeCalledWith('122.99');
   });
+
+  it('should have three or four columns', async () => {
+    window.innerHeight = 11 * rowHeight;
+    const { rerender } = render(
+      <Orderbook
+        decimalPlaces={decimalPlaces}
+        positionDecimalPlaces={0}
+        fillGaps
+        {...generateMockData({
+          ...params,
+          overlap: 0,
+        })}
+        onResolutionChange={onResolutionChange}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Bid / Ask vol')).toBeInTheDocument();
+    });
+    rerender(
+      <Orderbook
+        decimalPlaces={decimalPlaces}
+        positionDecimalPlaces={0}
+        fillGaps
+        {...generateMockData(params)}
+        onResolutionChange={onResolutionChange}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Bid vol')).toBeInTheDocument();
+      expect(screen.getByText('Ask vol')).toBeInTheDocument();
+    });
+    await expect(screen.queryByText('Bid / Ask vol')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
…n market is in continuous mode

# Related issues 🔗

Closes #3763 

# Description ℹ️

Use single bid/ask column when market is in continues mode 

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/338931/a4c5e96e-7cf7-4337-9dae-080ff2bfb688)


# Technical 👨‍🔧

-
