### PR TITLE
fix(proposals): truncated text in network param toast

### DIFF
--- a/libs/proposals/src/lib/proposals-hooks/use-update-network-paramaters-toasts.tsx
+++ b/libs/proposals/src/lib/proposals-hooks/use-update-network-paramaters-toasts.tsx
@@ -37,11 +37,10 @@ const UpdateNetworkParameterToastContent = ({
     <div>
       <ToastHeading>{title}</ToastHeading>
       <p className="italic">
-        '
-        {t(
-          `Update ${change.networkParameter.key} to ${change.networkParameter.value}`
-        )}
-        '
+        '{t('Update ')}
+        <span className="break-all">{change.networkParameter.key}</span>
+        {t(' to ')}
+        <span>{change.networkParameter.value}</span>'
       </p>
       {!isNaN(enactment) && (
         <p>


### PR DESCRIPTION
# Related issues 🔗

Closes #3734 

# Description ℹ️

* added 'break-all' to the param key (it can be really long)

# Demo 📺

![Screenshot 2023-07-04 at 16 18 48](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/21a90f1e-0c72-4e13-9136-39bf12a9a9a6)


