### PR TITLE
feat(governance): add 'all proposals' link on proposal details page

### DIFF
--- a/apps/governance/src/i18n/translations/dev.json
+++ b/apps/governance/src/i18n/translations/dev.json
@@ -824,5 +824,7 @@
   "disclaimer5": "No developer of the Vega Governance App accepts any responsibility for, or liability to users in connection with their use of the Vega Governance App.",
   "multisigContractLink": "Ethereum Multisig Contract",
   "multisigContractIncorrect": "is incorrectly configured. Validator and delegator rewards will be penalised until this is resolved.",
-  "learnMore": "Learn more"
+  "learnMore": "Learn more",
+  "AllValidators": "All validators",
+  "AllProposals": "All proposals"
 }

--- a/apps/governance/src/routes/proposals/components/proposal/proposal.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal/proposal.spec.tsx
@@ -1,3 +1,4 @@
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { generateProposal } from '../../test-helpers/generate-proposals';
 import { Proposal } from './proposal';
@@ -41,19 +42,35 @@ jest.mock('../list-asset', () => ({
   ListAsset: () => <div data-testid="proposal-list-asset"></div>,
 }));
 
+const renderComponent = (proposal: ProposalQuery['proposal']) => {
+  render(
+    <MemoryRouter>
+      <Proposal
+        restData={{}}
+        proposal={proposal as ProposalQuery['proposal']}
+      />
+    </MemoryRouter>
+  );
+};
+
 it('Renders with data-testid', async () => {
   const proposal = generateProposal();
-  render(
-    <Proposal restData={{}} proposal={proposal as ProposalQuery['proposal']} />
-  );
+  renderComponent(proposal);
+
   expect(await screen.findByTestId('proposal')).toBeInTheDocument();
+});
+
+it('Renders with a link back to "all proposals"', async () => {
+  const proposal = generateProposal();
+  renderComponent(proposal);
+
+  expect(await screen.findByTestId('all-proposals-link')).toBeInTheDocument();
 });
 
 it('renders each section', async () => {
   const proposal = generateProposal();
-  render(
-    <Proposal restData={{}} proposal={proposal as ProposalQuery['proposal']} />
-  );
+  renderComponent(proposal);
+
   expect(await screen.findByTestId('proposal-header')).toBeInTheDocument();
   expect(screen.getByTestId('proposal-change-table')).toBeInTheDocument();
   expect(screen.getByTestId('proposal-json')).toBeInTheDocument();
@@ -80,8 +97,7 @@ it('renders whitelist section if proposal is new asset and source is erc20', asy
       },
     },
   });
-  render(
-    <Proposal restData={{}} proposal={proposal as ProposalQuery['proposal']} />
-  );
+  renderComponent(proposal);
+
   expect(screen.getByTestId('proposal-list-asset')).toBeInTheDocument();
 });

--- a/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
@@ -2,7 +2,7 @@ import {
   NetworkParams,
   useNetworkParams,
 } from '@vegaprotocol/network-parameters';
-import { AsyncRenderer, RoundedWrapper } from '@vegaprotocol/ui-toolkit';
+import { AsyncRenderer, Icon, RoundedWrapper } from '@vegaprotocol/ui-toolkit';
 import { ProposalHeader } from '../proposal-detail-header/proposal-header';
 import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
@@ -13,6 +13,10 @@ import { ProposalTerms } from '../proposal-terms';
 import { ProposalVotesTable } from '../proposal-votes-table';
 import { VoteDetails } from '../vote-details';
 import { ListAsset } from '../list-asset';
+import { Link } from 'react-router-dom';
+import Routes from '../../../routes';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export enum ProposalType {
   PROPOSAL_NEW_MARKET = 'PROPOSAL_NEW_MARKET',
@@ -29,6 +33,7 @@ export interface ProposalProps {
 }
 
 export const Proposal = ({ proposal, restData }: ProposalProps) => {
+  const { t } = useTranslation();
   const { params, loading, error } = useNetworkParams([
     NetworkParams.governance_proposal_market_minVoterBalance,
     NetworkParams.governance_proposal_updateMarket_minVoterBalance,
@@ -81,6 +86,15 @@ export const Proposal = ({ proposal, restData }: ProposalProps) => {
   return (
     <AsyncRenderer data={params} loading={loading} error={error}>
       <section data-testid="proposal">
+        <div
+          className="flex items-center gap-1"
+          data-testid="all-proposals-link"
+        >
+          <Icon name={'chevron-left'} />
+          <Link className="underline" to={Routes.PROPOSALS}>
+            {t('AllProposals')}
+          </Link>
+        </div>
         <ProposalHeader proposal={proposal} isListItem={false} />
 
         <div className="my-10">

--- a/apps/governance/src/routes/staking/node/node.tsx
+++ b/apps/governance/src/routes/staking/node/node.tsx
@@ -107,7 +107,7 @@ export const StakingNode = ({ data, previousEpochData }: StakingNodeProps) => {
       <div className="flex items-center gap-1">
         <Icon name={'chevron-left'} />
         <Link className="underline" to={Routes.VALIDATORS}>
-          {t('All validators')}
+          {t('AllValidators')}
         </Link>
       </div>
       <Heading


### PR DESCRIPTION
# Related issues 🔗

Closes #2752

# Description ℹ️

To be consistent with a similar situation with validators, add an 'all proposals' link at the top of a proposal details page.

<img width="357" alt="Screenshot 2023-06-12 at 12 03 07" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/b0b5a6d2-98ee-4af7-92f5-94a0b2c8e9ca">

