### PR TITLE
chore(trading,governance,explorer): re-enable nx-cloud

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
   },
   "tasksRunnerOptions": {
     "default": {
-      "runner": "nx/tasks-runners/default",
+      "runner": "@nrwl/nx-cloud",
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "accessToken": "OTY4ZjdlZTItNGIwNy00NDcyLTllZjctOWIzYTg1NWE0Yzg1fHJlYWQtd3JpdGU=",


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Re-enables NX cloud as we are now on Nx cloud's open source plan which has unlimted CI pipeline executions per month