### PR TITLE
feat(governance): improve the display of Governance app on mobile

### DIFF
--- a/apps/governance/src/app.tsx
+++ b/apps/governance/src/app.tsx
@@ -184,7 +184,7 @@ const Web3Container = ({
                     <TemplateSidebar sidebar={sideBar}>
                       <AppRouter />
                     </TemplateSidebar>
-                    <footer className="p-4 border-t border-neutral-700">
+                    <footer className="p-4 border-t border-neutral-700 break-all">
                       <NetworkInfo />
                     </footer>
                   </AppLayout>
@@ -308,7 +308,7 @@ const AppContainer = () => {
     <Router>
       <ScrollToTop />
       <AppStateProvider>
-        <div className="min-h-full text-white grid">
+        <div className="min-h-full text-white">
           <NodeGuard
             skeleton={<div>{t('Loading')}</div>}
             failure={

--- a/apps/governance/src/routes/home/index.tsx
+++ b/apps/governance/src/routes/home/index.tsx
@@ -279,8 +279,8 @@ const GovernanceHome = ({ name }: RouteChildProps) => {
         trimmedActiveNodes={trimmedActiveNodes}
       />
 
-      <section className="grid grid-cols-2 gap-12 mb-16">
-        <div data-testid="home-rewards">
+      <section className="flex justify-between flex-wrap gap-12 mb-16">
+        <div className="min-w-[360px] flex-1" data-testid="home-rewards">
           <Heading title={t('Rewards')} marginTop={false} />
           <h3 className="mb-6">{t('homeRewardsIntro')}</h3>
           <div className="flex items-center mb-8 gap-4">
@@ -290,7 +290,7 @@ const GovernanceHome = ({ name }: RouteChildProps) => {
           </div>
         </div>
 
-        <div data-testid="home-vega-token">
+        <div className="min-w-[360px] flex-1" data-testid="home-vega-token">
           <Heading title={t('vegaToken')} marginTop={false} />
           <h3 className="mb-6">{t('homeVegaTokenIntro')}</h3>
           <div className="flex items-center mb-8 gap-4">

--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
@@ -159,7 +159,7 @@ export const ProposalHeader = ({
         </div>
       </div>
 
-      <div data-testid="proposal-title">
+      <div data-testid="proposal-title" className="break-all">
         {isListItem ? (
           <header>
             <SubHeading

--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
@@ -224,10 +224,10 @@ export const ProposalsList = ({
                 sortedProtocolUpgradeProposals.closed.length > 0 &&
                 filterString.length < 1 && (
                   <div
-                    className="grid w-full justify-end xl:-mt-12 pb-6"
+                    className="flex justify-end xl:-mt-12 pb-6"
                     data-testid="toggle-closed-proposals"
                   >
-                    <div className="w-[440px]">
+                    <div className="w-full max-w-[420px]">
                       <Toggle
                         name="closed-proposals-toggle"
                         toggles={[

--- a/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.tsx
@@ -130,7 +130,10 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
     ? t('byTokenVote')
     : t('byLiquidityVote');
 
-  const sectionWrapperClasses = classNames('grid sm:grid-cols-2 gap-6');
+  const sectionWrapperClasses = classNames(
+    'flex justify-between flex-wrap gap-6'
+  );
+  const sectionClasses = classNames('min-w-[300px] flex-1 flex-grow');
   const headingClasses = classNames('mb-2 text-vega-dark-400');
   const progressDetailsClasses = classNames(
     'flex justify-between flex-wrap mt-2 text-sm'
@@ -166,7 +169,10 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
         <div className="mb-4">
           <h3 className={headingClasses}>{t('liquidityProviderVote')}</h3>
           <div className={sectionWrapperClasses}>
-            <section data-testid="lp-majority-breakdown">
+            <section
+              className={sectionClasses}
+              data-testid="lp-majority-breakdown"
+            >
               <VoteProgress
                 percentageFor={yesLPPercentage}
                 colourfulBg={true}
@@ -241,7 +247,10 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
               </div>
             </section>
 
-            <section data-testid="lp-participation-breakdown">
+            <section
+              className={sectionClasses}
+              data-testid="lp-participation-breakdown"
+            >
               <VoteProgress
                 percentageFor={
                   lpParticipationThresholdProgress || new BigNumber(0)
@@ -288,7 +297,10 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
 
       {isUpdateMarket && <h3 className={headingClasses}>{t('tokenVote')}</h3>}
       <div className={sectionWrapperClasses}>
-        <section data-testid="token-majority-breakdown">
+        <section
+          className={sectionClasses}
+          data-testid="token-majority-breakdown"
+        >
           <VoteProgress
             percentageFor={yesPercentage}
             colourfulBg={true}
@@ -343,7 +355,10 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
           </div>
         </section>
 
-        <section data-testid="token-participation-breakdown">
+        <section
+          className={sectionClasses}
+          data-testid="token-participation-breakdown"
+        >
           <VoteProgress
             percentageFor={participationThresholdProgress}
             testId="token-participation-progress"

--- a/apps/governance/src/routes/rewards/home/rewards-page.tsx
+++ b/apps/governance/src/routes/rewards/home/rewards-page.tsx
@@ -133,24 +133,26 @@ export const RewardsPage = () => {
               </p>
             </div>
 
-            <div className="w-[360px]">
-              <Toggle
-                name="epoch-reward-view-toggle"
-                toggles={[
-                  {
-                    label: t('totalDistributed'),
-                    value: 'total',
-                  },
-                  {
-                    label: t('earnedByMe'),
-                    value: 'individual',
-                  },
-                ]}
-                checkedValue={toggleRewardsView}
-                onChange={(e) =>
-                  setToggleRewardsView(e.target.value as RewardsView)
-                }
-              />
+            <div className="flex justify-end">
+              <div className="w-full max-w-[360px]">
+                <Toggle
+                  name="epoch-reward-view-toggle"
+                  toggles={[
+                    {
+                      label: t('totalDistributed'),
+                      value: 'total',
+                    },
+                    {
+                      label: t('earnedByMe'),
+                      value: 'individual',
+                    },
+                  ]}
+                  checkedValue={toggleRewardsView}
+                  onChange={(e) =>
+                    setToggleRewardsView(e.target.value as RewardsView)
+                  }
+                />
+              </div>
             </div>
           </section>
 

--- a/apps/governance/src/routes/token/index.tsx
+++ b/apps/governance/src/routes/token/index.tsx
@@ -100,8 +100,8 @@ const Home = ({ name }: RouteChildProps) => {
           </Link>
         </p>
       </HomeSection>
-      <div className="flex gap-12">
-        <div className="flex-1">
+      <div className="flex justify-between flex-wrap gap-x-12 gap-y-4">
+        <div className="flex-1 min-w-[360px]">
           <HomeSection>
             <SubHeading title={t('Staking')} />
             <p>
@@ -118,7 +118,7 @@ const Home = ({ name }: RouteChildProps) => {
             </p>
           </HomeSection>
         </div>
-        <div className="flex-1">
+        <div className="flex-1 min-w-[360px]">
           <HomeSection>
             <SubHeading title={t('Governance')} />
             <p>

--- a/apps/governance/src/styles.css
+++ b/apps/governance/src/styles.css
@@ -6,6 +6,12 @@
 @tailwind utilities;
 
 @layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
   h1 {
     @apply text-2xl text-white uppercase mb-4;
   }


### PR DESCRIPTION
# Related issues 🔗

Issue: #4530

# Description ℹ️

Styling tweaks to make Governance more mobile friendly

Examples:

prev:
<img width="501" alt="Screenshot 2023-09-08 at 10 28 39" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/4f810d41-75a6-4ab0-8eb6-414f2120be7b">

now:
<img width="473" alt="Screenshot 2023-09-08 at 10 28 46" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/e0e88119-0896-48a1-8f7e-4cd6461c4e70">

prev:
<img width="525" alt="Screenshot 2023-09-08 at 10 29 08" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/687625bd-aba1-4686-91b0-f70502811b66">

now:
<img width="488" alt="Screenshot 2023-09-08 at 10 29 13" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/a6d6a107-3236-44d4-878b-bf621b1ee2f4">

prev:
<img width="683" alt="Screenshot 2023-09-08 at 10 26 48" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/60642b5c-b605-4315-8524-7cad1ea601a3">

now:
<img width="692" alt="Screenshot 2023-09-08 at 10 26 55" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/f5a69ac7-f3f9-4e43-9d81-80b71ddcfe4c">

prev:
<img width="463" alt="Screenshot 2023-09-08 at 10 28 12" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/9801b36f-2a05-4de1-b168-15667da72e6b">

now:
<img width="472" alt="Screenshot 2023-09-08 at 10 28 20" src="https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/bc2d9ddb-964f-40d9-8b10-8c07f8dd35b5">


