### PR TITLE
fix(explorer): properly render issue signatures tx

### DIFF
--- a/apps/explorer/src/app/components/txs/details/tx-issue-signatures.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-issue-signatures.tsx
@@ -41,7 +41,7 @@ export const TxDetailsIssueSignatures = ({
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
 
-  const cmd: Command = txData.command;
+  const cmd: Command = txData.command.issueSignatures;
   const k = cmd.kind ? kind[cmd.kind] : null;
 
   return (


### PR DESCRIPTION
# Related issues 🔗

Closes #2947

# Description ℹ️

Issue Signatures component was not rendering the details because the TX was not being parsed properly. This small change fixes it.

# Demo 📺
 
<img width="863" alt="Screenshot 2023-08-23 at 16 51 06" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/d13a71b6-2620-4d72-82a7-d1cb70cdb3be">
