### PR TITLE
fix(governance): corrected sorting of upgrade proposals by blockheight

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
+++ b/apps/governance/src/routes/proposals/components/proposals-list/proposals-list.tsx
@@ -55,7 +55,10 @@ export const orderByUpgradeBlockHeight = (
 ) =>
   orderBy(
     arr,
-    [(p) => p?.upgradeBlockHeight, (p) => p.vegaReleaseTag],
+    [
+      (p) => (p?.upgradeBlockHeight ? parseInt(p.upgradeBlockHeight, 10) : 0),
+      (p) => p.vegaReleaseTag,
+    ],
     ['desc', 'desc']
   );
 


### PR DESCRIPTION
# Related issues 🔗

Issue: #4716

# Description ℹ️

Upgrade proposals were being sorted by upgrade block height, but alphanumerically. Now sorted numerically.
