### PR TITLE
fix(governance): reinstate deleted mock

### DIFF
--- a/apps/governance/src/__mocks__/react-markdown.js
+++ b/apps/governance/src/__mocks__/react-markdown.js
@@ -1,0 +1,5 @@
+function ReactMarkdown({ children }) {
+  return <div>{children}</div>;
+}
+
+export default ReactMarkdown;


### PR DESCRIPTION
# Description ℹ️
In #4213, I deleted this mock because using `yarn run jest` reported
this as mocked twice. Now tests are failing because this isn't mocked.

- Reinstate deleted mock

