### PR TITLE
fix(explorer): liquidity amend order showed incorrect fee

### DIFF
--- a/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
@@ -32,7 +32,6 @@ function renderExistingAmend(id: string, version: number, amend: Amend) {
         query: ExplorerDeterministicOrderDocument,
         variables: {
           orderId: '123',
-          version: 1,
         },
       },
       result: {

--- a/apps/explorer/src/app/components/order-details/amend-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.tsx
@@ -34,13 +34,9 @@ export function getSideDeltaColour(delta: string): string {
  * @param param0
  * @returns
  */
-const AmendOrderDetails = ({
-  id,
-  version = 0,
-  amend,
-}: AmendOrderDetailsProps) => {
+const AmendOrderDetails = ({ id, amend }: AmendOrderDetailsProps) => {
   const { data, error } = useExplorerDeterministicOrderQuery({
-    variables: { orderId: id, version },
+    variables: { orderId: id },
   });
 
   if (error || (data && !data.orderByID)) {

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.test.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react';
+import { TxDetailsLiquidityAmendment } from './tx-liquidity-amend';
+import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint-blocks-response';
+import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
+import { MockedProvider } from '@apollo/client/testing';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('TxDetailsLiquidityAmendment', () => {
+  const mockTxData = {
+    hash: 'test',
+    command: {
+      liquidityProvisionAmendment: {
+        marketId: 'BTC-USD',
+        commitmentAmount: 100,
+        fee: '0.01',
+      },
+    },
+  };
+  const mockPubKey = '123';
+  const mockBlockData = {
+    result: {
+      block: {
+        header: {
+          height: '123',
+        },
+      },
+    },
+  };
+
+  it('should render the component with correct data', () => {
+    const { getByText } = render(
+      <MockedProvider>
+        <MemoryRouter>
+          <TxDetailsLiquidityAmendment
+            txData={mockTxData as BlockExplorerTransactionResult}
+            pubKey={mockPubKey}
+            blockData={mockBlockData as TendermintBlocksResponse}
+          />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    expect(getByText('Market')).toBeInTheDocument();
+    expect(getByText('BTC-USD')).toBeInTheDocument();
+    expect(getByText('Commitment amount')).toBeInTheDocument();
+    expect(getByText('100')).toBeInTheDocument();
+    expect(getByText('Fee')).toBeInTheDocument();
+    expect(getByText('1%')).toBeInTheDocument();
+  });
+
+  it('should display awaiting message when tx data is undefined', () => {
+    const { getByText } = render(
+      <MockedProvider>
+        <MemoryRouter>
+          <TxDetailsLiquidityAmendment
+            txData={undefined}
+            pubKey={mockPubKey}
+            blockData={mockBlockData as TendermintBlocksResponse}
+          />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    expect(
+      getByText('Awaiting Block Explorer transaction details')
+    ).toBeInTheDocument();
+  });
+
+  it('should display awaiting message when liquidityProvisionAmendment is undefined', () => {
+    const { getByText } = render(
+      <MockedProvider>
+        <MemoryRouter>
+          <TxDetailsLiquidityAmendment
+            txData={{ command: {} } as BlockExplorerTransactionResult}
+            pubKey={mockPubKey}
+            blockData={mockBlockData as TendermintBlocksResponse}
+          />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    expect(
+      getByText('Awaiting Block Explorer transaction details')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
@@ -34,6 +34,8 @@ export const TxDetailsLiquidityAmendment = ({
     txData.command.liquidityProvisionAmendment;
   const marketId: string = amendment.marketId || '-';
 
+  const fee = amendment.fee ? parseFloat(amendment.fee) * 100 : '-';
+
   return (
     <>
       <TableWithTbody className="mb-8" allowWrap={true}>
@@ -63,7 +65,7 @@ export const TxDetailsLiquidityAmendment = ({
         {amendment.fee ? (
           <TableRow modifier="bordered">
             <TableCell>{t('Fee')}</TableCell>
-            <TableCell>{amendment.fee}%</TableCell>
+            <TableCell>{fee}%</TableCell>
           </TableRow>
         ) : null}
       </TableWithTbody>

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
@@ -7,6 +7,7 @@ import { TableCell, TableRow, TableWithTbody } from '../../table';
 import type { components } from '../../../../types/explorer';
 import { LiquidityProvisionDetails } from './liquidity-provision/liquidity-provision-details';
 import PriceInMarket from '../../price-in-market/price-in-market';
+import BigNumber from 'bignumber.js';
 
 export type LiquidityAmendment =
   components['schemas']['v1LiquidityProvisionAmendment'];
@@ -34,7 +35,9 @@ export const TxDetailsLiquidityAmendment = ({
     txData.command.liquidityProvisionAmendment;
   const marketId: string = amendment.marketId || '-';
 
-  const fee = amendment.fee ? parseFloat(amendment.fee) * 100 : '-';
+  const fee = amendment.fee
+    ? new BigNumber(amendment.fee).times(100).toString()
+    : '-';
 
   return (
     <>


### PR DESCRIPTION
# Description ℹ️

The fee figure shown on amend LP TXs was not formatted as a percentage. Now it is.
