### PR TITLE
feat(explorer): properly represent batch error 71

### DIFF
--- a/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
@@ -5,12 +5,13 @@ export const ErrorCodes = new Map([
   [51, 'Transaction failed validation'],
   [60, 'Transaction could not be decoded'],
   [70, 'Error'],
+  [71, 'Partial success/error'],
   [80, 'Unknown command'],
   [89, 'Rejected as spam'],
   [0, 'Success'],
 ]);
 
-export const successCodes = new Set([0]);
+export const successCodes = new Set([0, 71]);
 
 interface ChainResponseCodeProps {
   code: number;
@@ -29,11 +30,12 @@ export const ChainResponseCode = ({
   error,
 }: ChainResponseCodeProps) => {
   const isSuccess = successCodes.has(code);
-
+  const successColour =
+    code === 71 ? 'fill-vega-orange' : 'fill-vega-green-600';
   const icon = isSuccess ? (
-    <Icon name="tick-circle" className="fill-vega-green-550" />
+    <Icon name="tick-circle" className={successColour} />
   ) : (
-    <Icon name="cross" className="fill-vega-pink-550" />
+    <Icon name="cross" className="fill-vega-pink-600" />
   );
   const label = ErrorCodes.get(code) || 'Unknown response code';
 


### PR DESCRIPTION
# Related issues 🔗

Closes #3360

# Description ℹ️

Makes it clearer which batches are partial error and which are full error

- Add orange coloured tick for partial success/error
- Update full success to a green tick
- Update full error to a red cross
- Add text label for partial success


![Screenshot 2023-06-01 at 18-35-10 Transactions VEGA explorer](https://github.com/vegaprotocol/frontend-monorepo/assets/6678/ead2c3ed-2e8c-4303-b14d-bc7e0b31823e)
![Screenshot 2023-06-01 at 18-35-23 TX 0xBB27BE3C60EBFAED0D1F08CE43BFC932ADE81DF7CFA105CAA36386AA8CFD0C94 Transactions VEGA explorer](https://github.com/vegaprotocol/frontend-monorepo/assets/6678/383844e8-4ebf-496c-957b-6bb217b425f7)
