### PR TITLE
fix(governance): earned by me reward percentage

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
@@ -48,10 +48,17 @@ export const EpochIndividualRewards = ({
     return removePaginationWrapper(data.party.rewardsConnection.edges);
   }, [data]);
 
+  const rewardsSummaries = useMemo(() => {
+    if (!data?.epochRewardSummaries) return [];
+
+    return removePaginationWrapper(data.epochRewardSummaries.edges);
+  }, [data]);
+
   const epochIndividualRewardSummaries = useMemo(() => {
     if (!data?.party) return [];
     return generateEpochIndividualRewardsList({
       rewards,
+      rewardsSummaries,
       epochId,
       page,
       size: EPOCHS_PAGE_SIZE,

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
@@ -48,7 +48,7 @@ export const EpochIndividualRewards = ({
     return removePaginationWrapper(data.party.rewardsConnection.edges);
   }, [data]);
 
-  const rewardsSummaries = useMemo(() => {
+  const epochRewardSummaries = useMemo(() => {
     if (!data?.epochRewardSummaries) return [];
 
     return removePaginationWrapper(data.epochRewardSummaries.edges);
@@ -58,12 +58,12 @@ export const EpochIndividualRewards = ({
     if (!data?.party) return [];
     return generateEpochIndividualRewardsList({
       rewards,
-      rewardsSummaries,
       epochId,
+      epochRewardSummaries,
       page,
       size: EPOCHS_PAGE_SIZE,
     });
-  }, [data?.party, epochId, page, rewards]);
+  }, [data?.party, epochId, epochRewardSummaries, page, rewards]);
 
   const refetchData = useCallback(
     async (toPage?: number) => {

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
@@ -31,6 +31,7 @@ const emptyRowAccountTypes = accountTypes.map((type) => [
 
 export const generateEpochIndividualRewardsList = ({
   rewards,
+  rewardsSummaries,
   epochId,
   page = 1,
   size = 10,

--- a/apps/governance/src/routes/rewards/home/Rewards.graphql
+++ b/apps/governance/src/routes/rewards/home/Rewards.graphql
@@ -58,18 +58,15 @@ query Rewards(
     }
   }
   epochRewardSummaries(
-      filter: {
-        fromEpoch: $fromEpoch
-        toEpoch: $toEpoch
-        }
-        pagination: $rewardsPagination
-      ) {
-          edges {
-            node {
-              ...EpochRewardSummaryFields
-            }
-          }
-        }
+    filter: { fromEpoch: $fromEpoch, toEpoch: $toEpoch }
+    pagination: $rewardsPagination
+  ) {
+    edges {
+      node {
+        ...EpochRewardSummaryFields
+      }
+    }
+  }
 }
 
 query EpochAssetsRewards(

--- a/apps/governance/src/routes/rewards/home/Rewards.graphql
+++ b/apps/governance/src/routes/rewards/home/Rewards.graphql
@@ -22,6 +22,13 @@ fragment DelegationFields on Delegation {
   epoch
 }
 
+fragment EpochRewardSummaryFields on EpochRewardSummary {
+  epoch
+  assetId
+  amount
+  rewardType
+}
+
 query Rewards(
   $partyId: ID!
   $fromEpoch: Int
@@ -63,13 +70,6 @@ query Rewards(
             }
           }
         }
-}
-
-fragment EpochRewardSummaryFields on EpochRewardSummary {
-  epoch
-  assetId
-  amount
-  rewardType
 }
 
 query EpochAssetsRewards(

--- a/apps/governance/src/routes/rewards/home/Rewards.graphql
+++ b/apps/governance/src/routes/rewards/home/Rewards.graphql
@@ -50,6 +50,19 @@ query Rewards(
       }
     }
   }
+  epochRewardSummaries(
+      filter: {
+        fromEpoch: $fromEpoch
+        toEpoch: $toEpoch
+        }
+        pagination: $rewardsPagination
+      ) {
+          edges {
+            node {
+              ...EpochRewardSummaryFields
+            }
+          }
+        }
 }
 
 fragment EpochRewardSummaryFields on EpochRewardSummary {

--- a/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
+++ b/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
@@ -7,6 +7,8 @@ export type RewardFieldsFragment = { __typename?: 'Reward', rewardType: Types.Ac
 
 export type DelegationFieldsFragment = { __typename?: 'Delegation', amount: string, epoch: number };
 
+export type EpochRewardSummaryFieldsFragment = { __typename?: 'EpochRewardSummary', epoch: number, assetId: string, amount: string, rewardType: Types.AccountType };
+
 export type RewardsQueryVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
   fromEpoch?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -16,9 +18,7 @@ export type RewardsQueryVariables = Types.Exact<{
 }>;
 
 
-export type RewardsQuery = { __typename?: 'Query', party?: { __typename?: 'Party', id: string, rewardsConnection?: { __typename?: 'RewardsConnection', edges?: Array<{ __typename?: 'RewardEdge', node: { __typename?: 'Reward', rewardType: Types.AccountType, amount: string, percentageOfTotal: string, receivedAt: any, asset: { __typename?: 'Asset', id: string, symbol: string, name: string, decimals: number }, party: { __typename?: 'Party', id: string }, epoch: { __typename?: 'Epoch', id: string } } } | null> | null } | null, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number } } | null> | null } | null } | null, epochRewardSummaries?: { __typename?: 'EpochRewardSummaryConnection', edges?: Array<{ __typename?: 'EpochRewardSummaryEdge', node: { __typename?: 'EpochRewardSummary', epoch: number, rewardType: Types.AccountType, amount: string } } | null> | null } | null };
-
-export type EpochRewardSummaryFieldsFragment = { __typename?: 'EpochRewardSummary', epoch: number, assetId: string, amount: string, rewardType: Types.AccountType };
+export type RewardsQuery = { __typename?: 'Query', party?: { __typename?: 'Party', id: string, rewardsConnection?: { __typename?: 'RewardsConnection', edges?: Array<{ __typename?: 'RewardEdge', node: { __typename?: 'Reward', rewardType: Types.AccountType, amount: string, percentageOfTotal: string, receivedAt: any, asset: { __typename?: 'Asset', id: string, symbol: string, name: string, decimals: number }, party: { __typename?: 'Party', id: string }, epoch: { __typename?: 'Epoch', id: string } } } | null> | null } | null, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number } } | null> | null } | null } | null, epochRewardSummaries?: { __typename?: 'EpochRewardSummaryConnection', edges?: Array<{ __typename?: 'EpochRewardSummaryEdge', node: { __typename?: 'EpochRewardSummary', epoch: number, assetId: string, amount: string, rewardType: Types.AccountType } } | null> | null } | null };
 
 export type EpochAssetsRewardsQueryVariables = Types.Exact<{
   epochRewardSummariesFilter?: Types.InputMaybe<Types.RewardSummaryFilter>;
@@ -108,15 +108,14 @@ export const RewardsDocument = gql`
   ) {
     edges {
       node {
-        epoch
-        rewardType
-        amount
+        ...EpochRewardSummaryFields
       }
     }
   }
 }
     ${RewardFieldsFragmentDoc}
-${DelegationFieldsFragmentDoc}`;
+${DelegationFieldsFragmentDoc}
+${EpochRewardSummaryFieldsFragmentDoc}`;
 
 /**
  * __useRewardsQuery__

--- a/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
+++ b/apps/governance/src/routes/rewards/home/__generated__/Rewards.ts
@@ -16,7 +16,7 @@ export type RewardsQueryVariables = Types.Exact<{
 }>;
 
 
-export type RewardsQuery = { __typename?: 'Query', party?: { __typename?: 'Party', id: string, rewardsConnection?: { __typename?: 'RewardsConnection', edges?: Array<{ __typename?: 'RewardEdge', node: { __typename?: 'Reward', rewardType: Types.AccountType, amount: string, percentageOfTotal: string, receivedAt: any, asset: { __typename?: 'Asset', id: string, symbol: string, name: string, decimals: number }, party: { __typename?: 'Party', id: string }, epoch: { __typename?: 'Epoch', id: string } } } | null> | null } | null, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number } } | null> | null } | null } | null };
+export type RewardsQuery = { __typename?: 'Query', party?: { __typename?: 'Party', id: string, rewardsConnection?: { __typename?: 'RewardsConnection', edges?: Array<{ __typename?: 'RewardEdge', node: { __typename?: 'Reward', rewardType: Types.AccountType, amount: string, percentageOfTotal: string, receivedAt: any, asset: { __typename?: 'Asset', id: string, symbol: string, name: string, decimals: number }, party: { __typename?: 'Party', id: string }, epoch: { __typename?: 'Epoch', id: string } } } | null> | null } | null, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number } } | null> | null } | null } | null, epochRewardSummaries?: { __typename?: 'EpochRewardSummaryConnection', edges?: Array<{ __typename?: 'EpochRewardSummaryEdge', node: { __typename?: 'EpochRewardSummary', epoch: number, rewardType: Types.AccountType, amount: string } } | null> | null } | null };
 
 export type EpochRewardSummaryFieldsFragment = { __typename?: 'EpochRewardSummary', epoch: number, assetId: string, amount: string, rewardType: Types.AccountType };
 
@@ -99,6 +99,18 @@ export const RewardsDocument = gql`
         node {
           ...DelegationFields
         }
+      }
+    }
+  }
+  epochRewardSummaries(
+    filter: {fromEpoch: $fromEpoch, toEpoch: $toEpoch}
+    pagination: $rewardsPagination
+  ) {
+    edges {
+      node {
+        epoch
+        rewardType
+        amount
       }
     }
   }


### PR DESCRIPTION
# Related issues 🔗

Closes #3942

# Description ℹ️

In a situation where there are multiple rewards per epoch of the same type and asset, we weren't correctly calculating total percentage earned for an individual's rewards. We now sum the rewards and compare that amount to the total rewarded of that asset in that reward type in that epoch to determine the correct percentage.