### PR TITLE
fix(trading): notional size formatting

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -124,7 +124,7 @@ export const DealTicket = ({
           normalizedOrder.size,
           market.positionDecimalPlaces
         ).multipliedBy(toBigNum(price, market.decimalPlaces)),
-        asset.decimals
+        market.decimalPlaces
       );
     }
     return null;
@@ -133,7 +133,6 @@ export const DealTicket = ({
     normalizedOrder?.size,
     market.decimalPlaces,
     market.positionDecimalPlaces,
-    asset.decimals,
   ]);
 
   const feeEstimate = useEstimateFees(


### PR DESCRIPTION
# Related issues 🔗

Closes #4189 

# Description ℹ️

The notional size was formatted again with asset dp. 

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
