### PR TITLE
chore(governance): add e2e test for network upgrade banner

### DIFF
--- a/apps/governance-e2e/src/integration/view/proposal.cy.ts
+++ b/apps/governance-e2e/src/integration/view/proposal.cy.ts
@@ -227,5 +227,42 @@ context(
       cy.getByTestId(networkUpgradeProposalListItem).should('not.exist');
       cy.getByTestId(closedProposalToggle).should('not.exist');
     });
+
+    it('should display network upgrade banner with estimate', function () {
+      mockNetworkUpgradeProposal();
+      cy.visit('/');
+      cy.getByTestId('banners').within(() => {
+        cy.get('div')
+          .should('contain.text', 'The network will upgrade to v1 in ')
+          .and(
+            'contain.text',
+            'Trading activity will be interrupted, manage your risk appropriately.'
+          );
+        cy.getByTestId('external-link')
+          .should('have.attr', 'href')
+          .and('contain', '/proposals/protocol-upgrade/v1');
+      });
+
+      // estimate does not display possibly due to mocks or Cypress unless the proposal is clicked on several times
+      // By default the application waits for 10 blocks until showing estimate - roughly 10 seconds
+      for (let i = 0; i < 3; i++) {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(3000);
+        navigateTo(navigation.proposals);
+        cy.getByTestId(networkUpgradeProposalListItem)
+          .first()
+          .find('[data-testid="view-proposal-btn"]')
+          .click();
+      }
+      cy.getByTestId('upgrade-proposal-estimate')
+        .invoke('text')
+        .as('displayedEstimate');
+      cy.get('@displayedEstimate').then((estimateText) => {
+        // Estimated time should automatically update every second
+        cy.getByTestId('protocol-upgrade-time')
+          .invoke('text')
+          .should('not.eq', estimateText);
+      });
+    });
   }
 );

--- a/libs/proposals/src/components/protocol-upgrade-proposal-notification.tsx
+++ b/libs/proposals/src/components/protocol-upgrade-proposal-notification.tsx
@@ -47,6 +47,7 @@ export const ProtocolUpgradeProposalNotification = ({
           <span
             title={t('estimated time to protocol upgrade')}
             className="text-vega-orange-500"
+            data-testid="upgrade-proposal-estimate"
           >
             {convertToCountdownString(time, '0:00:00:00')}
           </span>


### PR DESCRIPTION
# Related issues 🔗

Closes #3259 

There's an unknown issue where the network banner does not give an estimate on capsule without several repeated prompts. This seems to be an isolated issue either due to capsule/ mocks or Cypress causing it to not work. 
