### PR TITLE
fix(explorer): disable oracles in mainnet while api is broken

### DIFF
--- a/apps/explorer/.env.mainnet
+++ b/apps/explorer/.env.mainnet
@@ -13,3 +13,4 @@ NX_ORACLE_PROOFS_URL=https://raw.githubusercontent.com/vegaprotocol/well-known/m
 
 NX_TENDERMINT_URL=https://be.vega.community
 NX_TENDERMINT_WEBSOCKET_URL=wss://be.vega.community/websocket
+NX_EXPLORER_ORACLES=0

--- a/apps/explorer/src/app/routes/router-config.tsx
+++ b/apps/explorer/src/app/routes/router-config.tsx
@@ -241,6 +241,37 @@ const validators: Route[] = FLAGS.EXPLORER_VALIDATORS
     ]
   : [];
 
+const oraclesRoutes: Route[] = FLAGS.EXPLORER_ORACLES
+  ? [
+      {
+        path: Routes.ORACLES,
+        handle: {
+          name: t('Oracles'),
+          text: t('Oracles'),
+          breadcrumb: () => <Link to={Routes.ORACLES}>{t('Oracles')}</Link>,
+        },
+        element: <OraclePage />,
+        children: [
+          {
+            index: true,
+            element: <Oracles />,
+          },
+          {
+            path: ':id',
+            element: <Oracle />,
+            handle: {
+              breadcrumb: (params: Params<string>) => (
+                <Link to={linkTo(Routes.ORACLES, params.id)}>
+                  {truncateMiddle(params.id as string)}
+                </Link>
+              ),
+            },
+          },
+        ],
+      },
+    ]
+  : [];
+
 const linkTo = (...segments: (string | undefined)[]) =>
   compact(segments).join('/');
 
@@ -310,32 +341,7 @@ export const routerConfig: Route[] = [
           },
         ],
       },
-      {
-        path: Routes.ORACLES,
-        handle: {
-          name: t('Oracles'),
-          text: t('Oracles'),
-          breadcrumb: () => <Link to={Routes.ORACLES}>{t('Oracles')}</Link>,
-        },
-        element: <OraclePage />,
-        children: [
-          {
-            index: true,
-            element: <Oracles />,
-          },
-          {
-            path: ':id',
-            element: <Oracle />,
-            handle: {
-              breadcrumb: (params: Params<string>) => (
-                <Link to={linkTo(Routes.ORACLES, params.id)}>
-                  {truncateMiddle(params.id as string)}
-                </Link>
-              ),
-            },
-          },
-        ],
-      },
+      ...oraclesRoutes,
       {
         path: Routes.DISCLAIMER,
         element: <Disclaimer />,


### PR DESCRIPTION
Disables the Oracles section due to a broken API in 0.72.14

- Fix disabling Oracles section with feature flag
- Update flags to disable oracle section in mainnet env

Closes #4705


# Before
<img width="827" alt="Screenshot 2023-09-20 at 11 09 51" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/c0b13dbe-bc5e-4bf8-9d6c-4c06a35b728d">

# After
<img width="723" alt="Screenshot 2023-09-20 at 11 09 31" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/974beb28-08e3-4e61-8ec9-f7e46622af4a">
