### PR TITLE
fix(explorer): fix order amend tx view

### DIFF
--- a/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
@@ -12,7 +12,7 @@ type Amend = components['schemas']['v1OrderAmendment'];
 
 function renderAmendOrderDetails(
   id: string,
-  version: number,
+  version: number | undefined,
   amend: Amend,
   mocks: MockedResponse[]
 ) {
@@ -25,7 +25,11 @@ function renderAmendOrderDetails(
   );
 }
 
-function renderExistingAmend(id: string, version: number, amend: Amend) {
+function renderExistingAmend(
+  id: string,
+  version: number | undefined,
+  amend: Amend
+) {
   const mocks = [
     {
       request: {
@@ -66,6 +70,55 @@ function renderExistingAmend(id: string, version: number, amend: Amend) {
               tradableInstrument: {
                 instrument: {
                   name: 'test',
+                  product: {
+                    __typename: 'Future',
+                    quoteName: '123',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      request: {
+        query: ExplorerDeterministicOrderDocument,
+        variables: {
+          orderId: '123',
+        },
+      },
+      result: {
+        data: {
+          orderByID: {
+            __typename: 'Order',
+            id: '123',
+            type: 'GTT',
+            status: Schema.OrderStatus.STATUS_ACTIVE,
+            version: 100,
+            createdAt: '123',
+            updatedAt: '456',
+            expiresAt: '789',
+            timeInForce: Schema.OrderTimeInForce.TIME_IN_FORCE_GTC,
+            price: '200',
+            side: 'BUY',
+            remaining: '99',
+            rejectionReason: 'rejection',
+            reference: '123',
+            size: '200',
+            party: {
+              __typename: 'Party',
+              id: '234',
+            },
+            market: {
+              __typename: 'Market',
+              id: 'amend-to-order-latest-version',
+              state: 'STATUS_ACTIVE',
+              positionDecimalPlaces: 2,
+              decimalPlaces: '5',
+              tradableInstrument: {
+                instrument: {
+                  name: 'amend-to-order-latest-version-test',
                   product: {
                     __typename: 'Future',
                     quoteName: '123',
@@ -156,5 +209,16 @@ describe('Amend order details', () => {
     const res = renderExistingAmend('123', 1, amend);
     expect(await res.findByText('New price')).toBeInTheDocument();
     expect(await res.findByText('-7879')).toBeInTheDocument();
+  });
+
+  it('Fetches latest version when version is not specified', async () => {
+    const amend: Amend = {
+      price: '-7879',
+    };
+
+    const res = renderExistingAmend('123', undefined, amend);
+    expect(
+      await res.findByText('amend-to-order-latest-version')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/explorer/src/app/components/order-details/amend-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.tsx
@@ -12,7 +12,7 @@ import { wrapperClasses } from './deterministic-order-details';
 export interface AmendOrderDetailsProps {
   id: string;
   amend: components['schemas']['v1OrderAmendment'];
-  // Version to fetch, with 0 being 'latest' and 1 being 'first'. Defaults to 0
+  // Version to fetch. Latest is provided by default
   version?: number;
 }
 
@@ -34,13 +34,11 @@ export function getSideDeltaColour(delta: string): string {
  * @param param0
  * @returns
  */
-const AmendOrderDetails = ({
-  id,
-  version = 0,
-  amend,
-}: AmendOrderDetailsProps) => {
+const AmendOrderDetails = ({ id, version, amend }: AmendOrderDetailsProps) => {
+  const variables = version ? { orderId: id, version } : { orderId: id };
+
   const { data, error } = useExplorerDeterministicOrderQuery({
-    variables: { orderId: id, version },
+    variables,
   });
 
   if (error || (data && !data.orderByID)) {


### PR DESCRIPTION
# Related issues 🔗

Closes #4195

# Description ℹ️
Ages ago, the GraphQL schema for the data node changed the order versions parameter so that 0 no longer provides
the most recent version of an order. Instead, passing no version does this. Block explorer was stuck in the old world.
