### PR TITLE
feat(explorer): improve transaction pagination

### DIFF
--- a/apps/explorer/src/app/components/txs/tx-filter.tsx
+++ b/apps/explorer/src/app/components/txs/tx-filter.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSubContent,
   Icon,
-  Button,
 } from '@vegaprotocol/ui-toolkit';
 import type { Dispatch, SetStateAction } from 'react';
 import { FilterLabel } from './tx-filter-label';
@@ -100,15 +99,13 @@ export const TxsFilter = ({ filters, setFilters }: TxFilterProps) => {
     <DropdownMenu
       modal={false}
       trigger={
-        <DropdownMenuTrigger className="ml-0">
-          <Button size="xs" data-testid="filter-trigger">
-            <FilterLabel filters={filters} />
-          </Button>
+        <DropdownMenuTrigger>
+          <FilterLabel filters={filters} />
         </DropdownMenuTrigger>
       }
     >
       <DropdownMenuContent>
-        {filters.size > 0 ? null : (
+        {filters.size > 1 ? null : (
           <>
             <DropdownMenuCheckboxItem
               onCheckedChange={() => setFilters(new Set(AllFilterOptions))}

--- a/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
+++ b/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
@@ -44,7 +44,7 @@ export const TxsListNavigation = ({
           </Button>
           <Button
             size="xs"
-            disabled={!hasMoreTxs || loading}
+            disabled={!hasMoreTxs}
             onClick={() => {
               nextPage();
             }}

--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
@@ -86,14 +86,18 @@ describe('Txs infinite list item', () => {
     render(
       <MockedProvider>
         <MemoryRouter>
-          <TxsInfiniteListItem
-            type="testType"
-            submitter="testPubKey"
-            hash="testTxHash"
-            block="1"
-            code={0}
-            command={{}}
-          />
+          <table>
+            <tbody>
+              <TxsInfiniteListItem
+                type="testType"
+                submitter="testPubKey"
+                hash="testTxHash"
+                block="1"
+                code={0}
+                command={{}}
+              />
+            </tbody>
+          </table>
         </MemoryRouter>
       </MockedProvider>
     );

--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
@@ -14,9 +14,9 @@ const DEFAULT_TRUNCATE_LENGTH = 7;
 
 export function getIdTruncateLength(screen: Screen): number {
   if (['xxxl', 'xxl'].includes(screen)) {
-    return 64;
-  } else if (['xl', 'lg', 'md'].includes(screen)) {
     return 32;
+  } else if (['xl', 'lg', 'md'].includes(screen)) {
+    return 16;
   }
   return DEFAULT_TRUNCATE_LENGTH;
 }

--- a/apps/explorer/src/app/components/txs/txs-infinite-list.spec.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list.spec.tsx
@@ -5,11 +5,17 @@ import type { BlockExplorerTransactionResult } from '../../routes/types/block-ex
 import { Side } from '@vegaprotocol/types';
 import { MockedProvider } from '@apollo/client/testing';
 
+const generateHash = (): string =>
+  Array.from(
+    { length: 64 },
+    () => '0123456789ABCDEF'[Math.floor(Math.random() * 16)]
+  ).join('');
+
 const generateTxs = (number: number): BlockExplorerTransactionResult[] => {
   return Array.from(Array(number)).map((_) => ({
     block: '87901',
     index: 2,
-    hash: '0F8B98DA0923A50786B852D9CA11E051CACC4C733E1DB93D535C7D81DBD10F6F',
+    hash: generateHash(),
     submitter:
       '4b782482f587d291e8614219eb9a5ee9280fa2c58982dee71d976782a9be1964',
     type: 'Submit Order',

--- a/apps/explorer/src/app/components/txs/txs-per-block.tsx
+++ b/apps/explorer/src/app/components/txs/txs-per-block.tsx
@@ -14,7 +14,7 @@ interface TxsPerBlockProps {
 
 export const TxsPerBlock = ({ blockHeight, txCount }: TxsPerBlockProps) => {
   const filters = `filters[block.height]=${blockHeight}`;
-  const url = getTxsDataUrl({ limit: txCount.toString(), filters });
+  const url = getTxsDataUrl({ filters });
   const {
     state: { data, loading, error },
   } = useFetch<BlockExplorerTransactions>(url);

--- a/apps/explorer/src/app/components/txs/txs-per-block.tsx
+++ b/apps/explorer/src/app/components/txs/txs-per-block.tsx
@@ -14,7 +14,7 @@ interface TxsPerBlockProps {
 
 export const TxsPerBlock = ({ blockHeight, txCount }: TxsPerBlockProps) => {
   const filters = `filters[block.height]=${blockHeight}`;
-  const url = getTxsDataUrl({ filters });
+  const url = getTxsDataUrl({ filters, count: txCount });
   const {
     state: { data, loading, error },
   } = useFetch<BlockExplorerTransactions>(url);

--- a/apps/explorer/src/app/components/txs/txs-per-block.tsx
+++ b/apps/explorer/src/app/components/txs/txs-per-block.tsx
@@ -2,7 +2,7 @@ import { Table, TableRow } from '../table';
 import { t } from '@vegaprotocol/i18n';
 import { useFetch } from '@vegaprotocol/react-helpers';
 import type { BlockExplorerTransactions } from '../../routes/types/block-explorer-response';
-import { getTxsDataUrl } from '../../hooks/use-txs-data';
+import { getTxsDataUrl } from '../../hooks/get-txs-data-url';
 import { AsyncRenderer, Loader } from '@vegaprotocol/ui-toolkit';
 import EmptyList from '../empty-list/empty-list';
 import { TxsInfiniteListItem } from './txs-infinite-list-item';

--- a/apps/explorer/src/app/hooks/get-txs-data-url.ts
+++ b/apps/explorer/src/app/hooks/get-txs-data-url.ts
@@ -1,0 +1,62 @@
+import { DATA_SOURCES } from '../config';
+
+type IGetTxsDataPrevious = {
+  count?: number;
+  before: string;
+  filters?: string;
+  party?: string;
+};
+
+type IGetTxsDataNext = {
+  count?: number;
+  after: string;
+  filters?: string;
+  party?: string;
+};
+
+type IGetTxsDataFirstPage = {
+  count?: number;
+  party?: string;
+  filters?: string;
+};
+
+type IGetTxsDataUrl =
+  | IGetTxsDataPrevious
+  | IGetTxsDataNext
+  | IGetTxsDataFirstPage;
+
+export const BE_TXS_PER_REQUEST = 25;
+
+/**
+ * Properly encodes the filters and parameters for a request to the block explorer
+ * API for transactions. As the API uses a slightly less common format for encoding
+ * filters, some of it is more manual than you might expect.
+ *
+ * @param params An object containing the pagination and filters
+ * @returns string URL to call
+ */
+export const getTxsDataUrl = (params: IGetTxsDataUrl) => {
+  const url = new URL(`${DATA_SOURCES.blockExplorerUrl}/transactions`);
+  const count = `${params.count || BE_TXS_PER_REQUEST}`;
+
+  if ('before' in params) {
+    url.searchParams.append('last', count);
+    url.searchParams.append('before', params.before);
+  } else if ('after' in params) {
+    url.searchParams.append('first', count);
+    url.searchParams.append('after', params.after);
+  } else {
+    url.searchParams.append('first', count);
+  }
+
+  // Hacky fix for param as array
+  let urlAsString = url.toString();
+  if ('filters' in params && typeof params.filters === 'string') {
+    urlAsString += '&' + params.filters.replace(' ', '%20');
+  }
+  if ('party' in params) {
+    urlAsString += `&filters[tx.submitter]=${params.party}`;
+  }
+
+  return urlAsString;
+};

--- a/apps/explorer/src/app/hooks/use-txs-data.ts
+++ b/apps/explorer/src/app/hooks/use-txs-data.ts
@@ -87,7 +87,7 @@ export const useTxsData = ({
   filters,
   party,
 }: IUseTxsData) => {
-  const [params, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   const [{ txsData, hasMoreTxs, url }, setTxsState] = useState<TxsStateProps>({
     txsData: [],
@@ -205,7 +205,7 @@ export const useTxsData = ({
         }),
       }));
     },
-    [party, count, after, before]
+    [party, count, after, before, setSearchParams]
   );
 
   return {

--- a/apps/explorer/src/app/hooks/use-txs-data.ts
+++ b/apps/explorer/src/app/hooks/use-txs-data.ts
@@ -8,10 +8,13 @@ import type {
 } from '../routes/types/block-explorer-response';
 import { DATA_SOURCES } from '../config';
 import isNumber from 'lodash/isNumber';
+import { AllFilterOptions } from '../components/txs/tx-filter';
 import type { FilterOption } from '../components/txs/tx-filter';
 
 export function getTypeFilters(filters?: Set<FilterOption>) {
   if (!filters) {
+    return '';
+  } else if (filters.size > 1) {
     return '';
   }
 
@@ -182,6 +185,15 @@ export const useTxsData = ({
 
   const updateFilters = useCallback(
     (newFilters: Set<FilterOption>) => {
+      const params: URLSearchParamsInit = {};
+      if (newFilters && newFilters.size === 1) {
+        params.filters = Array.from(newFilters)[0];
+      }
+
+      setSearchParams(params);
+
+      console.dir(newFilters);
+
       setTxsState((prev) => ({
         ...prev,
         url: getTxsDataUrl({
@@ -207,3 +219,32 @@ export const useTxsData = ({
     previousPage,
   };
 };
+
+/**
+ * Returns a Set of filters based on the URLSearchParams, or
+ * defaults to all.
+ * @param params
+ * @returns Set
+ */
+export function getInitialFilters(params: URLSearchParams): Set<FilterOption> {
+  const defaultFilters = new Set(AllFilterOptions);
+
+  const p = params.get('filters');
+
+  if (!p) {
+    return defaultFilters;
+  }
+
+  const filters = new Set<FilterOption>();
+  p.split(',').forEach((f) => {
+    if (AllFilterOptions.includes(f as FilterOption)) {
+      filters.add(f as FilterOption);
+    }
+  });
+
+  if (filters.size === 0) {
+    return defaultFilters;
+  }
+
+  return filters;
+}

--- a/apps/explorer/src/app/hooks/use-txs-data.ts
+++ b/apps/explorer/src/app/hooks/use-txs-data.ts
@@ -1,15 +1,15 @@
 import { useSearchParams } from 'react-router-dom';
 import type { URLSearchParamsInit } from 'react-router-dom';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useFetch } from '@vegaprotocol/react-helpers';
 import type {
   BlockExplorerTransactionResult,
   BlockExplorerTransactions,
 } from '../routes/types/block-explorer-response';
-import { DATA_SOURCES } from '../config';
 import isNumber from 'lodash/isNumber';
 import { AllFilterOptions } from '../components/txs/tx-filter';
 import type { FilterOption } from '../components/txs/tx-filter';
+import { BE_TXS_PER_REQUEST, getTxsDataUrl } from './get-txs-data-url';
 
 export function getTypeFilters(filters?: Set<FilterOption>) {
   if (!filters) {
@@ -20,56 +20,6 @@ export function getTypeFilters(filters?: Set<FilterOption>) {
 
   const forcedSingleFilter = Array.from(filters)[0];
   return `filters[cmd.type]=${forcedSingleFilter}`;
-}
-
-interface IGetTxsDataUrl {
-  count?: number;
-  before?: string;
-  after?: string;
-  filters?: string;
-  party?: string;
-}
-const BE_TXS_PER_REQUEST = 25;
-
-export const getTxsDataUrl = ({
-  count = BE_TXS_PER_REQUEST,
-  before,
-  after,
-  filters,
-  party,
-}: IGetTxsDataUrl) => {
-  if (before && after) {
-    throw new Error('before and after cannot be used together');
-  }
-
-  const url = new URL(`${DATA_SOURCES.blockExplorerUrl}/transactions`);
-
-  if (before) {
-    url.searchParams.append('last', count.toString());
-    url.searchParams.append('before', before);
-  } else if (after) {
-    url.searchParams.append('first', count.toString());
-    url.searchParams.append('after', after);
-  } else {
-    url.searchParams.append('first', count.toString());
-  }
-
-  // Hacky fix for param as array
-  let urlAsString = url.toString();
-  if (filters) {
-    urlAsString += '&' + filters.replace(' ', '%20');
-  }
-  if (party) {
-    urlAsString += `&filters[tx.submitter]=${party}`;
-  }
-
-  return urlAsString;
-};
-
-export interface TxsStateProps {
-  txsData: BlockExplorerTransactionResult[];
-  hasMoreTxs: boolean;
-  url: string;
 }
 
 export interface IUseTxsData {
@@ -88,17 +38,15 @@ export const useTxsData = ({
   party,
 }: IUseTxsData) => {
   const [, setSearchParams] = useSearchParams();
+  let hasMoreTxs = true;
+  let txsData: BlockExplorerTransactionResult[] = [];
 
-  const [{ txsData, hasMoreTxs, url }, setTxsState] = useState<TxsStateProps>({
-    txsData: [],
-    hasMoreTxs: false,
-    url: getTxsDataUrl({
-      filters: getTypeFilters(filters),
-      count,
-      before,
-      after,
-      party,
-    }),
+  const url = getTxsDataUrl({
+    filters: getTypeFilters(filters),
+    count,
+    before,
+    after,
+    party,
   });
 
   const {
@@ -106,82 +54,38 @@ export const useTxsData = ({
     refetch,
   } = useFetch<BlockExplorerTransactions>(url, {}, true);
 
-  useEffect(() => {
-    if (!loading && data && isNumber(data.transactions.length)) {
-      setTxsState((prev) => {
-        return {
-          ...prev,
-          hasMoreTxs: data.transactions.length === count,
-          txsData: data.transactions,
-        };
-      });
-    }
-  }, [loading, data, count]);
+  if (!loading && data && isNumber(data.transactions.length)) {
+    hasMoreTxs = data.transactions.length === count;
+    txsData = data.transactions;
+  }
 
   const nextPage = useCallback(() => {
     const after = data?.transactions.at(-1)?.cursor || '';
-    const before = undefined;
     const params: URLSearchParamsInit = { after };
     if (filters) {
       params.filters = Array.from(filters).join(',');
     }
     setSearchParams(params);
-    setTxsState((prev) => ({
-      ...prev,
-      url: getTxsDataUrl({
-        party,
-        count,
-        after,
-        before,
-        filters: getTypeFilters(filters),
-      }),
-    }));
-  }, [count, party, filters, data, setSearchParams]);
+  }, [filters, data, setSearchParams]);
 
   const previousPage = useCallback(() => {
     const before = data?.transactions[0]?.cursor || '';
-    const after = undefined;
     const params: URLSearchParamsInit = { before };
     if (filters && filters.size > 0 && filters.size === 1) {
       params.filters = Array.from(filters)[0];
     }
     setSearchParams(params);
-
-    setTxsState((prev) => ({
-      ...prev,
-      url: getTxsDataUrl({
-        party,
-        count,
-        after,
-        before,
-        filters: getTypeFilters(filters),
-      }),
-    }));
-  }, [count, party, filters, data, setSearchParams]);
+  }, [filters, data, setSearchParams]);
 
   const refreshTxs = useCallback(async () => {
-    const before = undefined;
-    const after = undefined;
     const params: URLSearchParamsInit = {};
     if (filters && filters.size > 0 && filters.size === 1) {
       params.filters = Array.from(filters)[0];
     }
     setSearchParams(params);
 
-    setTxsState((prev) => ({
-      ...prev,
-      txsData: [],
-      url: getTxsDataUrl({
-        party,
-        count,
-        after,
-        before,
-        filters: getTypeFilters(filters),
-      }),
-    }));
-
     refetch({ count: BE_TXS_PER_REQUEST });
-  }, [party, setTxsState, refetch, filters]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [setSearchParams, refetch, filters]);
 
   const updateFilters = useCallback(
     (newFilters: Set<FilterOption>) => {
@@ -191,21 +95,8 @@ export const useTxsData = ({
       }
 
       setSearchParams(params);
-
-      console.dir(newFilters);
-
-      setTxsState((prev) => ({
-        ...prev,
-        url: getTxsDataUrl({
-          party,
-          count,
-          after,
-          before,
-          filters: getTypeFilters(newFilters),
-        }),
-      }));
     },
-    [party, count, after, before, setSearchParams]
+    [setSearchParams]
   );
 
   return {

--- a/apps/explorer/src/app/hooks/use-txs-data.ts
+++ b/apps/explorer/src/app/hooks/use-txs-data.ts
@@ -10,26 +10,35 @@ import isNumber from 'lodash/isNumber';
 export interface TxsStateProps {
   txsData: BlockExplorerTransactionResult[];
   hasMoreTxs: boolean;
-  cursor: string;
-  previousCursors: string[];
-  hasPreviousPage: boolean;
+  url: string
 }
 
 export interface IUseTxsData {
-  limit: number;
+  count?: number;
+  before?: string;
+  after?: string;
   filters?: string;
 }
 
 interface IGetTxsDataUrl {
-  limit: string;
+  count?: number;
+  before?: string;
+  after?: string;
   filters?: string;
 }
+const BE_TXS_PER_REQUEST = 25;
 
-export const getTxsDataUrl = ({ limit, filters }: IGetTxsDataUrl) => {
+export const getTxsDataUrl = ({ count = BE_TXS_PER_REQUEST, before, after, filters }: IGetTxsDataUrl) => {
   const url = new URL(`${DATA_SOURCES.blockExplorerUrl}/transactions`);
 
-  if (limit) {
-    url.searchParams.append('limit', limit);
+  if (before) {
+    url.searchParams.append('last', count.toString());
+    url.searchParams.append('before', before);
+  }
+
+  if (after) {
+    url.searchParams.append('last', count.toString());
+    url.searchParams.append('after', after);
   }
 
   // Hacky fix for param as array
@@ -41,19 +50,16 @@ export const getTxsDataUrl = ({ limit, filters }: IGetTxsDataUrl) => {
   return urlAsString;
 };
 
-export const useTxsData = ({ limit, filters }: IUseTxsData) => {
+export const useTxsData = ({ count, before, after, filters }: IUseTxsData) => {
   const [
-    { txsData, hasMoreTxs, cursor, previousCursors, hasPreviousPage },
+    { txsData, hasMoreTxs, url },
     setTxsState,
   ] = useState<TxsStateProps>({
     txsData: [],
     hasMoreTxs: false,
-    previousCursors: [],
-    cursor: '',
-    hasPreviousPage: false,
+    url: getTxsDataUrl({ filters, count, before, after })
   });
 
-  const url = getTxsDataUrl({ limit: limit.toString(), filters });
 
   const {
     state: { data, error, loading },
@@ -65,64 +71,40 @@ export const useTxsData = ({ limit, filters }: IUseTxsData) => {
       setTxsState((prev) => {
         return {
           ...prev,
-          txsData: data.transactions,
-          hasMoreTxs: data.transactions.length >= limit,
-          cursor: data?.transactions.at(-1)?.cursor || '',
+          txsData: data.transactions
         };
       });
     }
-  }, [loading, setTxsState, data, limit]);
+  }, [loading, setTxsState, data ]);
 
   const nextPage = useCallback(() => {
-    const c = data?.transactions.at(0)?.cursor;
-    const newPreviousCursors = c ? [...previousCursors, c] : previousCursors;
-
-    setTxsState((prev) => ({
-      ...prev,
-      hasPreviousPage: true,
-      previousCursors: newPreviousCursors,
-    }));
-
     return refetch({
-      limit,
-      before: cursor,
+      before: data?.transactions.at(-1)?.cursor || '',
     });
-  }, [data, previousCursors, cursor, limit, refetch]);
+  }, [data, refetch]);
 
   const previousPage = useCallback(() => {
-    const previousCursor = [...previousCursors].pop();
-    const newPreviousCursors = previousCursors.slice(0, -1);
-    setTxsState((prev) => ({
-      ...prev,
-      hasPreviousPage: newPreviousCursors.length > 0,
-      previousCursors: newPreviousCursors,
-    }));
     return refetch({
-      limit,
-      before: previousCursor,
+      before: data?.transactions.at(0)?.cursor || '',
     });
-  }, [previousCursors, limit, refetch]);
+  }, [data, refetch]);
 
   const refreshTxs = useCallback(async () => {
     setTxsState(() => ({
       txsData: [],
-      cursor: '',
       previousCursors: [],
       hasMoreTxs: false,
       hasPreviousPage: false,
     }));
 
-    refetch({ limit });
-  }, [setTxsState, limit, refetch, filters]); // eslint-disable-line react-hooks/exhaustive-deps
+    refetch({ count: BE_TXS_PER_REQUEST });
+  }, [setTxsState, refetch, filters]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     txsData,
     loading,
     error,
     hasMoreTxs,
-    hasPreviousPage,
-    previousCursors,
-    cursor,
     refreshTxs,
     nextPage,
     previousPage,

--- a/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
@@ -204,6 +204,7 @@ describe('Block', () => {
     (useFetch as jest.Mock).mockReturnValue({
       state: { data: createBlockResponse(1), loading: false, error: null },
     });
+
     render(renderComponent(1));
     await waitFor(() => screen.getByTestId('block-header'));
     expect(screen.getByTestId('previous-block-button')).toHaveAttribute(

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -40,11 +40,9 @@ const Party = () => {
     error,
     refreshTxs,
     loading,
-    txsData,
-    hasPreviousPage,
+    txsData
   } = useTxsData({
-    limit: 25,
-    filters: f,
+    filters: f
   });
 
   const variables = useMemo(() => ({ partyId }), [partyId]);
@@ -102,9 +100,9 @@ const Party = () => {
         refreshTxs={refreshTxs}
         nextPage={nextPage}
         previousPage={previousPage}
-        hasPreviousPage={hasPreviousPage}
+        hasPreviousPage={true}
         loading={loading}
-        hasMoreTxs={hasMoreTxs}
+        hasMoreTxs={true}
       >
         <TxsFilter filters={filters} setFilters={setFilters} />
       </TxsListNavigation>

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -15,6 +15,7 @@ import { PartyBlockAccounts } from './components/party-block-accounts';
 import { isValidPartyId } from './components/party-id-error';
 import { useDataProvider } from '@vegaprotocol/data-provider';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
+import type { FilterOption } from '../../../components/txs/tx-filter';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
 
 const Party = () => {
@@ -27,10 +28,17 @@ const Party = () => {
   const partyId = toNonHex(party ? party : '');
   const { isMobile } = useScreenDimensions();
   const visibleChars = useMemo(() => (isMobile ? 10 : 14), [isMobile]);
-  const baseFilters = `filters[tx.submitter]=${partyId}`;
 
-  const { nextPage, refreshTxs, previousPage, error, loading, txsData } =
-    useTxsData({});
+  const {
+    nextPage,
+    refreshTxs,
+    previousPage,
+    error,
+    loading,
+    txsData,
+    hasMoreTxs,
+    updateFilters,
+  } = useTxsData({ party: partyId });
 
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const {
@@ -89,9 +97,15 @@ const Party = () => {
         previousPage={previousPage}
         hasPreviousPage={true}
         loading={loading}
-        hasMoreTxs={true}
+        hasMoreTxs={hasMoreTxs}
       >
-        <TxsFilter filters={filters} setFilters={setFilters} />
+        <TxsFilter
+          filters={filters}
+          setFilters={(f) => {
+            setFilters(f);
+            updateFilters(f as Set<FilterOption>);
+          }}
+        />
       </TxsListNavigation>
       {!error && txsData ? (
         <TxsInfiniteList

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -28,15 +28,9 @@ const Party = () => {
   const { isMobile } = useScreenDimensions();
   const visibleChars = useMemo(() => (isMobile ? 10 : 14), [isMobile]);
   const baseFilters = `filters[tx.submitter]=${partyId}`;
-  const f =
-    filters && filters.size === 1
-      ? `${baseFilters}&filters[cmd.type]=${Array.from(filters)[0]}`
-      : baseFilters;
 
   const { nextPage, refreshTxs, previousPage, error, loading, txsData } =
-    useTxsData({
-      filters: f,
-    });
+    useTxsData({});
 
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const {

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -17,8 +17,11 @@ import { useDataProvider } from '@vegaprotocol/data-provider';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
 import type { FilterOption } from '../../../components/txs/tx-filter';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
+import { useSearchParams } from 'react-router-dom';
 
 const Party = () => {
+  const [params] = useSearchParams();
+
   const [filters, setFilters] = useState(new Set(AllFilterOptions));
   const { party } = useParams<{ party: string }>();
 
@@ -38,7 +41,12 @@ const Party = () => {
     txsData,
     hasMoreTxs,
     updateFilters,
-  } = useTxsData({ party: partyId });
+  } = useTxsData({
+    filters: filters.size === 1 ? filters : undefined,
+    before: params.get('before') || undefined,
+    after: !params.get('before') ? params.get('after') || undefined : undefined,
+    party: partyId,
+  });
 
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const {

--- a/apps/explorer/src/app/routes/parties/id/index.tsx
+++ b/apps/explorer/src/app/routes/parties/id/index.tsx
@@ -33,17 +33,10 @@ const Party = () => {
       ? `${baseFilters}&filters[cmd.type]=${Array.from(filters)[0]}`
       : baseFilters;
 
-  const {
-    hasMoreTxs,
-    nextPage,
-    previousPage,
-    error,
-    refreshTxs,
-    loading,
-    txsData
-  } = useTxsData({
-    filters: f
-  });
+  const { nextPage, refreshTxs, previousPage, error, loading, txsData } =
+    useTxsData({
+      filters: f,
+    });
 
   const variables = useMemo(() => ({ partyId }), [partyId]);
   const {
@@ -108,7 +101,7 @@ const Party = () => {
       </TxsListNavigation>
       {!error && txsData ? (
         <TxsInfiniteList
-          hasMoreTxs={hasMoreTxs}
+          hasMoreTxs={true}
           areTxsLoading={loading}
           txs={txsData}
           loadMoreTxs={nextPage}

--- a/apps/explorer/src/app/routes/txs/home/index.tsx
+++ b/apps/explorer/src/app/routes/txs/home/index.tsx
@@ -8,7 +8,6 @@ import { useState } from 'react';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
 
-const BE_TXS_PER_REQUEST = 25;
 
 export const TxsList = () => {
   useDocumentTitle(['Transactions']);
@@ -42,9 +41,7 @@ export const TxsListFiltered = () => {
     refreshTxs,
     loading,
     txsData,
-    hasPreviousPage,
   } = useTxsData({
-    limit: BE_TXS_PER_REQUEST,
     filters: f,
   });
 
@@ -54,9 +51,9 @@ export const TxsListFiltered = () => {
         refreshTxs={refreshTxs}
         nextPage={nextPage}
         previousPage={previousPage}
-        hasPreviousPage={hasPreviousPage}
+        hasPreviousPage={true}
         loading={loading}
-        hasMoreTxs={hasMoreTxs}
+        hasMoreTxs={true}
       >
         <TxsFilter filters={filters} setFilters={setFilters} />
       </TxsListNavigation>

--- a/apps/explorer/src/app/routes/txs/home/index.tsx
+++ b/apps/explorer/src/app/routes/txs/home/index.tsx
@@ -4,8 +4,9 @@ import { TxsInfiniteList } from '../../../components/txs';
 import { useTxsData } from '../../../hooks/use-txs-data';
 import { useDocumentTitle } from '../../../hooks/use-document-title';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
+import type { FilterOption } from '../../../components/txs/tx-filter';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
 import { useSearchParams } from 'react-router-dom';
 
@@ -21,22 +22,57 @@ export const TxsList = () => {
 };
 
 /**
+ * Returns a Set of filters based on the URLSearchParams, or
+ * defaults to all.
+ * @param params
+ * @returns Set
+ */
+export function getInitialFilters(params: URLSearchParams): Set<FilterOption> {
+  const defaultFilters = new Set(AllFilterOptions);
+
+  const p = params.get('filters');
+
+  if (!p) {
+    return defaultFilters;
+  }
+
+  const filters = new Set<FilterOption>();
+  p.split(',').forEach((f) => {
+    if (AllFilterOptions.includes(f as FilterOption)) {
+      filters.add(f as FilterOption);
+    }
+  });
+
+  if (filters.size === 0) {
+    return defaultFilters;
+  }
+
+  return filters;
+}
+
+/**
  * Displays a list of transactions with filters and controls to navigate through the list.
  *
  * @returns {JSX.Element} Transaction List and controls
  */
 export const TxsListFiltered = () => {
-  const [filters, setFilters] = useState(new Set(AllFilterOptions));
   const [params] = useSearchParams();
+  const [filters, setFilters] = useState(getInitialFilters(params));
 
-  const { nextPage, previousPage, error, refreshTxs, loading, txsData } =
-    useTxsData({
-      filters: filters.size === 1 ? filters : undefined,
-      before: params.get('before') || undefined,
-      after: !params.get('before')
-        ? params.get('after') || undefined
-        : undefined,
-    });
+  const {
+    nextPage,
+    previousPage,
+    error,
+    refreshTxs,
+    loading,
+    txsData,
+    hasMoreTxs,
+    updateFilters,
+  } = useTxsData({
+    filters: filters.size === 1 ? filters : undefined,
+    before: params.get('before') || undefined,
+    after: !params.get('before') ? params.get('after') || undefined : undefined,
+  });
 
   return (
     <>
@@ -46,9 +82,15 @@ export const TxsListFiltered = () => {
         previousPage={previousPage}
         hasPreviousPage={true}
         loading={loading}
-        hasMoreTxs={true}
+        hasMoreTxs={hasMoreTxs}
       >
-        <TxsFilter filters={filters} setFilters={setFilters} />
+        <TxsFilter
+          filters={filters}
+          setFilters={(f) => {
+            setFilters(f);
+            updateFilters(f as Set<FilterOption>);
+          }}
+        />
       </TxsListNavigation>
       <TxsInfiniteList
         hasFilters={filters.size > 0}

--- a/apps/explorer/src/app/routes/txs/home/index.tsx
+++ b/apps/explorer/src/app/routes/txs/home/index.tsx
@@ -8,7 +8,6 @@ import { useState } from 'react';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
 
-
 export const TxsList = () => {
   useDocumentTitle(['Transactions']);
 
@@ -33,17 +32,10 @@ export const TxsListFiltered = () => {
       ? `filters[cmd.type]=${Array.from(filters)[0]}`
       : '';
 
-  const {
-    hasMoreTxs,
-    nextPage,
-    previousPage,
-    error,
-    refreshTxs,
-    loading,
-    txsData,
-  } = useTxsData({
-    filters: f,
-  });
+  const { nextPage, previousPage, error, refreshTxs, loading, txsData } =
+    useTxsData({
+      filters: f,
+    });
 
   return (
     <>
@@ -59,7 +51,7 @@ export const TxsListFiltered = () => {
       </TxsListNavigation>
       <TxsInfiniteList
         hasFilters={filters.size > 0}
-        hasMoreTxs={hasMoreTxs}
+        hasMoreTxs={true}
         areTxsLoading={loading}
         txs={txsData}
         loadMoreTxs={nextPage}

--- a/apps/explorer/src/app/routes/txs/home/index.tsx
+++ b/apps/explorer/src/app/routes/txs/home/index.tsx
@@ -1,11 +1,11 @@
 import { t } from '@vegaprotocol/i18n';
 import { RouteTitle } from '../../../components/route-title';
 import { TxsInfiniteList } from '../../../components/txs';
-import { useTxsData } from '../../../hooks/use-txs-data';
+import { useTxsData, getInitialFilters } from '../../../hooks/use-txs-data';
 import { useDocumentTitle } from '../../../hooks/use-document-title';
 
 import { useState } from 'react';
-import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
+import { TxsFilter } from '../../../components/txs/tx-filter';
 import type { FilterOption } from '../../../components/txs/tx-filter';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
 import { useSearchParams } from 'react-router-dom';
@@ -20,35 +20,6 @@ export const TxsList = () => {
     </section>
   );
 };
-
-/**
- * Returns a Set of filters based on the URLSearchParams, or
- * defaults to all.
- * @param params
- * @returns Set
- */
-export function getInitialFilters(params: URLSearchParams): Set<FilterOption> {
-  const defaultFilters = new Set(AllFilterOptions);
-
-  const p = params.get('filters');
-
-  if (!p) {
-    return defaultFilters;
-  }
-
-  const filters = new Set<FilterOption>();
-  p.split(',').forEach((f) => {
-    if (AllFilterOptions.includes(f as FilterOption)) {
-      filters.add(f as FilterOption);
-    }
-  });
-
-  if (filters.size === 0) {
-    return defaultFilters;
-  }
-
-  return filters;
-}
 
 /**
  * Displays a list of transactions with filters and controls to navigate through the list.

--- a/apps/explorer/src/app/routes/txs/home/index.tsx
+++ b/apps/explorer/src/app/routes/txs/home/index.tsx
@@ -4,9 +4,10 @@ import { TxsInfiniteList } from '../../../components/txs';
 import { useTxsData } from '../../../hooks/use-txs-data';
 import { useDocumentTitle } from '../../../hooks/use-document-title';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AllFilterOptions, TxsFilter } from '../../../components/txs/tx-filter';
 import { TxsListNavigation } from '../../../components/txs/tx-list-navigation';
+import { useSearchParams } from 'react-router-dom';
 
 export const TxsList = () => {
   useDocumentTitle(['Transactions']);
@@ -26,15 +27,15 @@ export const TxsList = () => {
  */
 export const TxsListFiltered = () => {
   const [filters, setFilters] = useState(new Set(AllFilterOptions));
-
-  const f =
-    filters && filters.size === 1
-      ? `filters[cmd.type]=${Array.from(filters)[0]}`
-      : '';
+  const [params] = useSearchParams();
 
   const { nextPage, previousPage, error, refreshTxs, loading, txsData } =
     useTxsData({
-      filters: f,
+      filters: filters.size === 1 ? filters : undefined,
+      before: params.get('before') || undefined,
+      after: !params.get('before')
+        ? params.get('after') || undefined
+        : undefined,
     });
 
   return (


### PR DESCRIPTION
- fix(explorer): fixing txsdata fetch
- fix(explorer): working txsdata fetch
- feat(explorer): partial url support
- feat(explorer): url persistence
- feat(explorer): pagination and filters in url for parties

# Description
This PR started off as just fixing #4373, which broken in the Block Explorer API in 0.72.4 or 0.72.5, but ended up being enough work that it made sense to rope in #4215 

- TX filter now persisted in URL for `txs/index` and `parties/partyId`
- Cursor before/after now persisted in URL for `txs/index` and `parties/partyId`
- Relpace deprecated `limit` usage with `before`/`after`/`first`/`last` cursor usage

# Issues fixed
- Closes #4215 
- Closes #4274 
- Closes #4373
- Closes #4237