### PR TITLE
test(governance,markets): tidy up minor test quibbles

### DIFF
--- a/apps/governance/src/__mocks__/react-markdown.js
+++ b/apps/governance/src/__mocks__/react-markdown.js
@@ -1,5 +1,0 @@
-function ReactMarkdown({ children }) {
-  return <div>{children}</div>;
-}
-
-export default ReactMarkdown;

--- a/libs/announcements/src/lib/announcements.spec.tsx
+++ b/libs/announcements/src/lib/announcements.spec.tsx
@@ -26,9 +26,12 @@ describe('Announcements', () => {
     const { container } = render(
       <AnnouncementBanner app="console" configUrl={MOCK_URL} />
     );
-    await waitFor(() => {
-      expect(container.firstChild).toBeEmptyDOMElement();
-    });
+    await act(
+      async () =>
+        await waitFor(() => {
+          expect(container.firstChild).toBeEmptyDOMElement();
+        })
+    );
   });
 
   it('does not display the banner when there are no announcements', async () => {
@@ -42,9 +45,12 @@ describe('Announcements', () => {
     const { container } = render(
       <AnnouncementBanner app="console" configUrl={MOCK_URL} />
     );
-    await waitFor(() => {
-      expect(container.firstChild).toBeEmptyDOMElement();
-    });
+    await act(
+      async () =>
+        await waitFor(() => {
+          expect(container.firstChild).toBeEmptyDOMElement();
+        })
+    );
   });
 
   it('shows the correct announcement', async () => {
@@ -200,8 +206,11 @@ describe('Announcements', () => {
       jest.runOnlyPendingTimers();
     });
 
-    await waitFor(() => {
-      expect(queryByText('Live text')).not.toBeInTheDocument();
-    });
+    await act(
+      async () =>
+        await waitFor(() => {
+          expect(queryByText('Live text')).not.toBeInTheDocument();
+        })
+    );
   });
 });

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -4,7 +4,8 @@ import { Networks } from '../types';
 import { useEnvironment } from './use-environment';
 import { stripFullStops } from '@vegaprotocol/utils';
 
-const VEGA_DOCS_URL = process.env['NX_VEGA_DOCS_URL'] || '';
+const VEGA_DOCS_URL =
+  process.env['NX_VEGA_DOCS_URL'] || 'https://docs.vega.xyz/mainnet';
 
 type Net = Exclude<Networks, 'CUSTOM'>;
 export enum DApp {

--- a/libs/environment/src/hooks/use-vega-release.spec.ts
+++ b/libs/environment/src/hooks/use-vega-release.spec.ts
@@ -6,6 +6,7 @@ import {
   GITHUB_VEGA_DEV_RELEASES_DATA,
 } from './mocks/github-releases';
 import { useVegaRelease } from './use-vega-release';
+import { act } from 'react-dom/test-utils';
 
 describe('useVegaRelease', () => {
   beforeEach(() => {
@@ -31,8 +32,11 @@ describe('useVegaRelease', () => {
 
   it('should return undefined when a release cannot be found', async () => {
     const { result } = renderHook(() => useVegaRelease('v0.70.1'));
-    await waitFor(() => {
-      expect(result.current).toEqual(undefined);
-    });
+    await act(
+      async () =>
+        await waitFor(() => {
+          expect(result.current).toEqual(undefined);
+        })
+    );
   });
 });

--- a/libs/markets/src/lib/hooks/use-oracle-markets.spec.ts
+++ b/libs/markets/src/lib/hooks/use-oracle-markets.spec.ts
@@ -19,7 +19,6 @@ describe('useOracleMarkets', () => {
   it('returns correct market list for the given provider', () => {
     mockMarkets.mockReturnValueOnce({ data: marketsData });
     const { result } = renderHook(() => useOracleMarkets(mockProvider));
-    console.log(JSON.stringify(result.current));
     expect(result.current).toStrictEqual(oracleMarkets);
   });
 });


### PR DESCRIPTION
Tidy up some errors that don't cause failing tests, but noisy output on test runs. It's masked if you're running it through nx test all, but not in CI.

# Description ℹ️
- governance had the same mock declared twice
- libs/market tests had a console.log left in
- libs/announcements needed `act` wrappers around some testing data
- libs/environments needed `act` wrappers around some testing data
- governance failed some tests if not run via NX due to environment variables
