### PR TITLE
feat(explorer): do not colourise votes in tx list

### DIFF
--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -160,6 +160,7 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
         vote={command?.voteSubmission?.value === 'VALUE_YES'}
         yesText="Proposal vote"
         noText="Proposal vote"
+        useVoteColour={false}
       />
     );
   }

--- a/apps/explorer/src/app/components/vote-icon/vote-icon.spec.tsx
+++ b/apps/explorer/src/app/components/vote-icon/vote-icon.spec.tsx
@@ -34,4 +34,17 @@ describe('Vote TX icon', () => {
     const no = render(<VoteIcon vote={false} />);
     expect(no.getByRole('img')).toHaveAttribute('aria-label', 'delete icon');
   });
+
+  it('useVoteColour prop can be used to override coloured background', () => {
+    const no = render(<VoteIcon vote={false} />);
+    expect(no.container.children[0]).toHaveClass('bg-vega-pink-550');
+
+    const monochromeNo = render(
+      <VoteIcon vote={false} useVoteColour={false} />
+    );
+    expect(monochromeNo.container.children[0]).not.toHaveClass(
+      'bg-vega-pink-550'
+    );
+    expect(monochromeNo.container.children[0]).toHaveClass('bg-vega-dark-200');
+  });
 });

--- a/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
+++ b/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
@@ -12,6 +12,30 @@ export interface VoteIconProps {
   useVoteColour?: boolean;
 }
 
+function getBgColour(useVoteColour: boolean, vote: boolean) {
+  if (useVoteColour === false) {
+    return 'bg-vega-dark-200';
+  }
+
+  return vote ? 'bg-vega-green-550' : 'bg-vega-pink-550';
+}
+
+function getFillColour(useVoteColour: boolean, vote: boolean) {
+  if (useVoteColour === false) {
+    return 'white';
+  }
+
+  return vote ? 'vega-green-300' : 'vega-pink-300';
+}
+
+function getTextColour(useVoteColour: boolean, vote: boolean) {
+  if (useVoteColour === false) {
+    return 'white';
+  }
+
+  return vote ? 'vega-green-200' : 'vega-pink-200';
+}
+
 /**
  * Displays a lozenge with an icon representing the way a user voted for a proposal.
  * The yes and no text can be overridden
@@ -26,21 +50,9 @@ export function VoteIcon({
 }: VoteIconProps) {
   const label = vote ? yesText : noText;
   const icon: IconName = vote ? 'tick-circle' : 'delete';
-  const bg = useVoteColour
-    ? vote
-      ? 'bg-vega-green-550'
-      : 'bg-vega-pink-550'
-    : 'bg-vega-dark-200';
-  const fill = useVoteColour
-    ? vote
-      ? 'vega-green-300'
-      : 'vega-pink-300'
-    : 'white';
-  const text = useVoteColour
-    ? vote
-      ? 'vega-green-200'
-      : 'vega-pink-200'
-    : 'white';
+  const bg = getBgColour(useVoteColour, vote);
+  const fill = getFillColour(useVoteColour, vote);
+  const text = getTextColour(useVoteColour, vote);
 
   return (
     <div

--- a/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
+++ b/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
@@ -8,6 +8,8 @@ export interface VoteIconProps {
   yesText?: string;
   // Defaults to 'Against', but can be any text
   noText?: string;
+  // If set to false the background will not be coloured
+  useVoteColour?: boolean;
 }
 
 /**
@@ -18,14 +20,27 @@ export interface VoteIconProps {
  */
 export function VoteIcon({
   vote,
+  useVoteColour = true,
   yesText = 'For',
   noText = 'Against',
 }: VoteIconProps) {
   const label = vote ? yesText : noText;
-  const bg = vote ? 'bg-vega-green-550' : 'bg-vega-pink-550';
   const icon: IconName = vote ? 'tick-circle' : 'delete';
-  const fill = vote ? 'vega-green-300' : 'vega-pink-300';
-  const text = vote ? 'vega-green-200' : 'vega-pink-200';
+  const bg = useVoteColour
+    ? vote
+      ? 'bg-vega-green-550'
+      : 'bg-vega-pink-550'
+    : 'bg-vega-dark-200';
+  const fill = useVoteColour
+    ? vote
+      ? 'vega-green-300'
+      : 'vega-pink-300'
+    : 'white';
+  const text = useVoteColour
+    ? vote
+      ? 'vega-green-200'
+      : 'vega-pink-200'
+    : 'white';
 
   return (
     <div


### PR DESCRIPTION
# Related issues 🔗

Closes #3789

# Description ℹ️

Colourising a proposal vote by Yes or No turned out to be confusing in the transaction list. Using 'red' to mean 'no' looks more like 'error' in that context, as raised by @davidsiska. This PR removes the colours in tx lists.

# Demo 📺
<img width="576" alt="Screenshot 2023-05-30 at 11 26 10" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/834a7464-3d19-4ba6-b61e-b073b99cbcf4">

