### PR TITLE
chore(candles-chart): show more candles by default

### DIFF
--- a/libs/candles-chart/src/lib/candles-chart.tsx
+++ b/libs/candles-chart/src/lib/candles-chart.tsx
@@ -12,6 +12,8 @@ export type CandlesChartContainerProps = {
   marketId: string;
 };
 
+const INITIAL_CANDLES_TO_ZOOM = 150;
+
 export const CandlesChartContainer = ({
   marketId,
 }: CandlesChartContainerProps) => {
@@ -36,6 +38,7 @@ export const CandlesChartContainer = ({
         notEnoughDataText: (
           <span className="text-xs text-center">{t('No data')}</span>
         ),
+        initialNumCandlesToDisplay: INITIAL_CANDLES_TO_ZOOM,
       }}
       interval={interval}
       theme={theme}


### PR DESCRIPTION
# Related issues 🔗

Issue: #4727 

# Description ℹ️

Change parameter of displaying candles to get zoom effect on chart

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/338931/7072ab27-b388-47c2-8b1a-8db4f1916da6)

with reduced gaps:
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/338931/aae927d7-020d-4f11-8bc6-57b6ce6b61f9)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
