### PR TITLE
fix(explorer,trading): typo in release notes template

### DIFF
--- a/.github/workflows/add-ipfs-notes-to-release.yml
+++ b/.github/workflows/add-ipfs-notes-to-release.yml
@@ -56,7 +56,7 @@ jobs:
             * https://governance.vega.xyz
 
             # IPFS releases
-            Tye IPFS hash of this release of the Trading app is:
+            The IPFS hash of this release of the Trading app is:
 
             CIDv0: ${{ env.IPFS_V0 }}
             CIDv1: ${{ env.IPFS_V1 }}


### PR DESCRIPTION
`tye` -> 'the'

Closes #3976
