### PR TITLE
chore(governance): un-skip staking test and increase test coverage for smoke tests

### DIFF
--- a/apps/governance-e2e/cypress.config.js
+++ b/apps/governance-e2e/cypress.config.js
@@ -49,7 +49,7 @@ module.exports = defineConfig({
     vegaTokenContractAddress: '0xF41bD86d462D36b997C0bbb4D97a0a3382f205B7',
     vegaTokenAddress: '0x67175Da1D5e966e40D11c4B2519392B2058373de',
     txTimeout: { timeout: 70000 },
-    epochTimeout: { timeout: 6000 },
+    epochTimeout: { timeout: 10000 },
     blockConfirmations: 3,
     grepTags: '@regression @smoke @slow',
     grepFilterSpecs: true,

--- a/apps/governance-e2e/src/integration/flow/proposal-forms.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/proposal-forms.cy.ts
@@ -205,29 +205,33 @@ context(
     });
 
     // 3003-PMAN-001
-    it('Able to submit valid new market proposal', function () {
-      goToMakeNewProposal(governanceProposalType.NEW_MARKET);
-      cy.get(newProposalTitle).type('Test new market proposal');
-      cy.get(newProposalDescription).type('E2E test for proposals');
-      cy.fixture('/proposals/new-market').then((newMarketProposal) => {
-        const newMarketPayload = JSON.stringify(newMarketProposal);
-        cy.get(newProposalTerms).type(newMarketPayload, {
-          parseSpecialCharSequences: false,
-          delay: 2,
-        });
-      });
-      cy.get(proposalDownloadBtn)
-        .should('be.visible')
-        .click()
-        .then(() => {
-          cy.wrap(
-            getDownloadedProposalJsonPath('vega-new-market-proposal-')
-          ).then((filePath) => {
-            goToMakeNewProposal(governanceProposalType.RAW);
-            submitUniqueRawProposal({ proposalBody: filePath }); // 3003-PMAN-003
+    it(
+      'Able to submit valid new market proposal',
+      { tags: '@smoke' },
+      function () {
+        goToMakeNewProposal(governanceProposalType.NEW_MARKET);
+        cy.get(newProposalTitle).type('Test new market proposal');
+        cy.get(newProposalDescription).type('E2E test for proposals');
+        cy.fixture('/proposals/new-market').then((newMarketProposal) => {
+          const newMarketPayload = JSON.stringify(newMarketProposal);
+          cy.get(newProposalTerms).type(newMarketPayload, {
+            parseSpecialCharSequences: false,
+            delay: 2,
           });
         });
-    });
+        cy.get(proposalDownloadBtn)
+          .should('be.visible')
+          .click()
+          .then(() => {
+            cy.wrap(
+              getDownloadedProposalJsonPath('vega-new-market-proposal-')
+            ).then((filePath) => {
+              goToMakeNewProposal(governanceProposalType.RAW);
+              submitUniqueRawProposal({ proposalBody: filePath }); // 3003-PMAN-003
+            });
+          });
+      }
+    );
 
     it('Unable to submit new market proposal with missing/invalid fields', function () {
       const errorMsg =

--- a/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/staking-flow.cy.ts
@@ -63,7 +63,7 @@ context(
       vegaWalletSetSpecifiedApprovalAmount('1000');
     });
 
-    describe.skip('Eth wallet - contains VEGA tokens', function () {
+    describe('Eth wallet - contains VEGA tokens', function () {
       beforeEach(
         'teardown wallet & drill into a specific validator',
         function () {

--- a/apps/governance-e2e/src/integration/flow/token-association-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/token-association-flow.cy.ts
@@ -64,31 +64,38 @@ context(
         }
       );
 
-      it('Able to associate tokens - from wallet', function () {
-        //1004-ASSO-003
-        //1004-ASSO-005
-        //1004-ASSO-009
-        //1004-ASSO-030
-        //1004-ASSO-012
-        //1004-ASSO-013
-        //1004-ASSO-014
-        //1004-ASSO-015
-        //1004-ASSO-030
-        //0005-ETXN-006
-        //0005-ETXN-003
-        //0005-ETXN-005
-        stakingPageAssociateTokens('2', { skipConfirmation: true });
-        validateWalletCurrency('Associated', '0.00');
-        validateWalletCurrency('Pending association', '2.00');
-        validateWalletCurrency('Total associated after pending', '2.00');
-        // 0005-ETXN-002
-        verifyEthWalletAssociatedBalance('2.0');
-        verifyEthWalletTotalAssociatedBalance('2.0');
-        cy.get(vegaWallet).within(() => {
-          cy.get(vegaWalletAssociatedBalance, txTimeout).should('contain', 2.0);
-        });
-        cy.get(vegaWalletUnstakedBalance, txTimeout).should('contain', 2.0);
-      });
+      it(
+        'Able to associate tokens - from wallet',
+        { tags: '@smoke' },
+        function () {
+          //1004-ASSO-003
+          //1004-ASSO-005
+          //1004-ASSO-009
+          //1004-ASSO-030
+          //1004-ASSO-012
+          //1004-ASSO-013
+          //1004-ASSO-014
+          //1004-ASSO-015
+          //1004-ASSO-030
+          //0005-ETXN-006
+          //0005-ETXN-003
+          //0005-ETXN-005
+          stakingPageAssociateTokens('2', { skipConfirmation: true });
+          validateWalletCurrency('Associated', '0.00');
+          validateWalletCurrency('Pending association', '2.00');
+          validateWalletCurrency('Total associated after pending', '2.00');
+          // 0005-ETXN-002
+          verifyEthWalletAssociatedBalance('2.0');
+          verifyEthWalletTotalAssociatedBalance('2.0');
+          cy.get(vegaWallet).within(() => {
+            cy.get(vegaWalletAssociatedBalance, txTimeout).should(
+              'contain',
+              2.0
+            );
+          });
+          cy.get(vegaWalletUnstakedBalance, txTimeout).should('contain', 2.0);
+        }
+      );
 
       it('Able to disassociate all associated tokens - manually', function () {
         // 1004-ASSO-025

--- a/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
@@ -92,71 +92,75 @@ context(
       });
     });
 
-    it('Able to withdraw asset: -eth wallet connected -withdraw funds button', function () {
-      // fill in withdrawal form
-      cy.getByTestId(withdraw).should('be.visible').click();
-      cy.getByTestId(withdrawalForm, txTimeout).within(() => {
-        cy.getByTestId('select-asset').click();
-        cy.get('select')
-          .select(usdtSelectValue, { force: true })
-          .should('have.value', usdtSelectValue);
-        cy.getByTestId(balanceAvailable, txTimeout).should('exist');
-        cy.getByTestId(withdrawalThreshold).should(
-          'have.text',
-          '100,000.00000T'
-        );
-        cy.getByTestId(delayTime).should('have.text', 'None');
-        cy.getByTestId(amountInput).click().type('120');
-        cy.getByTestId(submitWithdrawalButton).click();
-      });
-      // assert withdrawal request
-      cy.getByTestId(toast)
-        .first(txTimeout)
-        .should('contain.text', 'Funds unlocked')
-        .within(() => {
-          cy.getByTestId('external-link').should('exist');
-          cy.getByTestId(toastPanel).should(
-            'contain.text',
-            'Withdraw 120.00 tUSDC'
+    it(
+      'Able to withdraw asset: -eth wallet connected -withdraw funds button',
+      { tags: '@smoke' },
+      function () {
+        // fill in withdrawal form
+        cy.getByTestId(withdraw).should('be.visible').click();
+        cy.getByTestId(withdrawalForm, txTimeout).within(() => {
+          cy.getByTestId('select-asset').click();
+          cy.get('select')
+            .select(usdtSelectValue, { force: true })
+            .should('have.value', usdtSelectValue);
+          cy.getByTestId(balanceAvailable, txTimeout).should('exist');
+          cy.getByTestId(withdrawalThreshold).should(
+            'have.text',
+            '100,000.00000T'
           );
-          cy.getByTestId(toastCompleteWithdrawal).click();
-          cy.getByTestId(toastClose).click();
+          cy.getByTestId(delayTime).should('have.text', 'None');
+          cy.getByTestId(amountInput).click().type('120');
+          cy.getByTestId(submitWithdrawalButton).click();
         });
-      // withdrawal complete
-      cy.getByTestId(toast)
-        .first(txTimeout)
-        .should('contain.text', 'The withdrawal has been approved.')
-        .within(() => {
-          cy.getByTestId(toastPanel).should(
-            'contain.text',
-            'Withdraw 120.00 tUSDC'
-          );
-        });
-      cy.getByTestId(toast)
-        .last(txTimeout)
-        .should('contain.text', 'Transaction confirmed')
-        .within(() => {
-          cy.getByTestId('external-link').should('exist');
-        });
-      // withdrawal history for complete withdrawal displayed
-      cy.get(tableWithdrawnStatus)
-        .eq(1, txTimeout)
-        .should('have.text', 'Completed')
-        .parent()
-        .within(() => {
-          cy.get(tableAssetSymbol).should('have.text', usdcSymbol);
-          cy.get(tableAmount).should('have.text', '120.00');
-          cy.get(tableReceiverAddress)
-            .find('a')
-            .should('have.attr', 'href')
-            .and('contain', 'https://sepolia.etherscan.io/address/');
-          cy.get(tableWithdrawnTimeStamp).should('not.be.empty');
-          cy.get(tableTxHash)
-            .find('a')
-            .should('have.attr', 'href')
-            .and('contain', 'https://sepolia.etherscan.io/tx/');
-        });
-    });
+        // assert withdrawal request
+        cy.getByTestId(toast)
+          .first(txTimeout)
+          .should('contain.text', 'Funds unlocked')
+          .within(() => {
+            cy.getByTestId('external-link').should('exist');
+            cy.getByTestId(toastPanel).should(
+              'contain.text',
+              'Withdraw 120.00 tUSDC'
+            );
+            cy.getByTestId(toastCompleteWithdrawal).click();
+            cy.getByTestId(toastClose).click();
+          });
+        // withdrawal complete
+        cy.getByTestId(toast)
+          .first(txTimeout)
+          .should('contain.text', 'The withdrawal has been approved.')
+          .within(() => {
+            cy.getByTestId(toastPanel).should(
+              'contain.text',
+              'Withdraw 120.00 tUSDC'
+            );
+          });
+        cy.getByTestId(toast)
+          .last(txTimeout)
+          .should('contain.text', 'Transaction confirmed')
+          .within(() => {
+            cy.getByTestId('external-link').should('exist');
+          });
+        // withdrawal history for complete withdrawal displayed
+        cy.get(tableWithdrawnStatus)
+          .eq(1, txTimeout)
+          .should('have.text', 'Completed')
+          .parent()
+          .within(() => {
+            cy.get(tableAssetSymbol).should('have.text', usdcSymbol);
+            cy.get(tableAmount).should('have.text', '120.00');
+            cy.get(tableReceiverAddress)
+              .find('a')
+              .should('have.attr', 'href')
+              .and('contain', 'https://sepolia.etherscan.io/address/');
+            cy.get(tableWithdrawnTimeStamp).should('not.be.empty');
+            cy.get(tableTxHash)
+              .find('a')
+              .should('have.attr', 'href')
+              .and('contain', 'https://sepolia.etherscan.io/tx/');
+          });
+      }
+    );
 
     it('Able to withdraw asset: -eth wallet not connected', function () {
       const ethWalletAddress = Cypress.env('ethWalletPublicKey');

--- a/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
@@ -55,6 +55,10 @@ context(
       navigateTo(navigation.withdraw);
       cy.connectVegaWallet();
       ethereumWalletConnect();
+      cy.getByTestId('currency-title', txTimeout).should(
+        'contain.text',
+        usdtName
+      );
     });
 
     it('Able to open withdrawal form with vega wallet connected', function () {

--- a/apps/governance-e2e/src/integration/view/validators.cy.ts
+++ b/apps/governance-e2e/src/integration/view/validators.cy.ts
@@ -5,7 +5,10 @@ import {
   verifyPageHeader,
   verifyTabHighlighted,
 } from '../../support/common.functions';
-import { clickOnValidatorFromList } from '../../support/staking.functions';
+import {
+  clickOnValidatorFromList,
+  waitForBeginningOfEpoch,
+} from '../../support/staking.functions';
 
 const guideLink = '[data-testid="staking-guide-link"]';
 const validatorTitle = '[data-testid="validator-node-title"]';
@@ -80,6 +83,7 @@ context('Validators Page - verify elements on page', function () {
         });
 
         it('Should be able to see validator stake tooltip', function () {
+          waitForBeginningOfEpoch();
           cy.getByTestId('total-stake').first().realHover();
 
           cy.get(stakedByOperatorToolTip)
@@ -102,6 +106,7 @@ context('Validators Page - verify elements on page', function () {
         });
 
         it('Should be able to see validator normalised voting power tooltip', function () {
+          waitForBeginningOfEpoch();
           cy.getByTestId('normalised-voting-power').first().realHover();
 
           cy.get(unnormalisedVotingPowerToolTip)
@@ -122,6 +127,7 @@ context('Validators Page - verify elements on page', function () {
         });
 
         it('Should be able to see validator penalties tooltip', function () {
+          waitForBeginningOfEpoch();
           cy.getByTestId('total-penalty').realHover();
 
           cy.get(performancePenaltyToolTip)

--- a/apps/governance-e2e/src/integration/view/wallet-vega.cy.ts
+++ b/apps/governance-e2e/src/integration/view/wallet-vega.cy.ts
@@ -337,6 +337,7 @@ context(
                 .parent()
                 .siblings()
                 .invoke('text')
+                .should('have.length.at.least', 4)
                 .then(parseFloat)
                 .should('be.gte', parseFloat(expectedAmount));
 


### PR DESCRIPTION
# Related issues 🔗

Previously, a staking test was skipped because of flaky failures. I believe that was already fixed in a previous PR. So will un-skip that test and monitor. 

- Added assertion to wallet test which has had flaky failures
- Added 3 additional smoke tests to increase coverage in PR builds - this adds around 2-3 minutes to the build time which I think is worth it for the extra coverage
