### PR TITLE
chore(ui-toolkit): remove forwardRef as refs weren't being passed

### DIFF
--- a/libs/ui-toolkit/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/ui-toolkit/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import { VegaIcon, VegaIconNames } from '../icon';
 import { Icon } from '../icon';
@@ -164,10 +164,9 @@ export const DropdownMenuSeparator = forwardRef<
 /**
  * Container element for submenus
  */
-export const DropdownMenuSub = forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Sub>,
-  React.ComponentProps<typeof DropdownMenuPrimitive.Sub>
->(({ ...subProps }) => <DropdownMenuPrimitive.Sub {...subProps} />);
+export const DropdownMenuSub = (
+  subProps: ComponentProps<typeof DropdownMenuPrimitive.Sub>
+) => <DropdownMenuPrimitive.Sub {...subProps} />;
 
 /**
  * Container within a DropdownMenuSub specifically for the content
@@ -201,10 +200,9 @@ export const DropdownMenuSubTrigger = forwardRef<
  * Portal to ensure menu portions are rendered outwith where they appear in the
  * DOM.
  */
-export const DropdownMenuPortal = forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Portal>,
-  React.ComponentProps<typeof DropdownMenuPrimitive.Portal>
->(({ ...portalProps }) => <DropdownMenuPrimitive.Portal {...portalProps} />);
+export const DropdownMenuPortal = (
+  portalProps: ComponentProps<typeof DropdownMenuPrimitive.Portal>
+) => <DropdownMenuPrimitive.Portal {...portalProps} />;
 
 /**
  * Wraps a regular DropdownMenuItem with copy to clip board functionality


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Removes unused ref warnings from dropdown menu
