### PR TITLE
fix(trading): performance issues with many orders

### DIFF
--- a/apps/trading/components/app-loader/app-loader.tsx
+++ b/apps/trading/components/app-loader/app-loader.tsx
@@ -59,7 +59,7 @@ const cacheConfig: InMemoryCacheConfig = {
       keyFields: false,
     },
     TradableInstrument: {
-      keyFields: ['instrument'],
+      keyFields: false,
     },
     Product: {
       keyFields: ['settlementAsset', ['id']],

--- a/apps/trading/components/app-loader/app-loader.tsx
+++ b/apps/trading/components/app-loader/app-loader.tsx
@@ -95,5 +95,10 @@ const cacheConfig: InMemoryCacheConfig = {
     Fees: {
       keyFields: false,
     },
+    // Don't cache order update as this subscription result gets merged into the main order cache
+    // We don't need to write these to the cache at all
+    OrderUpdate: {
+      keyFields: false,
+    },
   },
 };

--- a/apps/trading/pages/_app.page.tsx
+++ b/apps/trading/pages/_app.page.tsx
@@ -36,7 +36,7 @@ import { AppLoader, DynamicLoader } from '../components/app-loader';
 import { Navbar } from '../components/navbar';
 import { ENV } from '../lib/config';
 import { useDataProvider } from '@vegaprotocol/data-provider';
-import { activeOrdersProvider, allOrdersProvider } from '@vegaprotocol/orders';
+import { activeOrdersProvider } from '@vegaprotocol/orders';
 import { useTelemetryApproval } from '../lib/hooks/use-telemetry-approval';
 import {
   ProtocolUpgradeCountdownMode,
@@ -148,11 +148,6 @@ const PartyData = () => {
   const skip = !pubKey;
   useDataProvider({
     dataProvider: activeOrdersProvider,
-    variables,
-    skip,
-  });
-  useDataProvider({
-    dataProvider: allOrdersProvider,
     variables,
     skip,
   });

--- a/libs/data-provider/src/generic-data-provider.ts
+++ b/libs/data-provider/src/generic-data-provider.ts
@@ -235,6 +235,7 @@ function makeDataProviderInternal<
   // subscription is started before initial query, all deltas that will arrive before initial query response are put on queue
   const updateQueue: Delta[] = [];
 
+  let initialized = false;
   let resetTimer: ReturnType<typeof setTimeout>;
   let variables: Variables;
   let data: Data | null = null;
@@ -443,8 +444,8 @@ function makeDataProviderInternal<
     if (loading) {
       return;
     }
-    // hard reset on demand or when there is no apollo subscription yet
-    if (forceReset || !subscription) {
+    // hard reset on demand or when error occurs
+    if (forceReset || error) {
       reset();
       initialize();
     } else {
@@ -480,12 +481,10 @@ function makeDataProviderInternal<
   };
 
   const initialize = async () => {
-    if (subscription) {
-      if (resetTimer) {
-        clearTimeout(resetTimer);
-      }
+    if (initialized) {
       return;
     }
+    initialized = true;
     loading = true;
     error = undefined;
     notifyAll();
@@ -499,15 +498,12 @@ function makeDataProviderInternal<
   };
 
   const reset = () => {
-    if (!subscription) {
-      return;
-    }
     subscriptionUnsubscribe();
+    initialized = false;
     data = null;
     error = undefined;
     loading = false;
     loaded = false;
-    notifyAll();
   };
 
   // remove callback from list, and unsubscribe if there is no more callbacks registered
@@ -524,13 +520,14 @@ function makeDataProviderInternal<
 
   return (callback, c, v) => {
     callbacks.push(callback);
-    if (callbacks.length === 1) {
+    if (!initialized) {
       client = c;
       if (v) {
         variables = v;
       }
       initialize();
     } else {
+      clearTimeout(resetTimer);
       notify(callback);
     }
     return {

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -170,6 +170,7 @@ export const DealTicket = ({
         marginAccountBalance || generalAccountBalance ? balance : undefined,
     },
     skip: !normalizedOrder,
+    fetchPolicy: 'no-cache',
   });
 
   const assetSymbol =

--- a/libs/deal-ticket/src/hooks/use-fee-deal-ticket-details.tsx
+++ b/libs/deal-ticket/src/hooks/use-fee-deal-ticket-details.tsx
@@ -34,6 +34,7 @@ export const useEstimateFees = (
       type: order.type,
     },
     skip: !pubKey || !order?.size || !order?.price,
+    fetchPolicy: 'no-cache',
   });
   return data?.estimateFees;
 };

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -104,7 +104,6 @@ export const update = (
   if (!data) {
     return data;
   }
-  console.log('update orders');
   // A single update can contain the same order with multiple updates, so we need to find
   // the latest version of the order and only update using that
   const incoming = orderBy(

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -117,9 +117,9 @@ export const update = (
   return produce(data, (draft) => {
     // Add or update incoming orders
     incoming.forEach((node) => {
-      const index = draft.findIndex((edge) => edge.node.id === node.id);
+      const index = data.findIndex((edge) => edge.node.id === node.id);
       const newer =
-        draft.length === 0 || node.createdAt >= draft[0].node.createdAt;
+        data.length === 0 || node.createdAt >= data[0].node.createdAt;
       const doesFilterPass = !variables || orderMatchFilters(node, variables);
       if (index !== -1) {
         if (doesFilterPass) {
@@ -171,25 +171,6 @@ const ordersProvider = makeDataProvider<
   additionalContext: { isEnlargedTimeout: true },
   fetchPolicy: 'no-cache',
 });
-
-export const allOrdersProvider = makeDerivedDataProvider<
-  ReturnType<typeof getData>,
-  never,
-  { partyId: string; marketId?: string }
->(
-  [
-    (callback, client, variables) =>
-      ordersProvider(callback, client, {
-        partyId: variables.partyId,
-      }),
-  ],
-  (partsData, variables, prevData, parts, subscriptions) => {
-    const orders = partsData[0] as ReturnType<typeof getData>;
-    return variables.marketId
-      ? orders.filter((edge) => variables.marketId === edge.node.market.id)
-      : orders;
-  }
-);
 
 export const activeOrdersProvider = makeDerivedDataProvider<
   ReturnType<typeof getData>,

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -5,7 +5,7 @@ import {
   makeDataProvider,
   makeDerivedDataProvider,
 } from '@vegaprotocol/data-provider';
-import type { PageInfo, Edge } from '@vegaprotocol/data-provider';
+import type { Edge } from '@vegaprotocol/data-provider';
 import type { Market } from '@vegaprotocol/markets';
 import { marketsProvider } from '@vegaprotocol/markets';
 import { OrderStatus } from '@vegaprotocol/types';

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -132,6 +132,7 @@ export const update = (
     ),
     'createdAt'
   );
+
   return produce(data, (draft) => {
     // Add or update incoming orders
     incoming.forEach((node) => {
@@ -186,15 +187,9 @@ const ordersProvider = makeDataProvider<
   update,
   getData,
   getDelta,
-  pagination: {
-    getPageInfo,
-    append,
-    first: 1000,
-  },
   additionalContext: { isEnlargedTimeout: true },
+  fetchPolicy: 'no-cache',
 });
-
-const allOrderMaxCount = 50000;
 
 export const allOrdersProvider = makeDerivedDataProvider<
   ReturnType<typeof getData>,
@@ -203,19 +198,12 @@ export const allOrdersProvider = makeDerivedDataProvider<
 >(
   [
     (callback, client, variables) =>
-      ordersProvider(callback, client, { partyId: variables.partyId }),
+      ordersProvider(callback, client, {
+        partyId: variables.partyId,
+      }),
   ],
   (partsData, variables, prevData, parts, subscriptions) => {
     const orders = partsData[0] as ReturnType<typeof getData>;
-    // load next pages until allOrderMaxCount reached
-    if (
-      !parts[0].isUpdate &&
-      subscriptions &&
-      subscriptions[0].load &&
-      orders?.length < allOrderMaxCount
-    ) {
-      subscriptions[0].load();
-    }
     return variables.marketId
       ? orders.filter((edge) => variables.marketId === edge.node.market.id)
       : orders;

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -4,7 +4,6 @@ import uniqBy from 'lodash/uniqBy';
 import {
   makeDataProvider,
   makeDerivedDataProvider,
-  defaultAppend as append,
 } from '@vegaprotocol/data-provider';
 import type { PageInfo, Edge } from '@vegaprotocol/data-provider';
 import type { Market } from '@vegaprotocol/markets';
@@ -93,26 +92,8 @@ const getDelta = (
   if (!subscriptionData.orders) {
     return [];
   }
-  subscriptionData.orders.forEach((order) => {
-    client.cache.modify({
-      id: client.cache.identify({
-        __typename: 'Order',
-        id: order.id,
-      }),
-      fields: {
-        price: () => order.price,
-        size: () => order.size,
-        remaining: () => order.remaining,
-        updatedAt: () => order.updatedAt,
-        status: () => order.status,
-      },
-    });
-  });
   return subscriptionData.orders;
 };
-
-const getPageInfo = (responseData: OrdersQuery): PageInfo | null =>
-  responseData.party?.ordersConnection?.pageInfo || null;
 
 export const update = (
   data: ReturnType<typeof getData> | null,
@@ -123,6 +104,7 @@ export const update = (
   if (!data) {
     return data;
   }
+  console.log('update orders');
   // A single update can contain the same order with multiple updates, so we need to find
   // the latest version of the order and only update using that
   const incoming = orderBy(

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -4,10 +4,11 @@ import uniqBy from 'lodash/uniqBy';
 import {
   makeDataProvider,
   makeDerivedDataProvider,
+  defaultAppend as append,
 } from '@vegaprotocol/data-provider';
-import type { Edge } from '@vegaprotocol/data-provider';
 import type { Market } from '@vegaprotocol/markets';
 import { marketsProvider } from '@vegaprotocol/markets';
+import type { PageInfo, Edge } from '@vegaprotocol/data-provider';
 import { OrderStatus } from '@vegaprotocol/types';
 import type {
   OrderFieldsFragment,
@@ -156,7 +157,10 @@ export const update = (
   });
 };
 
-const ordersProvider = makeDataProvider<
+const getPageInfo = (responseData: OrdersQuery): PageInfo | null =>
+  responseData.party?.ordersConnection?.pageInfo || null;
+
+export const ordersProvider = makeDataProvider<
   OrdersQuery,
   ReturnType<typeof getData>,
   OrdersUpdateSubscription,
@@ -168,6 +172,12 @@ const ordersProvider = makeDataProvider<
   update,
   getData,
   getDelta,
+  pagination: {
+    getPageInfo,
+    append,
+    first: 5000,
+  },
+  resetDelay: 1000,
   additionalContext: { isEnlargedTimeout: true },
   fetchPolicy: 'no-cache',
 });

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -1,6 +1,6 @@
 import { AsyncRenderer } from '@vegaprotocol/ui-toolkit';
 import { t } from '@vegaprotocol/i18n';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@vegaprotocol/ui-toolkit';
 import type { AgGridReact } from 'ag-grid-react';
 import type { GridReadyEvent, FilterChangedEvent } from 'ag-grid-community';
@@ -16,7 +16,7 @@ import {
 } from '@vegaprotocol/wallet';
 import type { OrderTxUpdateFieldsFragment } from '@vegaprotocol/wallet';
 import { OrderEditDialog } from '../order-list/order-edit-dialog';
-import type { Order, OrdersQueryVariables } from '../order-data-provider';
+import type { Order } from '../order-data-provider';
 import { OrderStatus } from '@vegaprotocol/types';
 
 export enum Filter {
@@ -76,25 +76,10 @@ export const OrderListManager = ({
   const [editOrder, setEditOrder] = useState<Order | null>(null);
   const create = useVegaTransactionStore((state) => state.create);
   const hasAmendableOrder = useHasAmendableOrder(marketId);
-
-  const variables = useMemo<OrdersQueryVariables>(() => {
-    if (filter === Filter.Open) {
-      return { partyId, filter: { liveOnly: true } };
-    }
-    const variables: OrdersQueryVariables = {
-      partyId,
-      pagination: {
-        first: 5000,
-      },
-    };
-    if (filter === Filter.Closed || filter === Filter.Rejected) {
-      variables.filter = {
-        status: FilterStatusValue[filter],
-      };
-    }
-
-    return variables;
-  }, [filter, partyId]);
+  const variables =
+    filter === Filter.Open
+      ? { partyId, filter: { liveOnly: true } }
+      : { partyId };
 
   const { data, error, loading, reload } = useDataProvider({
     dataProvider: ordersWithMarketProvider,
@@ -146,7 +131,7 @@ export const OrderListManager = ({
     (event: FilterChangedEvent) => {
       const rowCount = gridRef.current?.api?.getModel().getRowCount();
       setHasData((rowCount ?? 0) > 0);
-      bottomPlaceholderOnFilterChanged?.(event);
+      bottomPlaceholderOnFilterChanged?.();
     },
     [bottomPlaceholderOnFilterChanged]
   );
@@ -181,7 +166,6 @@ export const OrderListManager = ({
           onFilterChanged={onFilterChanged}
           onRowDataChanged={onRowDataChanged}
           isReadOnly={isReadOnly}
-          blockLoadDebounceMillis={100}
           storeKey={storeKey}
           suppressLoadingOverlay
           suppressNoRowsOverlay

--- a/libs/orders/src/lib/components/order-list/order-list.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.tsx
@@ -49,8 +49,11 @@ export const OrderListTable = memo<
       { onCancel, onEdit, onMarketClick, onOrderTypeClick, filter, ...props },
       ref
     ) => {
-      const showAllActions =
-        filter === undefined || filter === Filter.Open ? true : false;
+      const showAllActions = props.isReadOnly
+        ? false
+        : filter === undefined || filter === Filter.Open
+        ? true
+        : false;
 
       return (
         <AgGrid

--- a/libs/wallet/src/use-vega-transaction-updater.tsx
+++ b/libs/wallet/src/use-vega-transaction-updater.tsx
@@ -25,6 +25,7 @@ export const useVegaTransactionUpdater = () => {
   useOrderTxUpdateSubscription({
     variables,
     skip,
+    fetchPolicy: 'no-cache',
     onData: ({ data: result }) =>
       result.data?.orders?.forEach((order) => {
         updateOrder(order);
@@ -34,6 +35,7 @@ export const useVegaTransactionUpdater = () => {
   useWithdrawalBusEventSubscription({
     variables,
     skip,
+    fetchPolicy: 'no-cache',
     onData: ({ data: result }) =>
       result.data?.busEvents?.forEach((event) => {
         if (event.event.__typename === 'Withdrawal') {
@@ -48,6 +50,7 @@ export const useVegaTransactionUpdater = () => {
   useTransactionEventSubscription({
     variables,
     skip,
+    fetchPolicy: 'no-cache',
     onData: ({ data: result }) =>
       result.data?.busEvents?.forEach((event) => {
         if (event.event.__typename === 'TransactionResult') {

--- a/libs/web3/src/lib/use-vega-transaction-toasts.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.tsx
@@ -174,6 +174,7 @@ const EditOrderDetails = ({
 }) => {
   const { data: orderById } = useOrderByIdQuery({
     variables: { orderId: data.orderId },
+    fetchPolicy: 'no-cache',
   });
   const { data: markets } = useMarketList();
 


### PR DESCRIPTION
# Related issues 🔗

Closes #3788

# Description ℹ️

Improves performance of the app when connected as a party with lots of orders.

# Technical 👨‍🔧

- Removes top level subscription for all orders, only subscribing to active orders
- Prevents caching of OrderUpdate types
- Prevents caching of transaction update subscription data
- Prevents caching of estimateFees and estimatePosition queries
