### PR TITLE
feat(explorer): iceberg details on order tx

### DIFF
--- a/apps/explorer/src/app/components/txs/details/order/tx-order-iceberg.tsx
+++ b/apps/explorer/src/app/components/txs/details/order/tx-order-iceberg.tsx
@@ -1,0 +1,52 @@
+import { t } from '@vegaprotocol/i18n';
+import type { components } from '../../../../../types/explorer';
+import { Tooltip } from '@vegaprotocol/ui-toolkit';
+
+export interface TxDetailsOrderIcebergDetailsProps {
+  iceberg: components['schemas']['v1IcebergOpts'];
+  size: components['schemas']['v1OrderSubmission']['size'];
+}
+
+/**
+
+.iceberg .sub {
+  vertical-align: bottom;
+  color: #954F01;
+}
+
+.iceberg .sup {
+  vertical-align: top;
+  color: #515E1E;
+}
+
+ */
+
+/**
+ * Visualises the iceberg details of an order, showing the minimum visible size,
+ * the full size and the peak size.
+ */
+export const TxOrderIcebergDetails = ({
+  iceberg,
+  size,
+}: TxDetailsOrderIcebergDetailsProps) => {
+  return (
+    <div
+      className="inline-block iceberg bg-vega-blue-300 border-vega-blue-350 border-[1px] text-[70%] font-mono py-[2px] pl-2 pr-3 height-[1em] leading-[1em] cursor-pointer"
+      style={{ clipPath: 'polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%)' }}
+    >
+      <Tooltip description={t('Iceberg: Minimum visible size')}>
+        <span className="align-bottom text-vega-orange-650">
+          {iceberg.minimumVisibleSize || '-'}
+        </span>
+      </Tooltip>
+      <Tooltip description={t('Iceberg: Total size')}>
+        <span className="text-sm text-vega-blue-600 mx-3">{size}</span>
+      </Tooltip>
+      <Tooltip description={t('Iceberg: Visible peak')}>
+        <span className="align-top text-vega-yellow-600">
+          {iceberg.peakSize || '-'}
+        </span>
+      </Tooltip>
+    </div>
+  );
+};

--- a/apps/explorer/src/app/components/txs/details/tx-order.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-order.tsx
@@ -8,6 +8,7 @@ import { txSignatureToDeterministicId } from '../lib/deterministic-ids';
 import DeterministicOrderDetails from '../../order-details/deterministic-order-details';
 import Hash from '../../links/hash';
 import { TxOrderPeggedReferenceRow } from './order/tx-order-peg';
+import { TxOrderIcebergDetails } from './order/tx-order-iceberg';
 
 interface TxDetailsOrderProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -32,6 +33,8 @@ export const TxDetailsOrder = ({
   const marketId = txData.command.orderSubmission.marketId || '-';
   const reference = txData.command.orderSubmission.peggedOrder;
   const side = txData.command.orderSubmission.side;
+  const iceberg = txData.command.orderSubmission.icebergOpts;
+  const size = txData.command.orderSubmission.size;
 
   let deterministicId = '';
 
@@ -73,6 +76,14 @@ export const TxDetailsOrder = ({
             reference={reference.reference}
             marketId={marketId}
           />
+        ) : null}
+        {iceberg ? (
+          <TableRow modifier="bordered">
+            <TableCell>{t('Iceberg details')}</TableCell>
+            <TableCell>
+              <TxOrderIcebergDetails iceberg={iceberg} size={size} />
+            </TableCell>
+          </TableRow>
         ) : null}
       </TableWithTbody>
 

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -166,6 +166,7 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
     'text-white dark:text-white bg-vega-dark-150 dark:bg-vega-dark-250';
 
   // This will get unwieldy and should probably produce a different colour of tag
+  // Note that colours are currently arbitrary
   if (type === 'Chain Event' && !!command?.chainEvent) {
     type = getLabelForChainEvent(command.chainEvent);
     colours = 'text-white dark-text-white bg-vega-pink dark:bg-vega-pink';
@@ -177,6 +178,9 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
       type = getLabelForProposal(command.proposalSubmission);
     }
     colours = 'text-black bg-vega-yellow';
+  } else if (type === 'Order' && command) {
+    type = getLabelForOrderType(orderType, command);
+    colours = 'text-white dark-text-white bg-vega-blue dark:bg-vega-blue';
   }
 
   if (type === 'Vote on Proposal') {


### PR DESCRIPTION
# Related issues 🔗

Closes #4108

# Description ℹ️

Adds a little visualiser thing for iceberg options if an order has them. Tooltips to explain them.

# Demo 📺

<img width="997" alt="Screenshot 2023-07-25 at 14 23 30" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/c39edce9-f0c6-4718-b8a9-7e7fef83b733">
