### PR TITLE
fix(trading): add overflow hidden to candles tab container

### DIFF
--- a/apps/trading/client-pages/market/trade-grid.tsx
+++ b/apps/trading/client-pages/market/trade-grid.tsx
@@ -56,6 +56,7 @@ const MainGrid = memo(
                 <Tabs storageKey="console-trade-grid-main-left">
                   <Tab
                     id="chart"
+                    overflowHidden
                     name={t('Chart')}
                     menu={<TradingViews.candles.menu />}
                   >

--- a/libs/ui-toolkit/src/components/tabs/tabs.tsx
+++ b/libs/ui-toolkit/src/components/tabs/tabs.tsx
@@ -113,7 +113,9 @@ export const Tabs = ({
           return (
             <TabsPrimitive.Content
               value={child.props.id}
-              className="h-full"
+              className={classNames('h-full', {
+                'overflow-hidden': child.props.overflowHidden,
+              })}
               data-testid={`tab-${child.props.id}`}
             >
               {child.props.children}
@@ -131,6 +133,7 @@ interface TabProps {
   name: string;
   indicator?: ReactNode;
   hidden?: boolean;
+  overflowHidden?: boolean;
   menu?: ReactNode;
 }
 


### PR DESCRIPTION
# Related issues 🔗

Closes #4795 

# Description ℹ️

add overflow hidden to candles tab container

