### PR TITLE
fix(trading): order book mid

### DIFF
--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -65,6 +65,9 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
         asks={data?.depth.sell ?? []}
         decimalPlaces={market?.decimalPlaces ?? 0}
         positionDecimalPlaces={market?.positionDecimalPlaces ?? 0}
+        assetSymbol={
+          market?.tradableInstrument.instrument.product.settlementAsset.symbol
+        }
         onClick={(price: string) => {
           if (price) {
             updateOrder(marketId, { price });

--- a/libs/market-depth/src/lib/orderbook-manager.tsx
+++ b/libs/market-depth/src/lib/orderbook-manager.tsx
@@ -65,9 +65,7 @@ export const OrderbookManager = ({ marketId }: OrderbookManagerProps) => {
         asks={data?.depth.sell ?? []}
         decimalPlaces={market?.decimalPlaces ?? 0}
         positionDecimalPlaces={market?.positionDecimalPlaces ?? 0}
-        assetSymbol={
-          market?.tradableInstrument.instrument.product.settlementAsset.symbol
-        }
+        assetSymbol={market?.tradableInstrument.instrument.product.quoteName}
         onClick={(price: string) => {
           if (price) {
             updateOrder(marketId, { price });

--- a/libs/market-depth/src/lib/orderbook.spec.tsx
+++ b/libs/market-depth/src/lib/orderbook.spec.tsx
@@ -41,6 +41,7 @@ describe('Orderbook', () => {
         decimalPlaces={decimalPlaces}
         positionDecimalPlaces={0}
         {...generateMockData(params)}
+        assetSymbol="USD"
       />
     );
     await waitFor(() =>
@@ -61,6 +62,7 @@ describe('Orderbook', () => {
         positionDecimalPlaces={0}
         onClick={onClickSpy}
         {...mockedData}
+        assetSymbol="USD"
       />
     );
     expect(

--- a/libs/market-depth/src/lib/orderbook.stories.tsx
+++ b/libs/market-depth/src/lib/orderbook.stories.tsx
@@ -18,6 +18,7 @@ const OrderbookMockDataProvider = ({ decimalPlaces, ...props }: Props) => {
           positionDecimalPlaces={0}
           decimalPlaces={decimalPlaces}
           {...generateMockData({ ...props })}
+          assetSymbol="USD"
         />
       </div>
     </div>

--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -52,7 +52,10 @@ const OrderbookTable = ({
         )
       }
     >
-      <div className={`grid auto-rows-[${rowHeight}px]`}>
+      <div
+        className="grid"
+        style={{ gridAutoRows: rowHeight }} // use style as tailwind won't compile the dynamically set height
+      >
         {rows.map((data) => (
           <OrderbookRow
             key={data.price}
@@ -111,7 +114,7 @@ export const Orderbook = ({
                 data-testid="orderbook-grid-element"
                 style={{
                   height: height + 'px',
-                  gridTemplateRows: `1fr ${midHeight}px 1fr`,
+                  gridTemplateRows: `1fr ${midHeight}px 1fr`, // cannot use tailwind here as tailwind will not parse a class string with interpolation
                 }}
               >
                 {askRows.length || bidRows.length ? (

--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -107,7 +107,7 @@ export const Orderbook = ({
             const bidRows = groupedBids?.slice(0, limit) ?? [];
             return (
               <div
-                className={`overflow-hidden grid grid-rows-[1fr_${midHeight}px_1fr]`}
+                className={`overflow-hidden grid grid-rows-[1fr_30px_1fr]`}
                 data-testid="orderbook-grid-element"
                 style={{ height: height + 'px' }}
               >

--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -13,18 +13,10 @@ import classNames from 'classnames';
 import { useState } from 'react';
 import type { PriceLevelFieldsFragment } from './__generated__/MarketDepth';
 
-interface OrderbookProps {
-  decimalPlaces: number;
-  positionDecimalPlaces: number;
-  onClick?: (price: string) => void;
-  midPrice?: string;
-  bids: PriceLevelFieldsFragment[];
-  asks: PriceLevelFieldsFragment[];
-}
-
 // Sets row height, will be used to calculate number of rows that can be
 // displayed each side of the book without overflow
 export const rowHeight = 17;
+const rowGap = 1;
 const midHeight = 30;
 
 const OrderbookTable = ({
@@ -54,7 +46,7 @@ const OrderbookTable = ({
     >
       <div
         className="grid"
-        style={{ gridAutoRows: rowHeight }} // use style as tailwind won't compile the dynamically set height
+        style={{ gridAutoRows: rowHeight, gap: rowGap }} // use style as tailwind won't compile the dynamically set height
       >
         {rows.map((data) => (
           <OrderbookRow
@@ -74,6 +66,16 @@ const OrderbookTable = ({
   );
 };
 
+interface OrderbookProps {
+  decimalPlaces: number;
+  positionDecimalPlaces: number;
+  onClick?: (price: string) => void;
+  midPrice?: string;
+  bids: PriceLevelFieldsFragment[];
+  asks: PriceLevelFieldsFragment[];
+  assetSymbol: string | undefined;
+}
+
 export const Orderbook = ({
   decimalPlaces,
   positionDecimalPlaces,
@@ -81,6 +83,7 @@ export const Orderbook = ({
   midPrice,
   asks,
   bids,
+  assetSymbol,
 }: OrderbookProps) => {
   const [resolution, setResolution] = useState(1);
   const resolutions = new Array(
@@ -104,7 +107,7 @@ export const Orderbook = ({
           {({ height }) => {
             const limit = Math.max(
               1,
-              Math.floor((height - midHeight) / 2 / rowHeight)
+              Math.floor((height - midHeight) / 2 / (rowHeight + rowGap))
             );
             const askRows = groupedAsks?.slice(limit * -1) ?? [];
             const bidRows = groupedBids?.slice(0, limit) ?? [];
@@ -127,14 +130,17 @@ export const Orderbook = ({
                       positionDecimalPlaces={positionDecimalPlaces}
                       onClick={onClick}
                     />
-                    <div className="flex items-center justify-center text-lg">
+                    <div className="flex items-center justify-center gap-2">
                       {midPrice && (
-                        <span
-                          className="font-mono"
-                          data-testid={`middle-mark-price-${midPrice}`}
-                        >
-                          {addDecimalsFormatNumber(midPrice, decimalPlaces)}
-                        </span>
+                        <>
+                          <span
+                            className="font-mono text-lg"
+                            data-testid={`middle-mark-price-${midPrice}`}
+                          >
+                            {addDecimalsFormatNumber(midPrice, decimalPlaces)}
+                          </span>
+                          <span className="text-base">{assetSymbol}</span>
+                        </>
                       )}
                     </div>
                     <OrderbookTable

--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -107,9 +107,12 @@ export const Orderbook = ({
             const bidRows = groupedBids?.slice(0, limit) ?? [];
             return (
               <div
-                className={`overflow-hidden grid grid-rows-[1fr_30px_1fr]`}
+                className="overflow-hidden grid"
                 data-testid="orderbook-grid-element"
-                style={{ height: height + 'px' }}
+                style={{
+                  height: height + 'px',
+                  gridTemplateRows: `1fr ${midHeight}px 1fr`,
+                }}
               >
                 {askRows.length || bidRows.length ? (
                   <>


### PR DESCRIPTION
# Related issues 🔗

Closes #4051 

# Description ℹ️

- Adds asset symbol to the mid
- Fixes the layout of the grid in the order book which wasn't taking into account the configured sizes
- Fixes row sizes which resulted in one less row per side being shown, even though there was space for it
- Adds a small 1px gap between rows

# Technical 👨‍🔧

- Changed to use some inline styles instead of tailwind as tailwind was not compiling the dynamically created rowHeight, midHeight sizes
