### PR TITLE
fix(trading): ignore conditions list empty

### DIFF
--- a/libs/data-provider/src/helpers.ts
+++ b/libs/data-provider/src/helpers.ts
@@ -29,4 +29,8 @@ const hasNotFoundGraphQLErrors = (errors: GraphQLErrors, path?: string[]) => {
 };
 
 export const marketDataErrorPolicyGuard = (errors: GraphQLErrors) =>
-  errors.every((e) => e.message.match(/no market data for market:/i));
+  errors.every(
+    (e) =>
+      e.message.match(/no market data for market:/i) ||
+      e.message.match(/Conditions list is empty/)
+  );

--- a/libs/markets/src/lib/components/market-info/market-info-data-provider.ts
+++ b/libs/markets/src/lib/components/market-info/market-info-data-provider.ts
@@ -1,6 +1,7 @@
 import {
   makeDataProvider,
   makeDerivedDataProvider,
+  marketDataErrorPolicyGuard,
 } from '@vegaprotocol/data-provider';
 import type {
   MarketInfoQuery,
@@ -30,6 +31,7 @@ export const marketInfoProvider = makeDataProvider<
 >({
   query: MarketInfoDocument,
   getData,
+  errorPolicyGuard: marketDataErrorPolicyGuard,
 });
 
 export const marketInfoWithDataProvider = makeDerivedDataProvider<

--- a/libs/markets/src/lib/markets-provider.ts
+++ b/libs/markets/src/lib/markets-provider.ts
@@ -2,6 +2,7 @@ import { useYesterday } from '@vegaprotocol/react-helpers';
 import {
   makeDataProvider,
   makeDerivedDataProvider,
+  marketDataErrorPolicyGuard,
   useDataProvider,
 } from '@vegaprotocol/data-provider';
 import type {
@@ -43,6 +44,7 @@ export const marketsProvider = makeDataProvider<
   query: MarketsDocument,
   getData,
   fetchPolicy: 'cache-first',
+  errorPolicyGuard: marketDataErrorPolicyGuard,
 });
 
 export const marketsMapProvider = makeDerivedDataProvider<


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

`marketConnection` queries comes with all data and an error (that can be safely ignored) when a market is proposed via protos (the UI doesn't let you) without conditions. 
This error not ignored was destroying the UI.

# Demo 📺

Before the fix:
<img width="1680" alt="Screenshot 2023-09-21 at 13 40 09" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/4a05a57b-b2f3-470a-b5bc-18d20a4b42c9">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
