### PR TITLE
fix(governance): dont start listening for pending eth events until connected

### DIFF
--- a/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
+++ b/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
@@ -11,14 +11,14 @@ export const useListenForPendingEthEvents = (
   removePendingTx: (event: Event) => void,
   resetPendingTxs: () => void
 ) => {
-  const { provider, account } = useWeb3React();
+  const { provider } = useWeb3React();
 
   /**
    * Add listener for the ethereum events on the contract passed in for the filter passed in.
    * Push the event into the store and wait for the correct number of confirmations before removing it.
    */
   useEffect(() => {
-    if (!account || !contract || !filter) {
+    if (!contract || !filter) {
       return;
     }
 
@@ -40,14 +40,7 @@ export const useListenForPendingEthEvents = (
     return () => {
       contract.off(filter, listener);
     };
-  }, [
-    addPendingTxs,
-    contract,
-    filter,
-    numberOfConfirmations,
-    removePendingTx,
-    account,
-  ]);
+  }, [addPendingTxs, contract, filter, numberOfConfirmations, removePendingTx]);
 
   /**
    * Get all transactions that exist on the blockchain but have yet to reach the number of confirmations
@@ -88,10 +81,7 @@ export const useListenForPendingEthEvents = (
   );
 
   useEffect(() => {
-    if (!account) return;
-
     let cancelled = false;
-
     resetPendingTxs();
     getExistingTransactions().then((events) => {
       if (!cancelled) {
@@ -109,6 +99,5 @@ export const useListenForPendingEthEvents = (
     numberOfConfirmations,
     resetPendingTxs,
     waitForExistingTransactions,
-    account,
   ]);
 };

--- a/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
+++ b/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
@@ -11,14 +11,14 @@ export const useListenForPendingEthEvents = (
   removePendingTx: (event: Event) => void,
   resetPendingTxs: () => void
 ) => {
-  const { provider } = useWeb3React();
+  const { provider, account } = useWeb3React();
 
   /**
    * Add listener for the ethereum events on the contract passed in for the filter passed in.
    * Push the event into the store and wait for the correct number of confirmations before removing it.
    */
   useEffect(() => {
-    if (!contract || !filter) {
+    if (!account || !contract || !filter) {
       return;
     }
 
@@ -40,7 +40,14 @@ export const useListenForPendingEthEvents = (
     return () => {
       contract.off(filter, listener);
     };
-  }, [addPendingTxs, contract, filter, numberOfConfirmations, removePendingTx]);
+  }, [
+    addPendingTxs,
+    contract,
+    filter,
+    numberOfConfirmations,
+    removePendingTx,
+    account,
+  ]);
 
   /**
    * Get all transactions that exist on the blockchain but have yet to reach the number of confirmations

--- a/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
+++ b/apps/governance/src/hooks/use-listen-for-pending-eth-events.ts
@@ -88,7 +88,10 @@ export const useListenForPendingEthEvents = (
   );
 
   useEffect(() => {
+    if (!account) return;
+
     let cancelled = false;
+
     resetPendingTxs();
     getExistingTransactions().then((events) => {
       if (!cancelled) {
@@ -106,5 +109,6 @@ export const useListenForPendingEthEvents = (
     numberOfConfirmations,
     resetPendingTxs,
     waitForExistingTransactions,
+    account,
   ]);
 };

--- a/apps/governance/src/hooks/use-listen-for-staking-events.ts
+++ b/apps/governance/src/hooks/use-listen-for-staking-events.ts
@@ -3,32 +3,32 @@ import { usePendingBalancesStore } from './use-pending-balances-manager';
 import type { Contract } from 'ethers';
 import { useListenForPendingEthEvents } from './use-listen-for-pending-eth-events';
 import { prepend0x } from '@vegaprotocol/smart-contracts';
+import { useWeb3React } from '@web3-react/core';
 
 export const useListenForStakingEvents = (
   contract: Contract | undefined,
   vegaPublicKey: string | null,
   numberOfConfirmations: number
 ) => {
+  const { account } = useWeb3React();
   const { addPendingTxs, removePendingTx, resetPendingTxs } =
     usePendingBalancesStore((state) => ({
       addPendingTxs: state.addPendingTxs,
       removePendingTx: state.removePendingTx,
       resetPendingTxs: state.resetPendingTxs,
     }));
-  const addFilter = useMemo(
-    () =>
-      vegaPublicKey && contract
-        ? contract.filters.Stake_Deposited(null, null, prepend0x(vegaPublicKey))
-        : null,
-    [contract, vegaPublicKey]
-  );
-  const removeFilter = useMemo(
-    () =>
-      vegaPublicKey && contract
-        ? contract.filters.Stake_Removed(null, null, prepend0x(vegaPublicKey))
-        : null,
-    [contract, vegaPublicKey]
-  );
+  const addFilter = useMemo(() => {
+    if (!account || !vegaPublicKey || !contract) return null;
+    return contract.filters.Stake_Deposited(
+      null,
+      null,
+      prepend0x(vegaPublicKey)
+    );
+  }, [contract, vegaPublicKey, account]);
+  const removeFilter = useMemo(() => {
+    if (!account || !vegaPublicKey || !contract) return null;
+    return contract.filters.Stake_Removed(null, null, prepend0x(vegaPublicKey));
+  }, [contract, vegaPublicKey, account]);
 
   /**
    * Listen for all add stake events


### PR DESCRIPTION
# Related issues 🔗

Closes #3995 

# Description ℹ️

Prevents starting listening for contract events until the user has connected an Ethereum wallet