### PR TITLE
feat(governance): improve asset proposal details view

### DIFF
--- a/apps/governance/src/i18n/translations/dev.json
+++ b/apps/governance/src/i18n/translations/dev.json
@@ -836,5 +836,6 @@
   "AllProposals": "All proposals",
   "RejectedProposals": "Rejected proposals",
   "networkGovernance": "Network governance",
-  "networkUpgrades": "Network upgrades"
+  "networkUpgrades": "Network upgrades",
+  "assetSpecification": "Asset specification"
 }

--- a/apps/governance/src/routes/proposals/components/proposal-asset-details/index.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-asset-details/index.tsx
@@ -1,0 +1,1 @@
+export * from './proposal-asset-details';

--- a/apps/governance/src/routes/proposals/components/proposal-asset-details/proposal-asset-details.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-asset-details/proposal-asset-details.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SubHeading } from '../../../../components/heading';
+import { CollapsibleToggle } from '../../../../components/collapsible-toggle';
+import { AssetDetail, AssetDetailsTable } from '@vegaprotocol/assets';
+import type { AssetFieldsFragment } from '@vegaprotocol/assets';
+
+export const ProposalAssetDetails = ({
+  asset,
+}: {
+  asset: AssetFieldsFragment;
+}) => {
+  const { t } = useTranslation();
+  const [showAssetDetails, setShowAssetDetails] = useState(false);
+
+  return (
+    <section data-testid="proposal-asset-details">
+      <CollapsibleToggle
+        toggleState={showAssetDetails}
+        setToggleState={setShowAssetDetails}
+        dataTestId={'proposal-asset-details-toggle'}
+      >
+        <SubHeading title={t('assetSpecification')} />
+      </CollapsibleToggle>
+
+      {showAssetDetails && (
+        <div className="mb-10 pb-4">
+          <AssetDetailsTable
+            asset={asset}
+            omitRows={[
+              AssetDetail.STATUS,
+              AssetDetail.INFRASTRUCTURE_FEE_ACCOUNT_BALANCE,
+              AssetDetail.GLOBAL_REWARD_POOL_ACCOUNT_BALANCE,
+              AssetDetail.MAKER_PAID_FEES_ACCOUNT_BALANCE,
+              AssetDetail.MAKER_RECEIVED_FEES_ACCOUNT_BALANCE,
+              AssetDetail.LP_FEE_REWARD_ACCOUNT_BALANCE,
+              AssetDetail.MARKET_PROPOSER_REWARD_ACCOUNT_BALANCE,
+            ]}
+            inline={true}
+            noBorder={true}
+            dtClassName="text-black dark:text-white text-ui !px-0 !font-normal"
+            ddClassName="text-black dark:text-white text-ui !px-0 !font-normal max-w-full"
+          />
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
@@ -10,6 +10,7 @@ import { ProposalDescription } from '../proposal-description';
 import { ProposalChangeTable } from '../proposal-change-table';
 import { ProposalJson } from '../proposal-json';
 import { ProposalVotesTable } from '../proposal-votes-table';
+import { ProposalAssetDetails } from '../proposal-asset-details';
 import { VoteDetails } from '../vote-details';
 import { ListAsset } from '../list-asset';
 import Routes from '../../../routes';
@@ -17,6 +18,8 @@ import { ProposalMarketData } from '../proposal-market-data';
 import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
 import type { MarketInfoWithData } from '@vegaprotocol/markets';
+import type { AssetQuery } from '@vegaprotocol/assets';
+import { removePaginationWrapper } from '@vegaprotocol/utils';
 import { ProposalState } from '@vegaprotocol/types';
 
 export enum ProposalType {
@@ -30,6 +33,7 @@ export enum ProposalType {
 export interface ProposalProps {
   proposal: ProposalFieldsFragment | ProposalQuery['proposal'];
   newMarketData?: MarketInfoWithData | null;
+  assetData?: AssetQuery | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   restData: any;
 }
@@ -38,6 +42,7 @@ export const Proposal = ({
   proposal,
   restData,
   newMarketData,
+  assetData,
 }: ProposalProps) => {
   const { t } = useTranslation();
   const { params, loading, error } = useNetworkParams([
@@ -52,6 +57,23 @@ export const Proposal = ({
 
   if (!proposal) {
     return null;
+  }
+
+  let asset = assetData
+    ? removePaginationWrapper(assetData.assetsConnection?.edges)[0]
+    : undefined;
+
+  if (proposal.terms.change.__typename === 'UpdateAsset' && asset) {
+    asset = {
+      ...asset,
+      quantum: proposal.terms.change.quantum,
+    };
+
+    if (asset.source.__typename === 'ERC20') {
+      asset.source.lifetimeLimit = proposal.terms.change.source.lifetimeLimit;
+      asset.source.withdrawThreshold =
+        proposal.terms.change.source.withdrawThreshold;
+    }
   }
 
   let minVoterBalance = null;
@@ -137,6 +159,14 @@ export const Proposal = ({
               <ProposalMarketData marketData={newMarketData} />
             </div>
           )}
+
+          {(proposal.terms.change.__typename === 'NewAsset' ||
+            proposal.terms.change.__typename === 'UpdateAsset') &&
+            asset && (
+              <div className="mb-4">
+                <ProposalAssetDetails asset={asset} />
+              </div>
+            )}
 
           <div className="mb-6">
             <ProposalJson proposal={restData?.data?.proposal} />

--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
@@ -191,12 +191,13 @@ export const ProposalsList = ({
         {sortedProposals.open.length > 0 ||
         sortedProtocolUpgradeProposals.open.length > 0 ? (
           <ul data-testid="open-proposals">
-            {sortedProtocolUpgradeProposals.open.map((proposal) => (
-              <ProtocolUpgradeProposalsListItem
-                key={proposal.upgradeBlockHeight}
-                proposal={proposal}
-              />
-            ))}
+            {filterString.length < 1 &&
+              sortedProtocolUpgradeProposals.open.map((proposal) => (
+                <ProtocolUpgradeProposalsListItem
+                  key={proposal.upgradeBlockHeight}
+                  proposal={proposal}
+                />
+              ))}
 
             {sortedProposals.open.filter(filterPredicate).map((proposal) => (
               <ProposalsListItem key={proposal?.id} proposal={proposal} />

--- a/libs/assets/src/lib/asset-details-table.spec.tsx
+++ b/libs/assets/src/lib/asset-details-table.spec.tsx
@@ -80,4 +80,14 @@ describe('AssetDetailsTable', () => {
       }
     }
   );
+  it('omits specified rows when omitRows prop is provided', async () => {
+    const asset = generateERC20Asset(1, Schema.AssetStatus.STATUS_ENABLED);
+    const omittedKeys = [AssetDetail.TYPE, AssetDetail.DECIMALS];
+    render(<AssetDetailsTable asset={asset} omitRows={omittedKeys} />);
+
+    for (const key of omittedKeys) {
+      expect(screen.queryByTestId(testId(key, 'label'))).toBeNull();
+      expect(screen.queryByTestId(testId(key, 'value'))).toBeNull();
+    }
+  });
 });

--- a/libs/assets/src/lib/asset-details-table.tsx
+++ b/libs/assets/src/lib/asset-details-table.tsx
@@ -224,9 +224,11 @@ export const testId = (detail: AssetDetail, field: 'label' | 'value') =>
 
 export type AssetDetailsTableProps = {
   asset: Asset;
+  omitRows?: AssetDetail[];
 } & Omit<KeyValueTableRowProps, 'children'>;
 export const AssetDetailsTable = ({
   asset,
+  omitRows = [],
   ...props
 }: AssetDetailsTableProps) => {
   const longStringModifiers = (key: AssetDetail, value: string) =>
@@ -243,7 +245,7 @@ export const AssetDetailsTable = ({
   return (
     <KeyValueTable>
       {details
-        .filter(({ value }) => Boolean(value))
+        .filter(({ key, value }) => Boolean(value) && !omitRows.includes(key))
         .map(({ key, label, value, tooltip, valueTooltip }) => (
           <KeyValueTableRow key={key} {...props}>
             <div


### PR DESCRIPTION
# Related issues 🔗

Closes #3781

# Description ℹ️

Adds a collapsible section detailing asset specs for new and update asset proposals. It uses the AssetDetailsTable component, which I've updated to receive an optional list of keys to omit as the asset proposals specs do not require all the data the table is able to provide.

# Demo 📺

<img width="1094" alt="Screenshot 2023-06-29 at 13 41 00" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/0d29a775-9e48-4aee-83d7-4cd8c01263df">