### PR TITLE
fix(governance): better vote error handling

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal/proposal.tsx
@@ -55,7 +55,7 @@ export const Proposal = ({
   mostRecentlyEnactedAssociatedMarketProposal,
 }: ProposalProps) => {
   const { t } = useTranslation();
-  const { submit, Dialog, finalizedVote } = useVoteSubmit();
+  const { submit, Dialog, finalizedVote, transaction } = useVoteSubmit();
   const { voteState, voteDatetime } = useUserVote(proposal?.id, finalizedVote);
 
   if (!proposal) {
@@ -215,6 +215,7 @@ export const Proposal = ({
               }
               submit={submit}
               dialog={Dialog}
+              transaction={transaction}
               voteState={voteState}
               voteDatetime={voteDatetime}
             />

--- a/apps/governance/src/routes/proposals/components/vote-details/vega-transaction-dialog.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vega-transaction-dialog.spec.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { VoteTransactionDialog } from './vote-transaction-dialog';
+import { VoteState } from './use-user-vote';
+import { VegaTxStatus } from '@vegaprotocol/wallet';
+
+describe('VoteTransactionDialog', () => {
+  const mockTransactionDialog = jest.fn(({ title, content }) => (
+    <div>
+      <div>{title}</div>
+      <div>{content?.Complete}</div>
+    </div>
+  ));
+
+  it('renders without crashing', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Yes}
+        transaction={null}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.getByTestId('vote-transaction-dialog')).toBeInTheDocument();
+  });
+
+  it('renders with txRequested title when voteState is Requested', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Requested}
+        transaction={null}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.getByText('txRequested')).toBeInTheDocument();
+  });
+
+  it('renders with votePending title when voteState is Pending', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Pending}
+        transaction={null}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.getByText('votePending')).toBeInTheDocument();
+  });
+
+  it('renders with no title when voteState is neither Requested nor Pending', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Yes} // or any other state other than Requested or Pending
+        transaction={null}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.queryByText('txRequested')).not.toBeInTheDocument();
+    expect(screen.queryByText('votePending')).not.toBeInTheDocument();
+  });
+
+  it('renders custom error message when voteState is Failed and error message exists', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Failed}
+        transaction={{
+          error: { message: 'Custom error test message', name: 'blah' },
+          txHash: null,
+          signature: null,
+          status: VegaTxStatus.Error,
+          dialogOpen: false,
+        }}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.getByText('Custom error test message')).toBeInTheDocument();
+  });
+
+  it('renders default error message when voteState is failed and no error message exists on the tx', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Failed}
+        transaction={{
+          error: null,
+          txHash: null,
+          signature: null,
+          status: VegaTxStatus.Error,
+          dialogOpen: false,
+        }}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.getByText('voteError')).toBeInTheDocument();
+  });
+
+  it('renders default ui (i.e. not error) when not in a failed state', () => {
+    render(
+      <VoteTransactionDialog
+        voteState={VoteState.Yes}
+        transaction={null}
+        TransactionDialog={mockTransactionDialog}
+      />
+    );
+
+    expect(screen.queryByText('voteError')).not.toBeInTheDocument();
+  });
+});

--- a/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import BigNumber from 'bignumber.js';
 import { VoteButtons } from './vote-buttons';
 import { VoteState } from './use-user-vote';
@@ -24,6 +24,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(1)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -47,6 +48,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(1)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -81,6 +83,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(1)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -105,6 +108,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(0)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -132,6 +136,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(1)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -159,6 +164,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(10)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>
@@ -183,6 +189,7 @@ describe('Vote buttons', () => {
               currentStakeAvailable={new BigNumber(10)}
               dialog={() => <div>Blah</div>}
               submit={() => Promise.resolve()}
+              transaction={null}
             />
           </VegaWalletContext.Provider>
         </MockedProvider>

--- a/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.tsx
@@ -17,7 +17,7 @@ import { VoteState } from './use-user-vote';
 import { ProposalMinRequirements, ProposalUserAction } from '../shared';
 import { VoteTransactionDialog } from './vote-transaction-dialog';
 import { useVoteButtonsQuery } from './__generated__/Stake';
-import type { DialogProps } from '@vegaprotocol/wallet';
+import type { DialogProps, VegaTxState } from '@vegaprotocol/wallet';
 
 interface VoteButtonsContainerProps {
   voteState: VoteState | null;
@@ -27,6 +27,7 @@ interface VoteButtonsContainerProps {
   minVoterBalance: string | null | undefined;
   spamProtectionMinTokens: string | null | undefined;
   submit: (voteValue: VoteValue, proposalId: string | null) => Promise<void>;
+  transaction: VegaTxState | null;
   dialog: (props: DialogProps) => JSX.Element;
   className?: string;
 }
@@ -67,6 +68,7 @@ export const VoteButtons = ({
   minVoterBalance,
   spamProtectionMinTokens,
   submit,
+  transaction,
   dialog: Dialog,
 }: VoteButtonsProps) => {
   const { t } = useTranslation();
@@ -208,7 +210,11 @@ export const VoteButtons = ({
           </p>
         )
       )}
-      <VoteTransactionDialog voteState={voteState} TransactionDialog={Dialog} />
+      <VoteTransactionDialog
+        voteState={voteState}
+        transaction={transaction}
+        TransactionDialog={Dialog}
+      />
     </>
   );
 };

--- a/apps/governance/src/routes/proposals/components/vote-details/vote-details.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vote-details.tsx
@@ -12,7 +12,7 @@ import { VoteButtonsContainer } from './vote-buttons';
 import { SubHeading } from '../../../../components/heading';
 import { ProposalType } from '../proposal/proposal';
 import type { VoteValue } from '@vegaprotocol/types';
-import type { DialogProps } from '@vegaprotocol/wallet';
+import type { DialogProps, VegaTxState } from '@vegaprotocol/wallet';
 import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
 import type { VoteState } from './use-user-vote';
@@ -22,6 +22,7 @@ interface VoteDetailsProps {
   minVoterBalance: string | null | undefined;
   spamProtectionMinTokens: string | null | undefined;
   proposalType: ProposalType | null;
+  transaction: VegaTxState | null;
   submit: (voteValue: VoteValue, proposalId: string | null) => Promise<void>;
   dialog: (props: DialogProps) => JSX.Element;
   voteState: VoteState | null;
@@ -34,6 +35,7 @@ export const VoteDetails = ({
   spamProtectionMinTokens,
   proposalType,
   submit,
+  transaction,
   dialog,
   voteState,
   voteDatetime,
@@ -228,6 +230,7 @@ export const VoteDetails = ({
                 spamProtectionMinTokens={spamProtectionMinTokens}
                 className="flex"
                 submit={submit}
+                transaction={transaction}
                 dialog={dialog}
               />
             )

--- a/apps/governance/src/routes/proposals/components/vote-details/vote-transaction-dialog.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vote-transaction-dialog.tsx
@@ -1,9 +1,10 @@
 import { t } from '@vegaprotocol/i18n';
 import { VoteState } from './use-user-vote';
-import type { DialogProps } from '@vegaprotocol/wallet';
+import type { DialogProps, VegaTxState } from '@vegaprotocol/wallet';
 
 interface VoteTransactionDialogProps {
   voteState: VoteState;
+  transaction: VegaTxState | null;
   TransactionDialog: (props: DialogProps) => JSX.Element;
 }
 
@@ -20,12 +21,15 @@ const dialogTitle = (voteState: VoteState): string | undefined => {
 
 export const VoteTransactionDialog = ({
   voteState,
+  transaction,
   TransactionDialog,
 }: VoteTransactionDialogProps) => {
   // Render a custom message if the voting fails otherwise
   // pass undefined so that the default vega transaction dialog UI gets used
   const customMessage =
-    voteState === VoteState.Failed ? <p>{t('voteError')}</p> : undefined;
+    voteState === VoteState.Failed ? (
+      <p>{transaction?.error?.message || t('voteError')}</p>
+    ) : undefined;
 
   return (
     <div data-testid="vote-transaction-dialog">


### PR DESCRIPTION
# Related issues 🔗

Closes #3522
Closes #3583 

# Description ℹ️

Previously, a generic error message was shown when an error occurred and the vote failed. Now, we are getting the error message from the transaction, and we only fall back to the generic message when the tx error message doesn't exist (which is likely never).
