### PR TITLE
feat(explorer): successor markets

### DIFF
--- a/apps/explorer/src/app/components/markets/market-details.tsx
+++ b/apps/explorer/src/app/components/markets/market-details.tsx
@@ -1,6 +1,9 @@
 import { t } from '@vegaprotocol/i18n';
 import type { MarketInfoWithData } from '@vegaprotocol/markets';
-import { PriceMonitoringBoundsInfoPanel } from '@vegaprotocol/markets';
+import {
+  PriceMonitoringBoundsInfoPanel,
+  SuccessionLineInfoPanel,
+} from '@vegaprotocol/markets';
 import {
   LiquidityInfoPanel,
   LiquidityMonitoringParametersInfoPanel,
@@ -103,6 +106,8 @@ export const MarketDetails = ({ market }: { market: MarketInfoWithData }) => {
           <OracleInfoPanel market={market} type="settlementData" />
         </>
       )}
+      <h2 className={`${headerClassName} mb-4`}>{t('Succession line')}</h2>
+      <SuccessionLineInfoPanel market={market} />
     </div>
   );
 };

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -10,6 +10,8 @@ import Hash from '../../links/hash';
 import { t } from '@vegaprotocol/i18n';
 import { ProposalSignatureBundleNewAsset } from './proposal/signature-bundle-new';
 import { ProposalSignatureBundleUpdateAsset } from './proposal/signature-bundle-update';
+import { MarketLink } from '../../links';
+import { formatNumber } from '@vegaprotocol/utils';
 
 export type Proposal = components['schemas']['v1ProposalSubmission'];
 export type ProposalTerms = components['schemas']['vegaProposalTerms'];
@@ -89,6 +91,9 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
   }
 
   const tx = proposal.terms?.newAsset || proposal.terms?.updateAsset;
+  const isSuccessorMarketProposal = proposal?.terms?.newMarket?.changes?.successor;
+  const parentMarketId = isSuccessorMarketProposal && proposal?.terms.newMarket?.changes?.successor?.parentMarketId;
+  const insurancePoolFraction = proposal?.terms?.newMarket?.changes?.successor?.insurancePoolFraction;
 
   // This component is not rendered if no bundle is required
   const SignatureBundleComponent = proposal.terms?.newAsset
@@ -115,6 +120,23 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
             <Hash text={deterministicId} />
           </TableCell>
         </TableRow>
+        {isSuccessorMarketProposal ? <>
+          {parentMarketId ?
+            <TableRow modifier='bordered'>
+              <TableCell>{t('Previous market')}</TableCell>
+              <TableCell>
+                <MarketLink id={proposal.terms?.newMarket.changes.successor.parentMarketId} />
+              </TableCell>
+            </TableRow> : null}
+          {insurancePoolFraction ?
+            <TableRow modifier='bordered'>
+              <TableCell>{t('Insurance pool fraction')}</TableCell>
+              <TableCell>
+                {formatNumber(Number(insurancePoolFraction) * 100, 0)}%
+              </TableCell>
+            </TableRow> : null}
+        </> : null}
+
       </TableWithTbody>
       <ProposalSummary
         id={deterministicId}

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -91,9 +91,13 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
   }
 
   const tx = proposal.terms?.newAsset || proposal.terms?.updateAsset;
-  const isSuccessorMarketProposal = proposal?.terms?.newMarket?.changes?.successor;
-  const parentMarketId = isSuccessorMarketProposal && proposal?.terms.newMarket?.changes?.successor?.parentMarketId;
-  const insurancePoolFraction = proposal?.terms?.newMarket?.changes?.successor?.insurancePoolFraction;
+  const isSuccessorMarketProposal =
+    proposal?.terms?.newMarket?.changes?.successor;
+  const parentMarketId =
+    isSuccessorMarketProposal &&
+    proposal?.terms.newMarket?.changes?.successor?.parentMarketId;
+  const insurancePoolFraction =
+    proposal?.terms?.newMarket?.changes?.successor?.insurancePoolFraction;
 
   // This component is not rendered if no bundle is required
   const SignatureBundleComponent = proposal.terms?.newAsset
@@ -120,23 +124,30 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
             <Hash text={deterministicId} />
           </TableCell>
         </TableRow>
-        {isSuccessorMarketProposal ? <>
-          {parentMarketId ?
-            <TableRow modifier='bordered'>
-              <TableCell>{t('Previous market')}</TableCell>
-              <TableCell>
-                <MarketLink id={proposal.terms?.newMarket.changes.successor.parentMarketId} />
-              </TableCell>
-            </TableRow> : null}
-          {insurancePoolFraction ?
-            <TableRow modifier='bordered'>
-              <TableCell>{t('Insurance pool fraction')}</TableCell>
-              <TableCell>
-                {formatNumber(Number(insurancePoolFraction) * 100, 0)}%
-              </TableCell>
-            </TableRow> : null}
-        </> : null}
-
+        {isSuccessorMarketProposal ? (
+          <>
+            {parentMarketId ? (
+              <TableRow modifier="bordered">
+                <TableCell>{t('Previous market')}</TableCell>
+                <TableCell>
+                  <MarketLink
+                    id={
+                      proposal.terms?.newMarket.changes.successor.parentMarketId
+                    }
+                  />
+                </TableCell>
+              </TableRow>
+            ) : null}
+            {insurancePoolFraction ? (
+              <TableRow modifier="bordered">
+                <TableCell>{t('Insurance pool fraction')}</TableCell>
+                <TableCell>
+                  {formatNumber(Number(insurancePoolFraction) * 100, 0)}%
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </>
+        ) : null}
       </TableWithTbody>
       <ProposalSummary
         id={deterministicId}

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -53,7 +53,11 @@ export function proposalTypeLabel(terms?: ProposalTerms): string {
   } else if (has(terms, 'updateAsset')) {
     return t('Update asset proposal');
   } else if (has(terms, 'newMarket')) {
-    return t('New market proposal');
+    if (terms?.newMarket?.changes?.successor) {
+      return t('Successor market proposal');
+    } else {
+      return t('New market proposal');
+    }
   } else if (has(terms, 'updateMarket')) {
     return t('Update market proposal');
   } else if (has(terms, 'updateNetworkParameter')) {

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -78,7 +78,7 @@ export function getLabelForProposal(
   } else if (proposal.terms?.updateAsset) {
     return t('Proposal: Update asset');
   } else if (proposal.terms?.newMarket) {
-    if (proposal.terms?.newMarket) {
+    if (proposal.terms?.newMarket.changes?.successor) {
       return t('Proposal: Successor market');
     } else {
       return t('Proposal: New market');

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -78,7 +78,11 @@ export function getLabelForProposal(
   } else if (proposal.terms?.updateAsset) {
     return t('Proposal: Update asset');
   } else if (proposal.terms?.newMarket) {
-    return t('Proposal: New market');
+    if (proposal.terms?.newMarket) {
+      return t('Proposal: Successor market');
+    } else {
+      return t('Proposal: New market');
+    }
   } else if (proposal.terms?.updateMarket) {
     return t('Proposal: Update market');
   } else if (proposal.terms?.updateNetworkParameter) {


### PR DESCRIPTION
- feat(explorer): specific label for successor markets
- feat(explorer): labvel fix and insurance pool details
- feat(explorer): succession line in market details

# Related issues 🔗

Closes #4175 

# Description ℹ️

- Add 'Proposal: Successor market' to TX list
- Add to TX page: Insurance Pool Percentage if set
- Add to TX page: previous market if set
- Add to market details page: succession line panel

# Demo 📺

## TX list
<img width="933" alt="Screenshot 2023-08-09 at 12 58 11" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/60dd3a6e-8aad-42ba-b1d2-bd99131a6b86">

## Details view
<img width="1169" alt="Screenshot 2023-08-09 at 12 58 19" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/1fe56453-1f1b-4aa5-99b0-29e525a0758b">

# Market details view
<img width="1141" alt="Screenshot 2023-08-09 at 17 42 24" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/b2cb84af-352a-4fdd-a722-1ed8d0261684">