### PR TITLE
fix(explorer): fix valueformatter in enactment date on proposal table

### DIFF
--- a/apps/explorer/src/app/components/proposals/proposals-table.tsx
+++ b/apps/explorer/src/app/components/proposals/proposals-table.tsx
@@ -137,7 +137,7 @@ export const ProposalsTable = ({ data }: ProposalsTableProps) => {
         hide: window.innerWidth <= BREAKPOINT_MD,
         headerName: t('Enactment date'),
         field: 'terms.enactmentDatetime',
-        valueFormatte: ({
+        valueFormatter: ({
           value,
         }: VegaValueFormatterParams<
           ProposalListFieldsFragment,


### PR DESCRIPTION
# Related issues 🔗

Closes #4356

# Description ℹ️

On Explorer, the two date columns were formatted differently due to a typo. This PR fixes that typo and hopefully makes
the formats the same again.
