### PR TITLE
fix(ui-toolkit): visual fixes for healthbar - % and text colours

### DIFF
--- a/libs/ui-toolkit/package.json
+++ b/libs/ui-toolkit/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/ui-toolkit",
-  "version": "0.12.4"
+  "version": "0.12.5"
 }

--- a/libs/ui-toolkit/src/components/healthbar/healthbar.tsx
+++ b/libs/ui-toolkit/src/components/healthbar/healthbar.tsx
@@ -82,12 +82,12 @@ const Level = ({
     : '-';
 
   const tooltipContent = (
-    <>
+    <div className="text-vega-dark-100 dark:text-vega-light-200">
       <div className="mt-1.5 inline-flex">
         <Indicator variant={intent} />
       </div>
       <span>
-        {formattedFee}% {t('Fee')}
+        {formattedFee} {t('Fee')}
       </span>
       <div className="flex  flex-col">
         <span>
@@ -95,7 +95,7 @@ const Level = ({
           {addDecimalsFormatNumber(commitmentAmount, decimals)}
         </span>
       </div>
-    </>
+    </div>
   );
 
   return (


### PR DESCRIPTION
# Related issues 🔗

Closes #4118 

# Description ℹ️

Integrating #4152 with the website project has identified a few more visual issues with the healthbar.

Remove a now-extra `%` and make sure we're specifying text colours for the tooltip content

Some screenshots post these changes:
<img width="246" alt="Screenshot 2023-06-21 at 15 51 54" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6756742/4250665c-38c5-4162-8b7b-623237335f55">
<img width="238" alt="Screenshot 2023-06-21 at 15 52 12" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6756742/d86fe19a-715f-4145-a144-6bee2aa6f7ca">


