### PR TITLE
fix(governance,environment,proposals): network upgrade proposal urls include block height

### DIFF
--- a/apps/governance-e2e/src/integration/view/proposal.cy.ts
+++ b/apps/governance-e2e/src/integration/view/proposal.cy.ts
@@ -183,7 +183,7 @@ context(
         .first()
         .find('[data-testid="view-proposal-btn"]')
         .click();
-      cy.url().should('contain', '/protocol-upgrades/v1');
+      cy.url().should('contain', '/protocol-upgrades/v1/2015942');
       cy.getByTestId('protocol-upgrade-proposal').within(() => {
         cy.get('h1').should('have.text', 'Vega Release v1');
         cy.getByTestId('protocol-upgrade-block-height').should(
@@ -243,7 +243,7 @@ context(
           );
         cy.getByTestId('external-link')
           .should('have.attr', 'href')
-          .and('contain', '/proposals/protocol-upgrade/v1');
+          .and('contain', '/proposals/protocol-upgrade/v1/2015942');
       });
 
       // estimate does not display possibly due to mocks or Cypress unless the proposal is clicked on several times

--- a/apps/governance/src/routes/proposals/components/protocol-upgrade-proposals-list-item/protocol-upgrade-proposals-list-item.tsx
+++ b/apps/governance/src/routes/proposals/components/protocol-upgrade-proposals-list-item/protocol-upgrade-proposals-list-item.tsx
@@ -67,7 +67,7 @@ export const ProtocolUpgradeProposalsListItem = ({
         <Link
           to={`${Routes.PROTOCOL_UPGRADES}/${stripFullStops(
             proposal.vegaReleaseTag
-          )}`}
+          )}/${proposal.upgradeBlockHeight}`}
         >
           <Button data-testid="view-proposal-btn">{t('viewDetails')}</Button>
         </Link>

--- a/apps/governance/src/routes/router-config.tsx
+++ b/apps/governance/src/routes/router-config.tsx
@@ -279,7 +279,7 @@ const routerConfig = [
     ],
   },
   {
-    path: `${Routes.PROTOCOL_UPGRADES}/:proposalReleaseTag`,
+    path: `${Routes.PROTOCOL_UPGRADES}/:proposalReleaseTag/:proposalBlockHeight`,
     element: <LazyProtocolUpgradeProposal />,
   },
   {

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -127,7 +127,7 @@ export const TOKEN_GOVERNANCE = '/proposals';
 export const TOKEN_PROPOSALS = '/proposals';
 export const TOKEN_PROPOSAL = '/proposals/:id';
 export const TOKEN_PROTOCOL_UPGRADE_PROPOSAL =
-  '/proposals/protocol-upgrade/:tag';
+  '/proposals/protocol-upgrade/:tag/:blockHeight';
 export const TOKEN_VALIDATOR = '/validators/:id';
 
 /**
@@ -135,12 +135,12 @@ export const TOKEN_VALIDATOR = '/validators/:id';
  */
 export const useProtocolUpgradeProposalLink = () => {
   const governance = useLinks(DApp.Token);
-  return (releaseTag: string) =>
+  return (releaseTag: string, blockHeight: string) =>
     governance(
       TOKEN_PROTOCOL_UPGRADE_PROPOSAL.replace(
         ':tag',
         stripFullStops(releaseTag)
-      )
+      ).replace(':blockHeight', blockHeight)
     );
 };
 

--- a/libs/proposals/src/components/protocol-upgrade-countdown.tsx
+++ b/libs/proposals/src/components/protocol-upgrade-countdown.tsx
@@ -73,7 +73,7 @@ export const ProtocolUpgradeCountdown = ({
 
   return (
     <a
-      href={detailsLink(data.vegaReleaseTag)}
+      href={detailsLink(data.vegaReleaseTag, data.upgradeBlockHeight)}
       target="_blank"
       rel="noreferrer nofollow noopener"
     >

--- a/libs/proposals/src/components/protocol-upgrade-in-progress-notification.tsx
+++ b/libs/proposals/src/components/protocol-upgrade-in-progress-notification.tsx
@@ -77,8 +77,8 @@ export const ProtocolUpgradeInProgressNotification = () => {
         {t(
           'Trading and other network activity has stopped until the upgrade is complete.'
         )}{' '}
-        {vegaReleaseTag && (
-          <ExternalLink href={detailsLink(vegaReleaseTag)}>
+        {vegaReleaseTag && upgradeBlockHeight && (
+          <ExternalLink href={detailsLink(vegaReleaseTag, upgradeBlockHeight)}>
             {t('View details')}
           </ExternalLink>
         )}

--- a/libs/proposals/src/components/protocol-upgrade-proposal-notification.tsx
+++ b/libs/proposals/src/components/protocol-upgrade-proposal-notification.tsx
@@ -79,7 +79,7 @@ export const ProtocolUpgradeProposalNotification = ({
         {t(
           'Trading activity will be interrupted, manage your risk appropriately.'
         )}{' '}
-        <ExternalLink href={detailsLink(vegaReleaseTag)}>
+        <ExternalLink href={detailsLink(vegaReleaseTag, upgradeBlockHeight)}>
           {t('View details')}
         </ExternalLink>
       </div>


### PR DESCRIPTION
# Related issues 🔗

Issue: #4700

# Description ℹ️

Protocol upgrade proposal urls have until now only used the upgrade tag, i.e. /proposals/protocol-upgrade/:tag

This is a problem if multiple proposals are made for the same upgrade version. We have no unique ID for these proposals, so to make proposal urls more unique, we are including the block height, i.e. /proposals/protocol-upgrade/:tag/:blockHeight

This work affects Governance and also the upgrade notification banner, which is displayed across the apps.
