### PR TITLE
fix(trading,governance,explorer): peer deps for published packages

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards.tsx
@@ -22,7 +22,6 @@ export const EpochTotalRewards = ({ currentEpoch }: EpochTotalRewardsProps) => {
   const { param: marketCreationQuantumMultiple } = useNetworkParam(
     'rewards_marketCreationQuantumMultiple'
   );
-  console.log(marketCreationQuantumMultiple);
   const [page, setPage] = useState(1);
   const { data, loading, error, refetch } = useEpochAssetsRewardsQuery({
     notifyOnNetworkStatusChange: true,

--- a/libs/announcements/package.json
+++ b/libs/announcements/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@vegaprotocol/announcements",
-  "version": "0.0.2",
-  "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  }
+  "version": "0.0.2"
 }

--- a/libs/announcements/package.json
+++ b/libs/announcements/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/announcements",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/libs/announcements/project.json
+++ b/libs/announcements/project.json
@@ -13,7 +13,13 @@
         "tsConfig": "libs/announcements/tsconfig.lib.json",
         "project": "libs/announcements/package.json",
         "entryFile": "libs/announcements/src/index.ts",
-        "external": ["react/jsx-runtime"],
+        "external": [
+          "react",
+          "react-dom",
+          "react/jsx-runtime",
+          "@vegaprotocol/react-helpers",
+          "@vegaprotocol/ui-toolkit"
+        ],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "compiler": "babel",
         "assets": [

--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vegaprotocol/i18n",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs"
 }

--- a/libs/i18n/project.json
+++ b/libs/i18n/project.json
@@ -7,6 +7,7 @@
     "build": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
+      "format": ["esm", "cjs"],
       "options": {
         "outputPath": "dist/libs/i18n",
         "main": "libs/i18n/src/index.ts",

--- a/libs/react-helpers/package.json
+++ b/libs/react-helpers/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/react-helpers",
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/libs/react-helpers/package.json
+++ b/libs/react-helpers/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@vegaprotocol/react-helpers",
-  "version": "0.2.5",
-  "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  }
+  "version": "0.2.5"
 }

--- a/libs/react-helpers/project.json
+++ b/libs/react-helpers/project.json
@@ -9,12 +9,17 @@
       "executor": "@nx/rollup:rollup",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "buildableProjectDepsInPackageJsonType": "dependencies",
         "outputPath": "dist/libs/react-helpers",
         "tsConfig": "libs/react-helpers/tsconfig.lib.json",
         "project": "libs/react-helpers/package.json",
         "entryFile": "libs/react-helpers/src/index.ts",
-        "external": ["react/jsx-runtime"],
+        "external": [
+          "react",
+          "react-dom",
+          "react/jsx-runtime",
+          "@vegaprotocol/tailwindcss-config",
+          "@vegaprotocol/utils"
+        ],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "compiler": "babel",
         "format": ["esm", "cjs"],

--- a/libs/tailwindcss-config/package.json
+++ b/libs/tailwindcss-config/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/tailwindcss-config",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }

--- a/libs/tailwindcss-config/project.json
+++ b/libs/tailwindcss-config/project.json
@@ -12,8 +12,7 @@
         "outputPath": "dist/libs/tailwindcss-config",
         "main": "libs/tailwindcss-config/src/index.js",
         "tsConfig": "libs/tailwindcss-config/tsconfig.lib.json",
-        "assets": ["libs/tailwindcss-config/*.md"],
-        "buildableProjectDepsInPackageJsonType": "dependencies"
+        "assets": ["libs/tailwindcss-config/*.md"]
       }
     },
     "lint": {

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/types",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/libs/types/project.json
+++ b/libs/types/project.json
@@ -13,7 +13,6 @@
         "tsConfig": "libs/types/tsconfig.lib.json",
         "project": "libs/types/package.json",
         "entryFile": "libs/types/src/index.ts",
-        "external": ["react/jsx-runtime"],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "compiler": "babel",
         "format": ["esm", "cjs"],
@@ -23,8 +22,7 @@
             "input": ".",
             "output": "."
           }
-        ],
-        "buildableProjectDepsInPackageJsonType": "dependencies"
+        ]
       }
     },
     "lint": {

--- a/libs/ui-toolkit/package.json
+++ b/libs/ui-toolkit/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@vegaprotocol/ui-toolkit",
-  "version": "0.12.8",
-  "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  }
+  "version": "0.12.8"
 }

--- a/libs/ui-toolkit/package.json
+++ b/libs/ui-toolkit/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/ui-toolkit",
-  "version": "0.12.8"
+  "version": "0.12.9"
 }

--- a/libs/ui-toolkit/project.json
+++ b/libs/ui-toolkit/project.json
@@ -9,12 +9,19 @@
       "executor": "@nx/rollup:rollup",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "buildableProjectDepsInPackageJsonType": "dependencies",
         "outputPath": "dist/libs/ui-toolkit",
         "tsConfig": "libs/ui-toolkit/tsconfig.lib.json",
         "project": "libs/ui-toolkit/package.json",
         "entryFile": "libs/ui-toolkit/src/index.ts",
-        "external": ["react/jsx-runtime"],
+        "external": [
+          "react",
+          "react-dom",
+          "react/jsx-runtime",
+          "@vegaprotocol/i18n",
+          "@vegaprotocol/react-helpers",
+          "@vegaprotocol/tailwindcss-config",
+          "@vegaprotocol/utils"
+        ],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "compiler": "babel",
         "format": ["esm", "cjs"],

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@vegaprotocol/utils",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs"
 }

--- a/libs/utils/project.json
+++ b/libs/utils/project.json
@@ -12,7 +12,8 @@
         "outputPath": "dist/libs/utils",
         "main": "libs/utils/src/index.ts",
         "tsConfig": "libs/utils/tsconfig.lib.json",
-        "assets": ["libs/utils/*.md"]
+        "assets": ["libs/utils/*.md"],
+        "external": ["@vegaprotocol/i18n", "@vegaprotocol/types"]
       }
     },
     "publish": {

--- a/libs/wallet/package.json
+++ b/libs/wallet/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@vegaprotocol/wallet",
-  "version": "0.0.1",
-  "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  }
+  "version": "0.0.1"
 }

--- a/libs/wallet/package.json
+++ b/libs/wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@vegaprotocol/wallet",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/libs/wallet/project.json
+++ b/libs/wallet/project.json
@@ -13,7 +13,17 @@
         "tsConfig": "libs/wallet/tsconfig.lib.json",
         "project": "libs/wallet/package.json",
         "entryFile": "libs/wallet/src/index.ts",
-        "external": ["react", "react-dom", "react/jsx-runtime"],
+        "external": [
+          "react",
+          "react-dom",
+          "react/jsx-runtime",
+          "@vegaprotocol/i18n",
+          "@vegaprotocol/react-helpers",
+          "@vegaprotocol/types",
+          "@vegaprotocol/ui-toolkit",
+          "@vegaprotocol/utils",
+          "@vegaprotocol/wallet-client"
+        ],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "compiler": "babel",
         "format": ["esm", "cjs"],


### PR DESCRIPTION
# Related issues 🔗

Issue: #4603 

# Description ℹ️

- Sets rollup configs to not bundle peer deps
- Removes peerDependencies from package.json for libs as its not required
- Bump versions for affected packages
