### PR TITLE
feat(governance): hide proposal details for freeform proposals

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
@@ -102,7 +102,8 @@ export const Proposal = ({ proposal, restData }: ProposalProps) => {
         </div>
 
         {proposal.terms.change.__typename !== 'NewMarket' &&
-          proposal.terms.change.__typename !== 'UpdateMarket' && (
+          proposal.terms.change.__typename !== 'UpdateMarket' &&
+          proposal.terms.change.__typename !== 'NewFreeform' && (
             <div className="mb-4">
               <ProposalTerms data={proposal.terms} />
             </div>


### PR DESCRIPTION
# Related issues 🔗

Closes #3876

# Description ℹ️

Does what it says on the tin. Freeform proposals have no useful information in their proposal terms details, so no need to show it.
