### PR TITLE
test(cypress): clean up nx todos

### DIFF
--- a/apps/explorer-e2e/src/integration/home.cy.js
+++ b/apps/explorer-e2e/src/integration/home.cy.js
@@ -27,11 +27,6 @@ context('Home Page', function () {
         16: 'Chain ID',
       };
 
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.get('[data-testid="stats-title"]')
         .each(($list, index) => {
           cy.wrap($list).should('contain.text', statTitles[index]);

--- a/apps/explorer-e2e/src/integration/network.cy.js
+++ b/apps/explorer-e2e/src/integration/network.cy.js
@@ -34,11 +34,6 @@ context('Network parameters page', { tags: '@smoke' }, function () {
           const parameterName = network_parameter[0];
           const parameterValue = network_parameter[1];
           if (this.networkParameterFormat.json.includes(parameterName)) {
-            /**
-             * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-             * You should use .then() to chain commands instead.
-             * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-             **/
             cy.get(tableRows)
               .contains(parameterName)
               .should('be.visible')
@@ -70,11 +65,6 @@ context('Network parameters page', { tags: '@smoke' }, function () {
           if (this.networkParameterFormat.percentage.includes(parameterName)) {
             const formattedPercentageParameter =
               (parseFloat(parameterValue) * 100).toFixed(0) + '%';
-            /**
-             * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-             * You should use .then() to chain commands instead.
-             * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-             **/
             cy.get(tableRows)
               .contains(parameterName)
               .should('be.visible')
@@ -158,11 +148,6 @@ context('Network parameters page', { tags: '@smoke' }, function () {
             cy.convert_number_to_max_four_decimal(parameterValue)
               .add_commas_to_number_if_large_enough()
               .then((parameterValueFormatted) => {
-                /**
-                 * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-                 * You should use .then() to chain commands instead.
-                 * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-                 **/
                 cy.get(tableRows)
                   .contains(parameterName)
                   .should('be.visible')
@@ -194,11 +179,6 @@ context('Network parameters page', { tags: '@smoke' }, function () {
             cy.convert_number_to_max_eighteen_decimal(parameterValue)
               .add_commas_to_number_if_large_enough()
               .then((parameterValueFormatted) => {
-                /**
-                 * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-                 * You should use .then() to chain commands instead.
-                 * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-                 **/
                 cy.get(tableRows)
                   .contains(parameterName)
                   .should('be.visible')

--- a/apps/explorer-e2e/src/integration/parties.cy.js
+++ b/apps/explorer-e2e/src/integration/parties.cy.js
@@ -169,12 +169,6 @@ context.skip('Parties page', { tags: '@regression' }, function () {
       const jsonFields = '.hljs';
       const sideMenuBackground = '.absolute';
 
-      // Engage dark mode if not allready set
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.get(sideMenuBackground)
         .should('have.css', 'background-color')
         .then((background_color) => {

--- a/apps/explorer-e2e/src/integration/transactions.cy.js
+++ b/apps/explorer-e2e/src/integration/transactions.cy.js
@@ -60,31 +60,16 @@ context.skip('Transactions page', function () {
             });
           cy.get('block').should('not.be.empty');
           cy.get('encoded-tnx').should('not.be.empty');
-          /**
-           * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-           * You should use .then() to chain commands instead.
-           * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-           **/
           cy.get('tx-type')
             .should('not.be.empty')
             .invoke('text')
             .then((txTypeTxt) => {
               if (txTypeTxt == 'Order Submission') {
-                /**
-                 * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-                 * You should use .then() to chain commands instead.
-                 * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-                 **/
                 cy.get('.hljs-attr')
                   .should('have.length.at.least', 8)
                   .each(($propertyName) => {
                     cy.wrap($propertyName).should('not.be.empty');
                   });
-                /**
-                 * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-                 * You should use .then() to chain commands instead.
-                 * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-                 **/
                 cy.get('.hljs-string')
                   .should('have.length.at.least', 8)
                   .each(($propertyValue) => {

--- a/apps/governance-e2e/src/integration/flow/proposal-details.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/proposal-details.cy.ts
@@ -98,11 +98,6 @@ describe(
         .and('have.length', 64);
       cy.getByTestId(proposalTermsToggle).click();
       // 3001-VOTE-052 3001-VOTE-010
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.get('code.language-json')
         .should('exist')
         .within(() => {

--- a/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/withdrawal-flow.cy.ts
@@ -116,12 +116,6 @@ context(
           cy.getByTestId(amountInput).click().type('120');
           cy.getByTestId(submitWithdrawalButton).click();
         });
-        // assert withdrawal request
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId(toast)
           .first(txTimeout)
           .should('contain.text', 'Funds unlocked')
@@ -135,11 +129,6 @@ context(
             cy.getByTestId(toastClose).click();
           });
         // withdrawal complete
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId(toast)
           .first(txTimeout)
           .should('contain.text', 'The withdrawal has been approved.')
@@ -149,11 +138,6 @@ context(
               'Withdraw 120.00 tUSDC'
             );
           });
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId(toast)
           .last(txTimeout)
           .should('contain.text', 'Transaction confirmed')
@@ -161,11 +145,6 @@ context(
             cy.getByTestId('external-link').should('exist');
           });
         // withdrawal history for complete withdrawal displayed
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.get(tableWithdrawnStatus)
           .eq(1, txTimeout)
           .should('have.text', 'Completed')
@@ -207,11 +186,6 @@ context(
         cy.getByTestId(submitWithdrawalButton).click();
       });
 
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(toast)
         .first(txTimeout)
         .should('contain.text', 'Funds unlocked')
@@ -223,11 +197,6 @@ context(
           );
           cy.getByTestId(toastClose).click();
         });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.get(tableTxHash)
         .eq(1)
         .should('have.text', 'Complete withdrawal')
@@ -243,33 +212,18 @@ context(
         });
       ethereumWalletConnect();
       cy.getByTestId(completeWithdrawalButton).first().click();
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(toast)
         .last(txTimeout)
         .should('contain.text', 'Awaiting confirmation')
         .within(() => {
           cy.getByTestId('external-link').should('exist');
         });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(toast)
         .first(txTimeout)
         .should('contain.text', 'The withdrawal has been approved.')
         .within(() => {
           cy.getByTestId(toastPanel).should('contain.text', '110.00', 'tUSDC');
         });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(toast)
         .last(txTimeout)
         .should('contain.text', 'Transaction confirmed')
@@ -293,11 +247,6 @@ context(
         cy.getByTestId(amountInput).click().type('50');
         cy.getByTestId(submitWithdrawalButton).click();
       });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(toast)
         .first(txTimeout)
         .should('contain.text', 'Funds unlocked')

--- a/apps/governance-e2e/src/integration/view/home.cy.ts
+++ b/apps/governance-e2e/src/integration/view/home.cy.ts
@@ -16,11 +16,6 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
     });
 
     it('should display announcement banner', function () {
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('app-announcement')
         .should('contain.text', 'TEST ANNOUNCEMENT!')
         .within(() => {
@@ -40,11 +35,6 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
           waitForSpinner();
         }
       });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('proposals-list-item')
         .should('have.length.at.least', 1)
         .first()
@@ -104,11 +94,6 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
     });
 
     it('should contain link to specific validators', function () {
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('validators')
         .should('have.length', '2')
         .each(($validator) => {
@@ -135,11 +120,6 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
     });
 
     it('should display network data', function () {
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('git-network-data')
         .should('contain.text', 'Reading network data from')
         .within(() => {
@@ -151,11 +131,6 @@ context('Home Page - verify elements on page', { tags: '@smoke' }, function () {
     });
 
     it('should display eth data', function () {
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('git-eth-data')
         .should('contain.text', 'Reading Ethereum data from')
         .within(() => {

--- a/apps/governance-e2e/src/integration/view/proposal.cy.ts
+++ b/apps/governance-e2e/src/integration/view/proposal.cy.ts
@@ -142,11 +142,6 @@ context(
       mockNetworkUpgradeProposal();
       navigateTo(navigation.proposals);
       cy.getByTestId('open-proposals').within(() => {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.get('li')
           .eq(0)
           .should('have.attr', 'data-testid', networkUpgradeProposalListItem)
@@ -205,11 +200,6 @@ context(
           .should('contain.text', '99.98% approval (% validator voting power)')
           .and('contain.text', '(67% voting power required)');
         cy.get('h2').should('contain.text', 'Approvers (4/4 validators)');
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('validator-name')
           .should('have.length', 4)
           .each(($validator) => {

--- a/apps/governance-e2e/src/integration/view/rewards.cy.ts
+++ b/apps/governance-e2e/src/integration/view/rewards.cy.ts
@@ -42,11 +42,6 @@ context(
       // Skipping due to bug #3471 causing flaky failuress
       it.skip('should have option to view go to next and previous page', function () {
         waitForBeginningOfEpoch();
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('page-info')
           .should('contain.text', 'Page ')
           .invoke('text')

--- a/apps/governance-e2e/src/integration/view/tranches.cy.ts
+++ b/apps/governance-e2e/src/integration/view/tranches.cy.ts
@@ -21,11 +21,6 @@ context(
     // 1005-VEST-001
     // 1005-VEST-002
     it('Able to view tranches', function () {
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('tranche-item')
         .should('have.length', 2)
         .first()
@@ -56,11 +51,6 @@ context(
         cy.get('span').eq(1).should('have.text', 0);
       });
       cy.getByTestId('key-value-table').within(() => {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('link')
           .should('have.length', 8)
           .each((ethLink) => {
@@ -68,11 +58,6 @@ context(
               .should('have.attr', 'href')
               .and('contain', 'https://sepolia.etherscan.io/address/');
           });
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('redeem-link')
           .should('have.length', 8)
           .each((redeemLink) => {
@@ -86,11 +71,6 @@ context(
     it('Able to view tranches with less than 10 vega', function () {
       navigateTo(navigation.supply);
       cy.getByTestId('show-all-tranches').click();
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId('tranche-item')
         .should('have.length', 8)
         .first()

--- a/apps/governance-e2e/src/integration/view/validators.cy.ts
+++ b/apps/governance-e2e/src/integration/view/validators.cy.ts
@@ -74,11 +74,6 @@ context('Validators Page - verify elements on page', function () {
     function () {
       // 1002-STKE-050
       it('Should be able to see validator names', function () {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.get('[col-id="validator"] > div > span')
           .should('have.length.at.least', 1)
           .each(($name) => {
@@ -87,11 +82,6 @@ context('Validators Page - verify elements on page', function () {
       });
 
       it('Should be able to see validator stake', function () {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('total-stake')
           .should('have.length.at.least', 1)
           .each(($stake) => {
@@ -115,11 +105,6 @@ context('Validators Page - verify elements on page', function () {
       });
 
       it('Should be able to see validator normalised voting power', function () {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('normalised-voting-power')
           .should('have.length.at.least', 1)
           .each(($vPower) => {
@@ -141,11 +126,6 @@ context('Validators Page - verify elements on page', function () {
 
       // 2002-SINC-018
       it('Should be able to see validator total penalties', function () {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('total-penalty')
           .should('have.length.at.least', 1)
           .each(($penalties) => {
@@ -166,11 +146,6 @@ context('Validators Page - verify elements on page', function () {
       });
 
       it('Should be able to see validator pending stake', function () {
-        /**
-         * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-         * You should use .then() to chain commands instead.
-         * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-         **/
         cy.getByTestId('total-pending-stake')
           .should('have.length.at.least', 1)
           .each(($pendingStake) => {

--- a/apps/governance-e2e/src/integration/view/wallet-vega.cy.ts
+++ b/apps/governance-e2e/src/integration/view/wallet-vega.cy.ts
@@ -340,7 +340,7 @@ context(
                 .contains(name)
                 .parent()
                 .siblings()
-                .then((elementAmount) => {
+                .should((elementAmount) => {
                   const displayedAmount = parseFloat(elementAmount.text());
                   expect(displayedAmount).be.gte(expectedAmount);
                 });

--- a/apps/trading-e2e/src/integration/capsule.cy.ts
+++ b/apps/trading-e2e/src/integration/capsule.cy.ts
@@ -100,11 +100,6 @@ describe('capsule - without MultiSign', { tags: '@slow' }, () => {
     cy.get('.ag-cell-value', txTimeout).should('contain.text', btcSymbol);
     cy.get('[col-id="status"]').should('not.have.text', 'Open', txTimeout);
 
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get('[col-id="txHash"]')
       .should('have.length.above', 2)
       .eq(1)
@@ -411,11 +406,6 @@ describe('capsule', { tags: '@slow', testIsolation: true }, () => {
       .eq(0, txTimeout)
       .should('contain.text', 'Completed');
 
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get('[col-id="txHash"]', txTimeout)
       .should('have.length.above', 1)
       .eq(1)
@@ -497,11 +487,6 @@ describe('capsule', { tags: '@slow', testIsolation: true }, () => {
     cy.get('.ag-cell-value', txTimeout).should('contain.text', vegaSymbol);
     cy.get('[col-id="status"]').should('not.have.text', 'Open', txTimeout);
 
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get('[col-id="txHash"]')
       .should('have.length.above', 2)
       .eq(1)

--- a/apps/trading-e2e/src/integration/market-summary.cy.ts
+++ b/apps/trading-e2e/src/integration/market-summary.cy.ts
@@ -137,11 +137,6 @@ describe('Market trading page', () => {
             .realHover();
         });
       });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(expirtyTooltip)
         .eq(0)
         .should(
@@ -175,11 +170,6 @@ describe('Market trading page', () => {
             .realHover();
         });
       });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(tradingModeTooltip)
         .should(
           'contain.text',
@@ -206,11 +196,6 @@ describe('Market trading page', () => {
           cy.getByTestId(itemValue).realHover();
         });
       });
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.getByTestId(liquiditySuppliedTooltip)
         .should('contain.text', 'Supplied stake')
         .and('contain.text', 'Target stake')

--- a/apps/trading-e2e/src/integration/trading-orders.cy.ts
+++ b/apps/trading-e2e/src/integration/trading-orders.cy.ts
@@ -118,11 +118,6 @@ describe('orders list', { tags: '@smoke', testIsolation: true }, () => {
     cy.contains('Reset').click();
     cy.getByTestId('All').click();
 
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.getByTestId('tab-orders')
       .get(`.ag-center-cols-container [col-id='${orderSymbol}']`)
       .should('have.length.at.least', expectedOrderList.length)
@@ -446,11 +441,6 @@ describe('amend and cancel order', { tags: '@smoke' }, () => {
       peggedOrder: null,
       liquidityProvisionId: null,
     });
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get(`[row-id=${orderId}]`)
       .find('[data-testid="edit"]')
       .should('have.text', 'Edit')
@@ -480,11 +470,6 @@ describe('amend and cancel order', { tags: '@smoke' }, () => {
       peggedOrder: null,
       liquidityProvisionId: null,
     });
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get(`[row-id=${orderId}]`)
       .find(`[data-testid="cancel"]`)
       .should('have.text', 'Cancel')
@@ -507,11 +492,6 @@ describe('amend and cancel order', { tags: '@smoke' }, () => {
       peggedOrder: null,
       liquidityProvisionId: null,
     });
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get(`[data-testid="cancelAll"]`)
       .should('have.text', 'Cancel all')
       .then(($btn) => {
@@ -528,11 +508,6 @@ describe('amend and cancel order', { tags: '@smoke' }, () => {
       peggedOrder: null,
       liquidityProvisionId: null,
     });
-    /**
-     * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-     * You should use .then() to chain commands instead.
-     * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-     **/
     cy.get(`[row-id=${orderId}]`)
       .find('[data-testid="edit"]')
       .should('have.text', 'Edit')

--- a/apps/trading-e2e/src/integration/trading-portfolio.cy.ts
+++ b/apps/trading-e2e/src/integration/trading-portfolio.cy.ts
@@ -47,11 +47,6 @@ describe('Portfolio page', { tags: '@smoke' }, () => {
       cy.get(
         '[role="columnheader"][col-id="fromAccountType"] .ag-header-cell-menu-button'
       ).click();
-      /**
-       * TODO(@nx/cypress): Nesting Cypress commands in a should assertion now throws.
-       * You should use .then() to chain commands instead.
-       * More Info: https://docs.cypress.io/guides/references/migration-guide#-should
-       **/
       cy.get('fieldset.ag-simple-filter-body-wrapper')
         .should('be.visible')
         .within((fields) => {


### PR DESCRIPTION
# Related issues 🔗

- Fixed flaky wallet test, hopefully for the last time
- Last commit that updated Nx generated a bunch of todos to remove chained assertions. Looking at the Cypress docs there's nothing about not being able to chain assertions anymore and the tests are all running without errors so removing all the todos from all the test files.
