### PR TITLE
fix(trading): update fonts for pennant

### DIFF
--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -64,6 +64,10 @@ html.dark {
 
 html [data-theme='dark'],
 html [data-theme='light'] {
+  /* fonts */
+  --pennant-font-family-base: theme(fontFamily.alpha);
+  --pennant-font-family-monospace: theme(fontFamily.mono);
+
   /* sell candles only use stroke as the candle is solid (without border) */
   --pennant-color-sell-stroke: theme(colors.market.red.DEFAULT);
 


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Sets pennant default font to alpha and pennant monospace font to system so we match better with the rest of the app