### PR TITLE
fix(trading): prevent overflow in deal ticket if market fails to load

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
@@ -9,7 +9,7 @@ import {
   useMarket,
   useMarketPrice,
 } from '@vegaprotocol/markets';
-import { AsyncRenderer, Splash } from '@vegaprotocol/ui-toolkit';
+import { AsyncRendererInline } from '@vegaprotocol/ui-toolkit';
 import { t } from '@vegaprotocol/i18n';
 import { DealTicket } from './deal-ticket';
 import { FLAGS } from '@vegaprotocol/environment';
@@ -42,7 +42,7 @@ export const DealTicketContainer = ({
   const { data: marketPrice } = useMarketPrice(market?.id);
   const create = useVegaTransactionStore((state) => state.create);
   return (
-    <AsyncRenderer
+    <AsyncRendererInline
       data={market && marketData}
       loading={marketLoading || marketDataLoading}
       error={marketError || marketDataError}
@@ -65,10 +65,8 @@ export const DealTicketContainer = ({
           />
         )
       ) : (
-        <Splash>
-          <p>{t('Could not load market')}</p>
-        </Splash>
+        <p>{t('Could not load market')}</p>
       )}
-    </AsyncRenderer>
+    </AsyncRendererInline>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Fixes a problem where the get started content is pushed off screen if the market fails to load. As seen below:

![Screenshot 2023-08-10 at 17 52 04](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/767d563d-b88c-474a-8c67-e13e5ca9f3f6)