### PR TITLE
chore(explorer,trading,governance): reconfigure hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -3,6 +3,3 @@
 
 # Lint commit messages to ensure they follow conventional commit standards
 yarn commitlint --edit "${1}"
-
-# Lint all staged files
-yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Lint all staged files
+yarn lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,3 +3,6 @@
 
 # Lint all staged files
 yarn nx format:check
+
+# Test all projects with changes
+yarn nx affected -t test --exclude trading

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Lint all staged files
+yarn nx format:check


### PR DESCRIPTION
Slightly changes the husky approach. These are relatively light touch, but point 3 might irritate some people. ~I'd like unit tests to be run pre-push too, but I'll see if I can start that just for Explorer and then start trying to convince other projects.~

1. `commit-msg` no longer reformats files, so you won't have changes after a commit. `commitlint` still runs
2. `pre-commit` reformats the files, so only formatted versions should be committed (effectively moved from `commit-msg`)
3. `pre-push` now checks formatting and will prevent pushing with unformatted files. This should stop us wasting CI time with pushes that will fail.
4. `pre-push` runs the unit tests for a changed project. `trading` has been explicitly ignored, so this mainly concerns `governance` and `trading`. I've excluded `trading` as the tests are a bit slow, and I didn't want to enfore a process change on another team without permission 😇 

<img width="996" alt="Screenshot 2023-08-30 at 13 51 20" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/ee79094c-6f52-4965-b996-358c33357c6c">


