### PR TITLE
fix(accounts): hide no rows label when there is only pinned row

### DIFF
--- a/libs/accounts/src/lib/accounts-table.tsx
+++ b/libs/accounts/src/lib/accounts-table.tsx
@@ -312,7 +312,6 @@ export const AccountTable = ({
   ]);
 
   const data = rowData?.filter((data) => data.asset.id !== pinnedAsset?.id);
-
   return (
     <AgGrid
       {...props}
@@ -321,6 +320,9 @@ export const AccountTable = ({
       rowData={data}
       defaultColDef={defaultColDef}
       columnDefs={colDefs}
+      overlayNoRowsTemplate={
+        rowData?.length ? '<span />' : props.overlayNoRowsTemplate
+      }
       getRowHeight={getPinnedAssetRowHeight}
       pinnedTopRowData={pinnedRow ? [pinnedRow] : undefined}
     />

--- a/libs/accounts/src/lib/accounts-table.tsx
+++ b/libs/accounts/src/lib/accounts-table.tsx
@@ -321,6 +321,10 @@ export const AccountTable = ({
       defaultColDef={defaultColDef}
       columnDefs={colDefs}
       overlayNoRowsTemplate={
+        // account for the pinned asset is filtered out to prevent duplicate
+        // data in the pinned row and the main table rows. AgGrid will not
+        // consider the pinned row when determining whether to show the no
+        // rows template or not so we need to override it
         rowData?.length ? '<span />' : props.overlayNoRowsTemplate
       }
       getRowHeight={getPinnedAssetRowHeight}


### PR DESCRIPTION
# Related issues 🔗

Closes #4794 

# Description ℹ️

Displays empty no rows label if pinned asset is only asset to display.

