### PR TITLE
fix(markets): market info for liquidity is showing "added" tags

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -658,7 +658,7 @@ export const LiquidityMonitoringParametersInfoPanel = ({
           parentMarket.liquidityMonitoringParameters.targetStakeParameters
             .scalingFactor,
       }
-    : {};
+    : undefined;
 
   return <MarketInfoTable data={marketData} parentData={parentMarketData} />;
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #4731

# Description ℹ️

We were incorrectly falling back to producing an empty object rather than an undefined in a piece of logic in the liquidity monitoring market info panel, resulting in the object being used in as parentData, being compared to the market data. This should only be used during the rendering of successor markets where this comparison is necessary. As the market data differs from an empty object, the liquidity panels were showing their values as having been 'added' since the 'parent' market. 
