### PR TITLE
fix(governance): temporarily skipped flaky staking tests

### DIFF
--- a/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
@@ -63,7 +63,7 @@ context(
       vegaWalletSetSpecifiedApprovalAmount('1000');
     });
 
-    describe('Eth wallet - contains VEGA tokens', function () {
+    describe.skip('Eth wallet - contains VEGA tokens', function () {
       beforeEach(
         'teardown wallet & drill into a specific validator',
         function () {


### PR DESCRIPTION
# Related issues 🔗

Closes #4066

# Description ℹ️
There are issues with flaky staking tests (https://github.com/vegaprotocol/frontend-monorepo/actions/runs/5213432071/jobs/9419229204?pr=4055#step:9:92). I have temporarily skipped these until @jtsang586 can take a look.
