### PR TITLE
chore: update the PM action secret token

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -6,7 +6,7 @@ name: 'Add Issues To Project Board'
     types:
       - opened
 env:
-  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  GH_TOKEN: ${{ secrets.PROJECT_MANAGE_ACTION }}
   PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
   ISSUE_ID: ${{ github.event.issue.node_id }}
   USER: ${{ github.actor }}


### PR DESCRIPTION
# Related issues 🔗

part of: https://github.com/vegaprotocol/devops-infra/issues/1960

# Description ℹ️

This PR changes the token used for the add issue to project to one more secure 

