### PR TITLE
fix(governance): remove incorrect individual reward percentage

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
@@ -5,7 +5,6 @@ import {
   RewardsTable,
 } from '../shared-rewards-table-assets/shared-rewards-table-assets';
 import type { EpochIndividualReward } from './generate-epoch-individual-rewards-list';
-import { useTranslation } from 'react-i18next';
 
 interface EpochIndividualRewardsGridProps {
   data: EpochIndividualReward;
@@ -22,14 +21,11 @@ interface RewardItemProps {
 const DisplayReward = ({
   reward,
   decimals,
-  percentageOfTotal,
 }: {
   reward: string;
   decimals: number;
   percentageOfTotal?: string;
 }) => {
-  const { t } = useTranslation();
-
   if (Number(reward) === 0) {
     return <span className="text-vega-dark-300">-</span>;
   }

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
@@ -39,23 +39,12 @@ const DisplayReward = ({
       description={
         <div className="flex flex-col items-start">
           <span>{formatNumber(toBigNum(reward, decimals), decimals)}</span>
-          {percentageOfTotal && (
-            <span className="text-vega-dark-300">
-              ({percentageOfTotal}% {t('ofTotalDistributed')})
-            </span>
-          )}
         </div>
       }
     >
       <button>
         <div className="flex flex-col items-start">
           <span>{formatNumber(toBigNum(reward, decimals), 4)}</span>
-          {percentageOfTotal && (
-            <span className="text-vega-dark-300">
-              ({formatNumber(percentageOfTotal, 4).toString()}
-              %)
-            </span>
-          )}
         </div>
       </button>
     </Tooltip>

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
@@ -168,17 +168,6 @@ describe('generateEpochIndividualRewardsList', () => {
     expect(result2[1].epoch).toEqual(1);
   });
 
-  it('correctly calculates the total value of rewards for an asset', () => {
-    const rewards = [reward1, reward4];
-    const result = generateEpochIndividualRewardsList({
-      rewards,
-      epochId: 1,
-      epochRewardSummaries: [],
-    });
-
-    expect(result[0].rewards[0].totalAmount).toEqual('200');
-  });
-
   it('returns data in the expected shape', () => {
     // Just sanity checking the whole structure here
     const rewards = [reward1, reward2, reward3, reward4];
@@ -457,70 +446,5 @@ describe('generateEpochIndividualRewardsList', () => {
         ],
       },
     ]);
-  });
-
-  it('correctly calculates the percentage of two or more rewards by referencing the total rewards amount', () => {
-    const result = generateEpochIndividualRewardsList({
-      rewards: [
-        // reward1 is 100 usd, which is 10% of the total rewards amount
-        reward1,
-        {
-          rewardType: AccountType.ACCOUNT_TYPE_GLOBAL_REWARD,
-          amount: '200',
-          percentageOfTotal: '0.2',
-          receivedAt: new Date(),
-          asset: { id: 'usd', symbol: 'USD', name: 'USD', decimals: 6 },
-          party: { id: 'blah' },
-          epoch: { id: '1' },
-        },
-      ],
-      epochId: 1,
-      epochRewardSummaries: [
-        {
-          __typename: 'EpochRewardSummary',
-          epoch: 1,
-          assetId: 'usd',
-          amount: '1000',
-          rewardType: AccountType.ACCOUNT_TYPE_GLOBAL_REWARD,
-        },
-      ],
-    });
-
-    expect(result[0]).toEqual({
-      epoch: 1,
-      rewards: [
-        {
-          asset: 'USD',
-          decimals: 6,
-          totalAmount: '300',
-          rewardTypes: {
-            [AccountType.ACCOUNT_TYPE_FEES_INFRASTRUCTURE]: {
-              amount: '0',
-              percentageOfTotal: '0',
-            },
-            [AccountType.ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES]: {
-              amount: '0',
-              percentageOfTotal: '0',
-            },
-            [AccountType.ACCOUNT_TYPE_GLOBAL_REWARD]: {
-              amount: '300',
-              percentageOfTotal: '30',
-            },
-            [AccountType.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES]: {
-              amount: '0',
-              percentageOfTotal: '0',
-            },
-            [AccountType.ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES]: {
-              amount: '0',
-              percentageOfTotal: '0',
-            },
-            [AccountType.ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS]: {
-              amount: '0',
-              percentageOfTotal: '0',
-            },
-          },
-        },
-      ],
-    });
   });
 });

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
@@ -106,14 +106,7 @@ export const generateEpochIndividualRewardsList = ({
 
       asset.rewardTypes[rewardType] = {
         amount: newAmount,
-        percentageOfTotal: matchingTotalRewardAmount
-          ? new BigNumber(newAmount)
-              .dividedBy(matchingTotalRewardAmount)
-              .multipliedBy(100)
-              .toString()
-          : // this should never be reached, if there's an individual reward there should
-            // always be a reward total from the api too, but set it as a fallback just in case
-            percentageOfTotal,
+        percentageOfTotal: percentageOfTotal,
       };
     }
 

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
@@ -59,7 +59,6 @@ export const generateEpochIndividualRewardsList = ({
   const epochIndividualRewards = rewards.reduce((acc, reward) => {
     const epochId = reward.epoch.id;
     const assetName = reward.asset.name;
-    const assetId = reward.asset.id;
     const assetDecimals = reward.asset.decimals;
     const rewardType = reward.rewardType;
     const amount = reward.amount;
@@ -77,13 +76,6 @@ export const generateEpochIndividualRewardsList = ({
     const epoch = acc.get(epochId);
 
     // matchingTotalReward is the total awarded for all users for the reward type in the epoch of the asset
-    const matchingTotalRewardAmount = epochRewardSummaries.find(
-      (summary) =>
-        summary.epoch === Number(epochId) &&
-        summary.assetId === assetId &&
-        summary.rewardType === rewardType
-    )?.amount;
-
     let asset = epoch?.rewards.find((r) => r.asset === assetName);
 
     if (!asset) {


### PR DESCRIPTION
# Related issues 🔗

Closes #4436

# Description ℹ️

The current calculation for this percentage is incorrect. Exactly where it is incorrect took longer to discover than
an arbitrary deadline, so instead the percentage is removed.

The complexity for this code is high. While there is a field in the API that, for each reward, returns the percentage
of the total reward, the table that displays this data is potentially aggregating multiple rewards of the same type. 
This should be straightforward, but the perceived value of this value is lower than the time it would take to trace the
logic and find the mistake.
