### PR TITLE
fix(trading): update click area in network switcher

### DIFF
--- a/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
@@ -152,7 +152,9 @@ describe('Network switcher', () => {
       VEGA_NETWORKS,
     }));
 
-    render(<NetworkSwitcher />);
+    await act(() => {
+      render(<NetworkSwitcher />);
+    });
 
     for (const network of [
       Networks.MAINNET,

--- a/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { t } from '@vegaprotocol/i18n';
 import { useEnvironment } from '../../hooks/use-environment';
@@ -13,6 +13,24 @@ import { Networks } from '../../';
 jest.mock('../../hooks/use-environment');
 
 describe('Network switcher', () => {
+  const { location } = window;
+  let hrefSetSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    hrefSetSpy = jest.fn();
+    // @ts-ignore can't set location as optional
+    delete window.location;
+    window.location = {} as Location;
+    Object.defineProperty(window.location, 'href', {
+      // @ts-ignore set cannot take SpyInstance
+      set: hrefSetSpy,
+    });
+  });
+
+  afterEach(() => {
+    window.location = location;
+  });
+
   it.each`
     network             | label
     ${Networks.CUSTOM}  | ${envTriggerMapping[Networks.CUSTOM]}
@@ -49,8 +67,7 @@ describe('Network switcher', () => {
     render(<NetworkSwitcher />);
 
     await userEvent.click(screen.getByRole('button'));
-
-    const links = screen.getAllByRole('link');
+    let links = screen.getAllByRole('link');
 
     expect(links[0]).toHaveTextContent(envNameMapping[Networks.MAINNET]);
     expect(links[1]).toHaveTextContent(envNameMapping[Networks.TESTNET]);
@@ -63,6 +80,16 @@ describe('Network switcher', () => {
     const menuitems = screen.getAllByRole('menuitem');
 
     expect(menuitems[0]).toHaveTextContent('Advanced');
+
+    await userEvent.click(links[0]);
+    expect(hrefSetSpy).toHaveBeenCalledWith(mainnetUrl);
+
+    // re open dropdown as clicking an item will close it
+    await userEvent.click(screen.getByRole('button'));
+    links = screen.getAllByRole('link');
+
+    await userEvent.click(links[1]);
+    expect(hrefSetSpy).toHaveBeenCalledWith(testnetUrl);
   });
 
   it('displays the correct selected network on the default dropdown view', async () => {
@@ -128,72 +155,53 @@ describe('Network switcher', () => {
     expect(links[0]).toHaveTextContent(t('not available'));
   });
 
-  it('displays the advanced view in the correct state', async () => {
-    const { location } = window;
-    const setHrefSpy = jest.fn();
-    // @ts-ignore can't set location as optional
-    delete window.location;
-    window.location = {} as Location;
-    Object.defineProperty(window.location, 'href', {
-      set: setHrefSpy,
-    });
+  it.each([Networks.MAINNET, Networks.TESTNET, Networks.DEVNET])(
+    'displays the advanced view in the correct state',
+    async (network) => {
+      const VEGA_NETWORKS: Record<Networks, string | undefined> = {
+        [Networks.CUSTOM]: undefined,
+        [Networks.MAINNET]: 'https://main.net',
+        [Networks.TESTNET]: 'https://test.net',
+        [Networks.VALIDATOR_TESTNET]: 'https://validator-test.net',
+        [Networks.DEVNET]: 'https://dev.net',
+        [Networks.STAGNET1]: 'https://stag1.net',
+      };
+      // @ts-ignore Typescript doesn't know about this module being mocked
+      useEnvironment.mockImplementation(() => ({
+        VEGA_ENV: Networks.DEVNET,
+        VEGA_NETWORKS,
+      }));
 
-    const VEGA_NETWORKS: Record<Networks, string | undefined> = {
-      [Networks.CUSTOM]: undefined,
-      [Networks.MAINNET]: 'https://main.net',
-      [Networks.TESTNET]: 'https://test.net',
-      [Networks.VALIDATOR_TESTNET]: 'https://validator-test.net',
-      [Networks.DEVNET]: 'https://dev.net',
-      [Networks.STAGNET1]: 'https://stag1.net',
-    };
-    // @ts-ignore Typescript doesn't know about this module being mocked
-    useEnvironment.mockImplementation(() => ({
-      VEGA_ENV: Networks.DEVNET,
-      VEGA_NETWORKS,
-    }));
-
-    await act(() => {
       render(<NetworkSwitcher />);
-    });
 
-    for (const network of [
-      Networks.MAINNET,
-      Networks.TESTNET,
-      Networks.DEVNET,
-    ]) {
-      await act(() => {
-        userEvent.click(screen.getByTestId('network-switcher'));
-      });
-      await waitFor(() => {
-        screen.getByRole('menuitem', { name: t('Advanced') });
-      });
-      await act(() => {
-        userEvent.click(screen.getByRole('menuitem', { name: t('Advanced') }));
-      });
-      await waitFor(() => {
-        expect(
-          screen.getByText(envDescriptionMapping[network])
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('link', {
-            name: new RegExp(`^${envNameMapping[network]}`),
-          })
-        ).toBeInTheDocument();
-      });
-      await act(() => {
-        screen
-          .getByRole('link', {
-            name: new RegExp(`^${envNameMapping[network]}`),
-          })
-          .click();
-      });
-      await waitFor(() => {
-        expect(setHrefSpy).toHaveBeenCalledWith(VEGA_NETWORKS[network]);
-      });
+      await userEvent.click(screen.getByTestId('network-switcher'));
+
+      expect(
+        await screen.findByRole('menuitem', { name: t('Advanced') })
+      ).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('menuitem', { name: t('Advanced') })
+      );
+
+      expect(
+        await screen.findByText(envDescriptionMapping[network])
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', {
+          name: new RegExp(`^${envNameMapping[network]}`),
+        })
+      ).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('link', {
+          name: new RegExp(`^${envNameMapping[network]}`),
+        })
+      );
+
+      expect(hrefSetSpy).toHaveBeenCalledWith(VEGA_NETWORKS[network]);
     }
-
-    window.location = location;
-  });
+  );
 
   it('labels the selected network in the advanced view', async () => {
     const selectedNetwork = Networks.DEVNET;

--- a/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.spec.tsx
@@ -154,7 +154,9 @@ describe('Network switcher', () => {
 
     [Networks.MAINNET, Networks.TESTNET, Networks.DEVNET].forEach((network) => {
       expect(
-        screen.getByRole('link', { name: envNameMapping[network] })
+        screen.getByRole('link', {
+          name: new RegExp(`^${envNameMapping[network]}`),
+        })
       ).toHaveAttribute('href', VEGA_NETWORKS[network]);
       expect(
         screen.getByText(envDescriptionMapping[network])
@@ -188,7 +190,7 @@ describe('Network switcher', () => {
     const label = screen.getByText(`(${t('current')})`);
 
     expect(label).toBeInTheDocument();
-    expect(label.parentNode?.firstElementChild).toHaveTextContent(
+    expect(label.parentNode?.parentNode?.firstElementChild).toHaveTextContent(
       envNameMapping[selectedNetwork]
     );
   });
@@ -217,7 +219,7 @@ describe('Network switcher', () => {
     const label = screen.getByText('(not available)');
 
     expect(label).toBeInTheDocument();
-    expect(label.parentNode?.firstElementChild).toHaveTextContent(
+    expect(label.parentNode?.parentNode?.firstElementChild).toHaveTextContent(
       envNameMapping[Networks.MAINNET]
     );
   });

--- a/libs/environment/src/components/network-switcher/network-switcher.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { t } from '@vegaprotocol/i18n';
 import {
-  Link,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -134,15 +133,16 @@ export const NetworkSwitcher = ({
                 key={key}
                 data-testid="network-item"
                 disabled={!VEGA_NETWORKS[key]}
-                className="p-0"
+                role="link"
+                onClick={() =>
+                  (window.location.href = VEGA_NETWORKS[key] || '')
+                }
               >
-                <a href={VEGA_NETWORKS[key]} className="w-full h-full p-2">
-                  {envNameMapping[key]}
-                  <NetworkLabel
-                    isCurrent={current === key}
-                    isAvailable={!!VEGA_NETWORKS[key]}
-                  />
-                </a>
+                {envNameMapping[key]}
+                <NetworkLabel
+                  isCurrent={current === key}
+                  isAvailable={!!VEGA_NETWORKS[key]}
+                />
               </DropdownMenuItem>
             ))}
             <DropdownMenuItem
@@ -163,25 +163,26 @@ export const NetworkSwitcher = ({
               <DropdownMenuItem
                 key={key}
                 data-testid="network-item-advanced"
-                className="p-0"
+                role="link"
+                onClick={() =>
+                  (window.location.href = VEGA_NETWORKS[key] || '')
+                }
               >
-                <Link href={VEGA_NETWORKS[key]} className="w-full p-2">
-                  <div className="w-full flex justify-between gap-2">
-                    <div>
-                      {envNameMapping[key]}
-                      <NetworkLabel
-                        isCurrent={current === key}
-                        isAvailable={!!VEGA_NETWORKS[key]}
-                      />
-                    </div>
-                    <span
-                      className="hidden md:inline"
-                      data-testid="network-item-description"
-                    >
-                      {envDescriptionMapping[key]}
-                    </span>
+                <div className="w-full flex justify-between gap-2">
+                  <div>
+                    {envNameMapping[key]}
+                    <NetworkLabel
+                      isCurrent={current === key}
+                      isAvailable={!!VEGA_NETWORKS[key]}
+                    />
                   </div>
-                </Link>
+                  <span
+                    className="hidden md:inline"
+                    data-testid="network-item-description"
+                  >
+                    {envDescriptionMapping[key]}
+                  </span>
+                </div>
               </DropdownMenuItem>
             ))}
           </>

--- a/libs/environment/src/components/network-switcher/network-switcher.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { t } from '@vegaprotocol/i18n';
 import {
   DropdownMenu,

--- a/libs/environment/src/components/network-switcher/network-switcher.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.tsx
@@ -134,8 +134,9 @@ export const NetworkSwitcher = ({
                 key={key}
                 data-testid="network-item"
                 disabled={!VEGA_NETWORKS[key]}
+                className="p-0"
               >
-                <a href={VEGA_NETWORKS[key]}>
+                <a href={VEGA_NETWORKS[key]} className="w-full h-full p-2">
                   {envNameMapping[key]}
                   <NetworkLabel
                     isCurrent={current === key}
@@ -159,22 +160,28 @@ export const NetworkSwitcher = ({
         {isAdvancedView && (
           <>
             {advancedNetworkKeys.map((key) => (
-              <DropdownMenuItem key={key} data-testid="network-item-advanced">
-                <div className="w-full flex justify-between gap-2">
-                  <div>
-                    <Link href={VEGA_NETWORKS[key]}>{envNameMapping[key]}</Link>
-                    <NetworkLabel
-                      isCurrent={current === key}
-                      isAvailable={!!VEGA_NETWORKS[key]}
-                    />
+              <DropdownMenuItem
+                key={key}
+                data-testid="network-item-advanced"
+                className="p-0"
+              >
+                <Link href={VEGA_NETWORKS[key]} className="w-full p-2">
+                  <div className="w-full flex justify-between gap-2">
+                    <div>
+                      {envNameMapping[key]}
+                      <NetworkLabel
+                        isCurrent={current === key}
+                        isAvailable={!!VEGA_NETWORKS[key]}
+                      />
+                    </div>
+                    <span
+                      className="hidden md:inline"
+                      data-testid="network-item-description"
+                    >
+                      {envDescriptionMapping[key]}
+                    </span>
                   </div>
-                  <span
-                    className="hidden md:inline"
-                    data-testid="network-item-description"
-                  >
-                    {envDescriptionMapping[key]}
-                  </span>
-                </div>
+                </Link>
               </DropdownMenuItem>
             ))}
           </>

--- a/libs/environment/src/components/network-switcher/network-switcher.tsx
+++ b/libs/environment/src/components/network-switcher/network-switcher.tsx
@@ -98,7 +98,6 @@ export const NetworkSwitcher = ({
     },
     [setOpen, setAdvancedView]
   );
-  const menuRef = useRef<HTMLButtonElement | null>(null);
 
   const current = currentNetwork || VEGA_ENV;
 
@@ -109,7 +108,6 @@ export const NetworkSwitcher = ({
       trigger={
         <DropdownMenuTrigger
           data-testid="network-switcher"
-          ref={menuRef}
           className={classNames(
             'flex justify-between items-center text-sm text-vega-dark-600 dark:text-vega-light-600 py-1 px-2 rounded border border-vega-dark-200 whitespace-nowrap dark:hover:bg-vega-dark-500 hover:bg-vega-light-500',
             className
@@ -122,10 +120,7 @@ export const NetworkSwitcher = ({
         </DropdownMenuTrigger>
       }
     >
-      <DropdownMenuContent
-        align="start"
-        style={{ minWidth: `${menuRef.current?.offsetWidth || 290}px` }}
-      >
+      <DropdownMenuContent align="start">
         {!isAdvancedView && (
           <>
             {standardNetworkKeys.map((key) => (


### PR DESCRIPTION
# Related issues 🔗

Closes #3704 

# Description ℹ️

Uses click handler for menu item to navigate to the new network. This way the expected 'click area' is used

# Demo 📺

-

# Technical 👨‍🔧

-
