### PR TITLE
fix(liquidity): update liquidity table row id

### DIFF
--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -55,7 +55,7 @@ export const LiquidityTable = forwardRef<AgGridReact, LiquidityTableProps>(
       <AgGrid
         style={{ width: '100%', height: '100%' }}
         overlayNoRowsTemplate={t('No liquidity provisions')}
-        getRowId={({ data }) => data.id}
+        getRowId={({ data }) => `${data.party.id}-${data.status}`}
         ref={ref}
         tooltipShowDelay={500}
         defaultColDef={{


### PR DESCRIPTION
# Related issues 🔗

Closes #4079 

# Description ℹ️

Fixes an issue where some rows where not ordered correctly in LP table. 

# Demo 📺

<img width="952" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/5f068ae0-fffb-46dd-aacb-6b913ab0bcda">

# Technical 👨‍🔧

Liquidity provisions do not have an ID so we need to construct the row id based on party ID and the status of liquidity provision (because a party might have multiple inactive LPs for a market i.e. cancelled, rejected).
