### PR TITLE
fix(proposals): error policy guard for proposal data provider

### DIFF
--- a/libs/proposals/src/lib/proposals-data-provider/proposals-data-provider.tsx
+++ b/libs/proposals/src/lib/proposals-data-provider/proposals-data-provider.tsx
@@ -17,4 +17,17 @@ export const proposalsDataProvider = makeDataProvider<
   never,
   never,
   ProposalsListQueryVariables
->({ query: ProposalsListDocument, getData });
+>({
+  query: ProposalsListDocument,
+  getData,
+  /**
+   * Ignores errors for not found settlement asset for NewMarket proposals.
+   *
+   * It can happen that a NewMarket proposal is incomplete and does not contain
+   * `futureProduct` details. This guard protects against that.
+   *
+   * GQL Path: `terms.change.instrument.futureProduct.settlementAsset`
+   */
+  errorPolicyGuard: (errors) =>
+    errors.every((e) => e.message.match(/failed to get asset for ID/)),
+});


### PR DESCRIPTION
# Related issues 🔗

Closes #4473 
Closes #4364 

# Description ℹ️

It can happen that a NewMarket proposal is incomplete and does not contain `futureProduct` details. This PR adds a guard that ignores that error for proposal listings.

Example of "failed" proposal: 57b6a70ff3c17c4002befc03f94fc8e6e5fe917da587c4b36672bb1c404966c9 (TESTNET)