### PR TITLE
test(trading): #3505 add test coverage to 6002-MDET-market-details

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -1,12 +1,18 @@
 import { MarketTradingModeMapping } from '@vegaprotocol/types';
 import { MarketState } from '@vegaprotocol/types';
 
-const marketInfoBtn = 'Info';
-const row = 'key-value-table-row';
-const marketTitle = 'accordion-title';
-const externalLink = 'external-link';
 const accordionContent = 'accordion-content';
+const blockExplorerLink = 'block-explorer-link';
+const dialogClose = 'dialog-close';
+const dialogContent = 'dialog-content';
+const externalLink = 'external-link';
+const githubLink = 'github-link';
+const liquidityLink = 'view-liquidity-link';
+const marketInfoBtn = 'Info';
+const marketTitle = 'accordion-title';
 const providerName = 'provider-name';
+const row = 'key-value-table-row';
+const verifiedProofs = 'verified-proofs';
 
 describe('market info is displayed', { tags: '@smoke' }, () => {
   beforeEach(() => {
@@ -91,17 +97,16 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       .and('contain', 'Another oracle');
 
     cy.getByTestId(providerName).should('be.visible').click();
-
-    cy.getByTestId('dialog-content')
+    cy.getByTestId(dialogContent)
       .eq(1)
       .within(() => {
-        cy.getByTestId('block-explorer-link').contains('Block explorer');
-        cy.getByTestId('github-link').contains('Oracle repository');
+        cy.getByTestId(blockExplorerLink).contains('Block explorer');
+        cy.getByTestId(githubLink).contains('Oracle repository');
       });
-    cy.getByTestId('dialog-close').click();
+    cy.getByTestId(dialogClose).click();
 
     cy.getByTestId(accordionContent)
-      .getByTestId('verified-proofs')
+      .getByTestId(verifiedProofs)
       .and('contain', '1');
   });
 
@@ -191,8 +196,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
     validateMarketDataRow(0, 'Target Stake', '10.00 tBTC');
     validateMarketDataRow(1, 'Supplied Stake', '0.01 tBTC');
     validateMarketDataRow(2, 'Market Value Proxy', '20.00 tBTC');
-
-    cy.getByTestId('view-liquidity-link').should(
+    cy.getByTestId(liquidityLink).should(
       'have.text',
       'View liquidity provision table'
     );

--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -7,9 +7,6 @@ const marketTitle = 'accordion-title';
 const externalLink = 'external-link';
 const accordionContent = 'accordion-content';
 const providerName = 'provider-name';
-const oracleBannerStatus = 'oracle-banner-status';
-const oracleBannerDialogTrigger = 'oracle-banner-dialog-trigger';
-const oracleFullProfile = 'oracle-full-profile';
 
 describe('market info is displayed', { tags: '@smoke' }, () => {
   beforeEach(() => {
@@ -17,12 +14,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
   });
 
   before(() => {
-    cy.mockTradingPage(
-      MarketState.STATE_ACTIVE,
-      undefined,
-      undefined,
-      'COMPROMISED'
-    );
+    cy.mockTradingPage(MarketState.STATE_ACTIVE);
     cy.mockSubscription();
     cy.visit('/#/markets/market-0');
     cy.wait('@Markets');
@@ -30,16 +22,8 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
     cy.wait('@MarketInfo');
   });
 
-  it('show oracle banner', () => {
-    cy.getByTestId(marketTitle).contains('Oracle').click();
-    cy.getByTestId(oracleBannerStatus).should('contain.text', 'COMPROMISED');
-    cy.getByTestId(oracleBannerDialogTrigger)
-      .should('contain.text', 'Show more')
-      .click();
-    cy.getByTestId(oracleFullProfile).should('exist');
-  });
-
   it('current fees displayed', () => {
+    // 6002-MDET-101
     cy.getByTestId(marketTitle).contains('Current fees').click();
     validateMarketDataRow(0, 'Maker Fee', '0.02%');
     validateMarketDataRow(1, 'Infrastructure Fee', '0.05%');
@@ -48,6 +32,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
   });
 
   it('market price', () => {
+    // 6002-MDET-102
     cy.getByTestId(marketTitle).contains('Market price').click();
     validateMarketDataRow(0, 'Mark Price', '46,126.90058');
     validateMarketDataRow(1, 'Best Bid Price', '44,126.90058 ');
@@ -56,6 +41,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
   });
 
   it('market volume displayed', () => {
+    // 6002-MDET-103
     cy.getByTestId(marketTitle).contains('Market volume').click();
     validateMarketDataRow(1, 'Open Interest', '-');
     validateMarketDataRow(2, 'Best Bid Volume', '1');
@@ -65,11 +51,13 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
   });
 
   it('insurance pool displayed', () => {
+    // 6002-MDET-104
     cy.getByTestId(marketTitle).contains('Insurance pool').click();
     validateMarketDataRow(0, 'Balance', '0');
   });
 
   it('key details displayed', () => {
+    // 6002-MDET-201
     cy.getByTestId(marketTitle).contains('Key details').click();
 
     validateMarketDataRow(0, 'Name', 'BTCUSD Monthly (30 Jun 2022)');
@@ -85,6 +73,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
   });
 
   it('instrument displayed', () => {
+    // 6002-MDET-202
     cy.getByTestId(marketTitle).contains('Instrument').click();
 
     validateMarketDataRow(0, 'Market Name', 'BTCUSD Monthly (30 Jun 2022)');
@@ -93,98 +82,8 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
     validateMarketDataRow(3, 'Quote Name', 'BTC');
   });
 
-  it('settlement asset displayed', () => {
-    cy.getByTestId(marketTitle).contains('Settlement asset').click();
-    cy.window().then((win) => {
-      cy.stub(win, 'prompt').returns('DISABLED WINDOW PROMPT');
-    });
-    validateMarketDataRow(0, 'ID', 'asset-id');
-    validateMarketDataRow(1, 'Type', 'ERC20');
-    validateMarketDataRow(2, 'Name', 'Euro');
-    validateMarketDataRow(3, 'Symbol', 'tEURO');
-    validateMarketDataRow(4, 'Decimals', '5');
-    validateMarketDataRow(5, 'Quantum', '1');
-    validateMarketDataRow(6, 'Status', 'Enabled');
-    validateMarketDataRow(
-      7,
-      'Contract address',
-      '0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4'
-    );
-    validateMarketDataRow(8, 'Withdrawal threshold', '0.0005');
-    validateMarketDataRow(9, 'Lifetime limit', '1,230');
-  });
-
-  it('metadata displayed', () => {
-    cy.getByTestId(marketTitle).contains('Metadata').click();
-
-    validateMarketDataRow(0, 'Formerly', '076BB86A5AA41E3E');
-    validateMarketDataRow(1, 'Base', 'BTC');
-    validateMarketDataRow(2, 'Quote', 'USD');
-    validateMarketDataRow(3, 'Class', 'fx/crypto');
-    validateMarketDataRow(4, 'Sector', 'crypto');
-  });
-
-  it('risk model displayed', () => {
-    cy.getByTestId(marketTitle).contains('Risk model').click();
-    validateMarketDataRow(0, 'Tau', '0.0001140771161');
-    validateMarketDataRow(1, 'Risk Aversion Parameter', '0.01');
-  });
-
-  it('risk parameters displayed', () => {
-    cy.getByTestId(marketTitle).contains('Risk parameters').click();
-    validateMarketDataRow(0, 'R', '0.016');
-    validateMarketDataRow(1, 'Sigma', '0.3');
-  });
-
-  it('risk factors displayed', () => {
-    cy.getByTestId(marketTitle).contains('Risk factors').click();
-
-    validateMarketDataRow(0, 'Short', '0.008571790367285281');
-    validateMarketDataRow(1, 'Long', '0.008508132993273576');
-  });
-
-  it('price monitoring bounds displayed', () => {
-    cy.getByTestId(marketTitle).contains('Price monitoring bounds 1').click();
-    cy.get('p.col-span-1').contains('99.99999% probability price bounds');
-    cy.get('p.col-span-1').contains('Within 43,200 seconds');
-    validateMarketDataRow(0, 'Highest Price', '7.97323 ');
-    validateMarketDataRow(1, 'Lowest Price', '6.54701 ');
-  });
-
-  it('liquidity monitoring parameters displayed', () => {
-    cy.getByTestId(marketTitle)
-      .contains('Liquidity monitoring parameters')
-      .click();
-
-    validateMarketDataRow(0, 'Triggering Ratio', '0');
-    validateMarketDataRow(1, 'Time Window', '3,600');
-    validateMarketDataRow(2, 'Scaling Factor', '10');
-  });
-
-  it('liquidity displayed', () => {
-    cy.getByTestId(marketTitle)
-      .contains(/Liquidity(?! m)/)
-      .click();
-
-    validateMarketDataRow(0, 'Target Stake', '10.00 tBTC');
-    validateMarketDataRow(1, 'Supplied Stake', '0.01 tBTC');
-    validateMarketDataRow(2, 'Market Value Proxy', '20.00 tBTC');
-
-    cy.getByTestId('view-liquidity-link').should(
-      'have.text',
-      'View liquidity provision table'
-    );
-  });
-
-  it('liquidity price range displayed', () => {
-    cy.getByTestId(marketTitle).contains('Liquidity price range').click();
-
-    validateMarketDataRow(0, 'Liquidity Price Range', '2.00% of mid price');
-    validateMarketDataRow(1, 'Lowest Price', '45,204.362 BTC');
-    validateMarketDataRow(2, 'Highest Price', '47,049.438 BTC');
-  });
-
   it('oracle displayed', () => {
+    // 6002-MDET-203
     cy.getByTestId(marketTitle).contains('Oracle').click();
 
     cy.getByTestId(accordionContent)
@@ -206,7 +105,110 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       .and('contain', '1');
   });
 
+  it('settlement asset displayed', () => {
+    // 6002-MDET-206
+    cy.getByTestId(marketTitle).contains('Settlement asset').click();
+    cy.window().then((win) => {
+      cy.stub(win, 'prompt').returns('DISABLED WINDOW PROMPT');
+    });
+    validateMarketDataRow(0, 'ID', 'asset-id');
+    validateMarketDataRow(1, 'Type', 'ERC20');
+    validateMarketDataRow(2, 'Name', 'Euro');
+    validateMarketDataRow(3, 'Symbol', 'tEURO');
+    validateMarketDataRow(4, 'Decimals', '5');
+    validateMarketDataRow(5, 'Quantum', '1');
+    validateMarketDataRow(6, 'Status', 'Enabled');
+    validateMarketDataRow(
+      7,
+      'Contract address',
+      '0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4'
+    );
+    validateMarketDataRow(8, 'Withdrawal threshold', '0.0005');
+    validateMarketDataRow(9, 'Lifetime limit', '1,230');
+    validateMarketDataRow(10, 'Infrastructure fee account balance', '0.00001');
+    validateMarketDataRow(11, 'Global reward pool account balance', '0.00002');
+  });
+
+  it('metadata displayed', () => {
+    // 6002-MDET-207
+    cy.getByTestId(marketTitle).contains('Metadata').click();
+
+    validateMarketDataRow(0, 'Formerly', '076BB86A5AA41E3E');
+    validateMarketDataRow(1, 'Base', 'BTC');
+    validateMarketDataRow(2, 'Quote', 'USD');
+    validateMarketDataRow(3, 'Class', 'fx/crypto');
+    validateMarketDataRow(4, 'Sector', 'crypto');
+  });
+
+  it('risk model displayed', () => {
+    // 6002-MDET-208
+    cy.getByTestId(marketTitle).contains('Risk model').click();
+    validateMarketDataRow(0, 'Tau', '0.0001140771161');
+    validateMarketDataRow(1, 'Risk Aversion Parameter', '0.01');
+  });
+
+  it('risk parameters displayed', () => {
+    // 6002-MDET-209
+    cy.getByTestId(marketTitle).contains('Risk parameters').click();
+    validateMarketDataRow(0, 'R', '0.016');
+    validateMarketDataRow(1, 'Sigma', '0.3');
+  });
+
+  it('risk factors displayed', () => {
+    // 6002-MDET-210
+    cy.getByTestId(marketTitle).contains('Risk factors').click();
+
+    validateMarketDataRow(0, 'Short', '0.008571790367285281');
+    validateMarketDataRow(1, 'Long', '0.008508132993273576');
+  });
+
+  it('price monitoring bounds displayed', () => {
+    // 6002-MDET-211
+    cy.getByTestId(marketTitle).contains('Price monitoring bounds 1').click();
+    cy.get('p.col-span-1').contains('99.99999% probability price bounds');
+    cy.get('p.col-span-1').contains('Within 43,200 seconds');
+    validateMarketDataRow(0, 'Highest Price', '7.97323 ');
+    validateMarketDataRow(1, 'Lowest Price', '6.54701 ');
+  });
+
+  it('liquidity monitoring parameters displayed', () => {
+    // 6002-MDET-212
+    cy.getByTestId(marketTitle)
+      .contains('Liquidity monitoring parameters')
+      .click();
+
+    validateMarketDataRow(0, 'Triggering Ratio', '0');
+    validateMarketDataRow(1, 'Time Window', '3,600');
+    validateMarketDataRow(2, 'Scaling Factor', '10');
+  });
+
+  it('liquidity displayed', () => {
+    // 6002-MDET-213
+    cy.getByTestId(marketTitle)
+      .contains(/Liquidity(?! m)/)
+      .click();
+
+    validateMarketDataRow(0, 'Target Stake', '10.00 tBTC');
+    validateMarketDataRow(1, 'Supplied Stake', '0.01 tBTC');
+    validateMarketDataRow(2, 'Market Value Proxy', '20.00 tBTC');
+
+    cy.getByTestId('view-liquidity-link').should(
+      'have.text',
+      'View liquidity provision table'
+    );
+  });
+
+  it('liquidity price range displayed', () => {
+    // 6002-MDET-214
+    cy.getByTestId(marketTitle).contains('Liquidity price range').click();
+
+    validateMarketDataRow(0, 'Liquidity Price Range', '2.00% of mid price');
+    validateMarketDataRow(1, 'Lowest Price', '45,204.362 BTC');
+    validateMarketDataRow(2, 'Highest Price', '47,049.438 BTC');
+  });
+
   it('proposal displayed', () => {
+    // 6002-MDET-301
     cy.getByTestId(marketTitle).contains('Proposal').click();
 
     cy.getByTestId(accordionContent)

--- a/apps/trading-e2e/src/integration/market-summary.cy.ts
+++ b/apps/trading-e2e/src/integration/market-summary.cy.ts
@@ -8,6 +8,7 @@ const marketVolume = 'market-volume';
 const marketMode = 'market-trading-mode';
 const marketState = 'market-state';
 const marketSettlement = 'market-settlement-asset';
+const liquiditySupplied = 'liquidity-supplied';
 const percentageValue = 'price-change-percentage';
 const priceChangeValue = 'price-change';
 const itemHeader = 'item-header';
@@ -31,10 +32,12 @@ describe('Market trading page', () => {
     // 7002-SORD-001
     // 7002-SORD-002
     it('must display market name', () => {
+      // 6002-MDET-001
       cy.getByTestId('header-title').should('not.be.empty');
     });
 
     it('must see market expiry', () => {
+      // 6002-MDET-002
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketExpiry).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Expiry');
@@ -44,6 +47,7 @@ describe('Market trading page', () => {
     });
 
     it('must see market price', () => {
+      // 6002-MDET-003
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketPrice).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Price');
@@ -53,6 +57,7 @@ describe('Market trading page', () => {
     });
 
     it('must see market change', () => {
+      // 6002-MDET-004
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketChange).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Change (24h)');
@@ -63,6 +68,7 @@ describe('Market trading page', () => {
     });
 
     it('must see market volume', () => {
+      // 6002-MDET-005
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketVolume).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Volume (24h)');
@@ -72,16 +78,21 @@ describe('Market trading page', () => {
     });
 
     it('must see market mode', () => {
+      // 6002-MDET-006
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketMode).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Trading mode');
-          cy.getByTestId(itemValue).should('not.be.empty');
+          cy.getByTestId(itemValue).should(
+            'have.text',
+            'Monitoring auction - liquidity (target not met)'
+          );
         });
       });
     });
 
-    it('must see market state', () => {
-      //7002-SORD-061
+    it('must see market status', () => {
+      // 6002-MDET-007
+      // 7002-SORD-061
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketState).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Status');
@@ -91,6 +102,7 @@ describe('Market trading page', () => {
     });
 
     it('must see market settlement', () => {
+      // 6002-MDET-008
       cy.getByTestId(marketSummaryBlock).within(() => {
         cy.getByTestId(marketSettlement).within(() => {
           cy.getByTestId(itemHeader).should('have.text', 'Settlement asset');
@@ -98,15 +110,12 @@ describe('Market trading page', () => {
         });
       });
     });
-
-    it('must see market mode', () => {
+    it('must see market liquidity supplied', () => {
+      // 6002-MDET-009
       cy.getByTestId(marketSummaryBlock).within(() => {
-        cy.getByTestId(marketMode).within(() => {
-          cy.getByTestId(itemHeader).should('have.text', 'Trading mode');
-          cy.getByTestId(itemValue).should(
-            'have.text',
-            'Monitoring auction - liquidity (target not met)'
-          );
+        cy.getByTestId(liquiditySupplied).within(() => {
+          cy.getByTestId(itemHeader).should('have.text', 'Liquidity supplied');
+          cy.getByTestId(itemValue).should('not.be.empty');
         });
       });
     });
@@ -172,6 +181,29 @@ describe('Market trading page', () => {
               .should('have.text', auctionToolTipLabels[i]);
             cy.getByTestId(toolTipValue).eq(i).should('not.be.empty');
           }
+        });
+    });
+
+    it('should see liquidity supplied tooltip', () => {
+      cy.getByTestId(marketSummaryBlock).within(() => {
+        cy.getByTestId(liquiditySupplied).within(() => {
+          cy.getByTestId(itemValue).realHover();
+        });
+      });
+
+      cy.getByTestId('liquidity-supplied-tooltip')
+        .should('contain.text', 'Supplied stake')
+        .and('contain.text', 'Target stake')
+        .first()
+        .within(() => {
+          cy.getByTestId('view-liquidity-link').should(
+            'have.text',
+            'View liquidity provision table'
+          );
+          cy.getByTestId('external-link').should(
+            'have.text',
+            'Learn about providing liquidity'
+          );
         });
     });
   });

--- a/apps/trading-e2e/src/integration/market-summary.cy.ts
+++ b/apps/trading-e2e/src/integration/market-summary.cy.ts
@@ -1,18 +1,25 @@
 import * as Schema from '@vegaprotocol/types';
 
-const marketSummaryBlock = 'header-summary';
-const marketExpiry = 'market-expiry';
-const marketPrice = 'market-price';
-const marketChange = 'market-change';
-const marketVolume = 'market-volume';
-const marketMode = 'market-trading-mode';
-const marketState = 'market-state';
-const marketSettlement = 'market-settlement-asset';
-const liquiditySupplied = 'liquidity-supplied';
-const percentageValue = 'price-change-percentage';
-const priceChangeValue = 'price-change';
+const expirtyTooltip = 'expiry-tooltip';
+const externalLink = 'external-link';
 const itemHeader = 'item-header';
 const itemValue = 'item-value';
+const link = 'link';
+const liquidityLink = 'view-liquidity-link';
+const liquiditySupplied = 'liquidity-supplied';
+const liquiditySuppliedTooltip = 'liquidity-supplied-tooltip';
+const marketChange = 'market-change';
+const marketExpiry = 'market-expiry';
+const marketMode = 'market-trading-mode';
+const marketName = 'header-title';
+const marketPrice = 'market-price';
+const marketSettlement = 'market-settlement-asset';
+const marketState = 'market-state';
+const marketSummaryBlock = 'header-summary';
+const marketVolume = 'market-volume';
+const percentageValue = 'price-change-percentage';
+const priceChangeValue = 'price-change';
+const tradingModeTooltip = 'trading-mode-tooltip';
 
 describe('Market trading page', () => {
   before(() => {
@@ -33,7 +40,7 @@ describe('Market trading page', () => {
     // 7002-SORD-002
     it('must display market name', () => {
       // 6002-MDET-001
-      cy.getByTestId('header-title').should('not.be.empty');
+      cy.getByTestId(marketName).should('not.be.empty');
     });
 
     it('must see market expiry', () => {
@@ -130,14 +137,14 @@ describe('Market trading page', () => {
             .realHover();
         });
       });
-      cy.getByTestId('expiry-tooltip')
+      cy.getByTestId(expirtyTooltip)
         .eq(0)
         .should(
           'contain.text',
           'This market expires when triggered by its oracle, not on a set date.'
         )
         .within(() => {
-          cy.getByTestId('link')
+          cy.getByTestId(link)
             .should('have.attr', 'href')
             .and('include', Cypress.env('EXPLORER_URL'));
         });
@@ -163,15 +170,14 @@ describe('Market trading page', () => {
             .realHover();
         });
       });
-
-      cy.getByTestId('trading-mode-tooltip')
+      cy.getByTestId(tradingModeTooltip)
         .should(
           'contain.text',
           'This market is in auction until it reaches sufficient liquidity.'
         )
         .eq(0)
         .within(() => {
-          cy.getByTestId('external-link')
+          cy.getByTestId(externalLink)
             .should('have.attr', 'href')
             .and('include', Cypress.env('TRADING_MODE_LINK'));
 
@@ -190,17 +196,16 @@ describe('Market trading page', () => {
           cy.getByTestId(itemValue).realHover();
         });
       });
-
-      cy.getByTestId('liquidity-supplied-tooltip')
+      cy.getByTestId(liquiditySuppliedTooltip)
         .should('contain.text', 'Supplied stake')
         .and('contain.text', 'Target stake')
         .first()
         .within(() => {
-          cy.getByTestId('view-liquidity-link').should(
+          cy.getByTestId(liquidityLink).should(
             'have.text',
             'View liquidity provision table'
           );
-          cy.getByTestId('external-link').should(
+          cy.getByTestId(externalLink).should(
             'have.text',
             'Learn about providing liquidity'
           );

--- a/apps/trading-e2e/src/integration/oracle.cy.ts
+++ b/apps/trading-e2e/src/integration/oracle.cy.ts
@@ -1,7 +1,7 @@
 import { MarketState } from '@vegaprotocol/types';
 
-const oracleBannerStatus = 'oracle-banner-status';
 const oracleBannerDialogTrigger = 'oracle-banner-dialog-trigger';
+const oracleBannerStatus = 'oracle-banner-status';
 const oracleFullProfile = 'oracle-full-profile';
 
 describe('oracle information', { tags: '@smoke' }, () => {

--- a/apps/trading-e2e/src/integration/oracle.cy.ts
+++ b/apps/trading-e2e/src/integration/oracle.cy.ts
@@ -1,0 +1,32 @@
+import { MarketState } from '@vegaprotocol/types';
+
+const oracleBannerStatus = 'oracle-banner-status';
+const oracleBannerDialogTrigger = 'oracle-banner-dialog-trigger';
+const oracleFullProfile = 'oracle-full-profile';
+
+describe('oracle information', { tags: '@smoke' }, () => {
+  beforeEach(() => {
+    cy.mockTradingPage();
+  });
+
+  before(() => {
+    cy.mockTradingPage(
+      MarketState.STATE_ACTIVE,
+      undefined,
+      undefined,
+      'COMPROMISED'
+    );
+    cy.mockSubscription();
+    cy.visit('/#/markets/market-0');
+    cy.wait('@Markets');
+    cy.wait('@MarketInfo');
+  });
+
+  it('show oracle banner', () => {
+    cy.getByTestId(oracleBannerStatus).should('contain.text', 'COMPROMISED');
+    cy.getByTestId(oracleBannerDialogTrigger)
+      .should('contain.text', 'Show more')
+      .click();
+    cy.getByTestId(oracleFullProfile).should('exist');
+  });
+});

--- a/apps/trading-e2e/src/integration/oracle.cy.ts
+++ b/apps/trading-e2e/src/integration/oracle.cy.ts
@@ -5,10 +5,6 @@ const oracleBannerDialogTrigger = 'oracle-banner-dialog-trigger';
 const oracleFullProfile = 'oracle-full-profile';
 
 describe('oracle information', { tags: '@smoke' }, () => {
-  beforeEach(() => {
-    cy.mockTradingPage();
-  });
-
   before(() => {
     cy.mockTradingPage(
       MarketState.STATE_ACTIVE,
@@ -19,7 +15,6 @@ describe('oracle information', { tags: '@smoke' }, () => {
     cy.mockSubscription();
     cy.visit('/#/markets/market-0');
     cy.wait('@Markets');
-    cy.wait('@MarketInfo');
   });
 
   it('show oracle banner', () => {

--- a/apps/trading/components/liquidity-supplied/liquidity-supplied.tsx
+++ b/apps/trading/components/liquidity-supplied/liquidity-supplied.tsx
@@ -99,7 +99,7 @@ export const MarketLiquiditySupplied = ({
       AuctionTrigger.AUCTION_TRIGGER_UNABLE_TO_DEPLOY_LP_ORDERS;
 
   const description = marketId ? (
-    <section>
+    <section data-testid="liquidity-supplied-tooltip">
       <KeyValueTable>
         <KeyValueTableRow>
           <span>{t('Supplied stake')}</span>


### PR DESCRIPTION
# Related issues 🔗

Closes #3505 

# Description ℹ️

Added test coverage for 6002-MDET-market-details.

Skipped two ACS: 
- 6002-MDET-204
- 6002-MDET-205

as it would require some additional effort with mocking, but we plan to create more Oracle logic test coverage later.
