### PR TITLE
fix(explorer): fix broken protocol upgrade tx link

### DIFF
--- a/apps/explorer/.env
+++ b/apps/explorer/.env
@@ -15,6 +15,7 @@ NX_VEGA_GOVERNANCE_URL=https://governance.stagnet1.vega.rocks
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.json
 NX_VEGA_NETWORKS='{"TESTNET":"https://explorer.fairground.wtf","MAINNET":"https://explorer.vega.xyz"}'
 NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases/tag/
 
 # App flags
 NX_EXPLORER_ASSETS=1


### PR DESCRIPTION
# Related issues 🔗

Closes #4028

# Description ℹ️

A missing environment variable meant that the link to release tags on the Protocol Upgrade TX page was broken. This
PR adds the Github address of core, which fixes the issue.
