### PR TITLE
chore(wallet): dont show error state if user rejects connection

### DIFF
--- a/libs/wallet/src/connect-dialog/injected-connector-form.tsx
+++ b/libs/wallet/src/connect-dialog/injected-connector-form.tsx
@@ -131,7 +131,12 @@ const Error = ({
   );
 
   if (error) {
-    if (error.message === InjectedConnectorErrors.INVALID_CHAIN.message) {
+    if (error.message === InjectedConnectorErrors.USER_REJECTED.message) {
+      title = t('User rejected');
+      text = t('The user rejected the wallet connection');
+    } else if (
+      error.message === InjectedConnectorErrors.INVALID_CHAIN.message
+    ) {
       title = t('Wrong network');
       text = t(
         'To complete your wallet connection, set your wallet network in your app to "%s".',

--- a/libs/wallet/src/connectors/injected-connector.ts
+++ b/libs/wallet/src/connectors/injected-connector.ts
@@ -42,6 +42,7 @@ declare global {
 }
 
 export const InjectedConnectorErrors = {
+  USER_REJECTED: new Error('Connection denied'),
   VEGA_UNDEFINED: new Error('window.vega not found'),
   INVALID_CHAIN: new Error('Invalid chain'),
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #4441 

# Description ℹ️

Makes the user rejected state not appear as an error and also match what is shown when a user rejects a json rpc connection

# Demo 📺

![Screenshot 2023-09-20 at 14 54 01](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/8d1146dc-bab7-4fdb-b2e6-c087a2b3405c)