### PR TITLE
chore(trading): disable console-test run until CI fixed

### DIFF
--- a/.github/workflows/ci-cd-trigger.yml
+++ b/.github/workflows/ci-cd-trigger.yml
@@ -177,14 +177,14 @@ jobs:
       preview_explorer: ${{ env.PREVIEW_EXPLORER }}
       preview_tools: ${{ env.PREVIEW_TOOLS }}
 
-  console-e2e:
-    needs: build-sources
-    name: '(CI) console python'
-    uses: ./.github/workflows/console-test-run.yml
-    secrets: inherit
-    if: ${{ contains(fromJSON(needs.build-sources.outputs.projects), 'trading') && github.event_name == 'pull_request' }}
-    with:
-      github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+  # console-e2e:
+  #   needs: build-sources
+  #   name: '(CI) console python'
+  #   uses: ./.github/workflows/console-test-run.yml
+  #   secrets: inherit
+  #   if: ${{ contains(fromJSON(needs.build-sources.outputs.projects), 'trading') && github.event_name == 'pull_request' }}
+  #   with:
+  #     github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
   cypress:
     needs: build-sources


### PR DESCRIPTION
Temporarily disable console-test run, to unblock runners for other uses.