### PR TITLE
feat(governance,explorer,trading): add env config for mainnet-mirror apps

### DIFF
--- a/apps/explorer/.env.mainnet-mirror
+++ b/apps/explorer/.env.mainnet-mirror
@@ -1,0 +1,13 @@
+# App configuration variables
+NX_TENDERMINT_URL=https://be.mainnet-mirror.vega.rocks
+NX_TENDERMINT_WEBSOCKET_URL=wss://be.mainnet-mirror.vega.rocks/websocket
+NX_SENTRY_DSN=https://4b8c8a8ba07742648aa4dfe1b8d17e40@o286262.ingest.sentry.io/5882996
+NX_VEGA_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/mainnet-mirror/vegawallet-mainnet-mirror.toml
+NX_VEGA_URL=https://api.mainnet-mirror.vega.rocks/graphql
+NX_VEGA_ENV=MAINNET-MIRROR
+NX_BLOCK_EXPLORER=https://be.mainnet-mirror.vega.rocks/rest
+NX_ETHERSCAN_URL=https://sepolia.etherscan.io
+NX_VEGA_GOVERNANCE_URL=https://governance.mainnet-mirror.vega.rocks
+NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/mainnet/announcements.json
+NX_VEGA_EXPLORER_URL=https://explorer.mainnet-mirror.vega.rocks/
+NX_VEGA_CONSOLE_URL=https://console.mainnet-mirror.vega.rocks

--- a/apps/explorer/README.md
+++ b/apps/explorer/README.md
@@ -32,6 +32,7 @@ yarn nx serve explorer
 Example configurations are provided here:
 
 - [Mainnet](./.env.mainnet)
+- [Mainnet-mirror](./.env.mainnet-mirror)
 - [Devnet](./.env.devnet)
 - [Capsule](./.env.capsule)
 - [Testnet](./.env.testnet)

--- a/apps/governance/.env.mainnet-mirror
+++ b/apps/governance/.env.mainnet-mirror
@@ -1,0 +1,15 @@
+# App configuration variables
+NX_VEGA_ENV=MAINNET-MIRROR
+NX_VEGA_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/mainnet-mirror/vegawallet-mainnet-mirror.toml
+NX_VEGA_URL=https://api.mainnet-mirror.vega.rocks/graphql
+NX_VEGA_NETWORKS='{"DEVNET":"https://dev.governance.vega.xyz","TESTNET":"https://governance.fairground.wtf","MAINNET":"https://governance.vega.xyz","MAINNET-MIRROR":"https://governance.mainnet-mirror.vega.rocks","STAGNET1":"https://trading.stagnet1.vega.rocks"}'
+NX_ETHEREUM_PROVIDER_URL=https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
+NX_ETHERSCAN_URL=https://sepolia.etherscan.io
+NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
+NX_SENTRY_DSN=https://4b8c8a8ba07742648aa4dfe1b8d17e40@o286262.ingest.sentry.io/5882996
+NX_VEGA_EXPLORER_URL=https://explorer.mainnet-mirror.vega.rocks
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet
+NX_DELEGATIONS_PAGINATION=50
+NX_TRANCHES_SERVICE_URL=https://tranches-mainnet-mirror-k8s.ops.vega.xyz
+NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/mainnet/announcements.json
+NX_VEGA_REST_URL=https://api.mainnet-mirror.vega.rocks/api/v2/

--- a/apps/governance/README.md
+++ b/apps/governance/README.md
@@ -25,6 +25,7 @@ yarn nx serve governance
 Example configurations are provided here:
 
 - [Mainnet](./.env.mainnet)
+- [Mainnet-mirror](./.env.mainnet-mirror)
 - [Devnet](./.env.devnet)
 - [Testnet](./.env.testnet)
 

--- a/apps/trading/.env.mainnet-mirror
+++ b/apps/trading/.env.mainnet-mirror
@@ -1,0 +1,17 @@
+NX_ETHEREUM_PROVIDER_URL=https://sepolia.infura.io/v3/4f846e79e13f44d1b51bbd7ed9edefb8
+NX_ETHERSCAN_URL=https://sepolia.etherscan.io
+NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
+NX_SENTRY_DSN=https://2ffce43721964aafa78277c50654ece4@o286262.ingest.sentry.io/6300613
+NX_VEGA_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/mainnet-mirror/vegawallet-mainnet-mirror.toml
+NX_VEGA_ENV=MAINNET-MIRROR
+NX_VEGA_EXPLORER_URL=https://explorer.mainnet-mirror.vega.rocks
+NX_VEGA_NETWORKS={\"MAINNET\":\"https://console.vega.xyz\",\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://trading.stagnet1.vega.rocks\",\"MAINNET-MIRROR\":\"https://trading.mainnet-mirror.vega.rocks\"}
+NX_VEGA_TOKEN_URL=https://governance.mainnet-mirror.vega.rocks
+NX_VEGA_WALLET_URL=http://localhost:1789
+NX_VEGA_DOCS_URL=https://docs.vega.xyz/mainnet
+NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases
+NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/mainnet/announcements.json
+NX_VEGA_INCIDENT_URL=https://blog.vega.xyz/tagged/vega-incident-reports
+NX_VEGA_CONSOLE_URL=https://console.mainnet-mirror.vega.rocks
+# TAG name of the current app version - TODO: bump to the latest upon release
+NX_APP_VERSION=v0.20.19-core-0.71.6

--- a/apps/trading/README.md
+++ b/apps/trading/README.md
@@ -19,6 +19,7 @@ yarn nx serve explorer
 Example configurations are provided here:
 
 - [Mainnet](./.env.mainnet)
+- [Mainnet-mirror](./.env.mainnet-mirror)
 - [Devnet](./.env.devnet)
 - [Testnet](./.env.testnet)
 


### PR DESCRIPTION
# Description ℹ️

In order for the front ends to be present for the mainnet mirror environment this PR adds configs for:

- https://explorer.mainnet-mirror.vega.rocks/
- https://console.mainnet-mirror.vega.rocks/
- https://governance.mainnet-mirror.vega.rocks/

