### PR TITLE
fix(trading): market info number formatting

### DIFF
--- a/apps/trading-e2e/src/integration/market-info.cy.ts
+++ b/apps/trading-e2e/src/integration/market-info.cy.ts
@@ -182,7 +182,7 @@ describe('market info is displayed', { tags: '@smoke' }, () => {
       .contains('Liquidity monitoring parameters')
       .click();
 
-    validateMarketDataRow(0, 'Triggering Ratio', '0');
+    validateMarketDataRow(0, 'Triggering Ratio', '0.7');
     validateMarketDataRow(1, 'Time Window', '3,600');
     validateMarketDataRow(2, 'Scaling Factor', '10');
   });

--- a/libs/markets/src/lib/components/market-info/info-key-value-table.tsx
+++ b/libs/markets/src/lib/components/market-info/info-key-value-table.tsx
@@ -47,7 +47,10 @@ const Row = ({
     if (asPercentage) {
       return formatNumberPercentage(new BigNumber(value).times(100));
     }
-    return `${formatNumber(Number(value))} ${assetSymbol}`;
+    if (assetSymbol) {
+      return `${Number(value).toLocaleString()} ${assetSymbol}`;
+    }
+    return Number(value).toLocaleString();
   };
 
   const formattedValue = getFormattedValue(value);

--- a/libs/markets/src/lib/components/market-info/info-key-value-table.tsx
+++ b/libs/markets/src/lib/components/market-info/info-key-value-table.tsx
@@ -1,6 +1,5 @@
 import {
   addDecimalsFormatNumber,
-  formatNumber,
   formatNumberPercentage,
 } from '@vegaprotocol/utils';
 import { t } from '@vegaprotocol/i18n';

--- a/libs/markets/src/lib/components/market-info/market-info.mock.ts
+++ b/libs/markets/src/lib/components/market-info/market-info.mock.ts
@@ -94,7 +94,7 @@ export const marketInfoQuery = (
       },
       lpPriceRange: '0.02',
       liquidityMonitoringParameters: {
-        triggeringRatio: '0',
+        triggeringRatio: '0.7',
         targetStakeParameters: {
           timeWindow: 3600,
           scalingFactor: 10,


### PR DESCRIPTION
# Related issues 🔗

Closes #4166 

# Description ℹ️

Market info number formatting. 
formatNumber method was used before with 0 dp 
``` return getNumberFormat(formatDecimals).format(Number(rawValue));```  - it rounded values less < 1 (ex. 0.7) to 1 

# Demo 📺

<img width="778" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/b3856ac2-b17f-45b1-ab21-60f2fe0e6022">

format number decimals 0 rounds the number 

<img width="778" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/503aa2bd-e6aa-4cb1-90f9-f79fdfad514a">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
