### PR TITLE
fix(governance): removed loop caused by rewards epoch refresh

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState, useCallback } from 'react';
+import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AsyncRenderer, Pagination } from '@vegaprotocol/ui-toolkit';
 import { removePaginationWrapper } from '@vegaprotocol/utils';
@@ -86,12 +86,18 @@ export const EpochIndividualRewards = ({
     [epochId, page, refetch, delegationsPagination, pubKey]
   );
 
+  const prevEpochIdRef = useRef<number | null>(null);
+
   useEffect(() => {
-    // when the epoch changes, we want to refetch the data to update the current page
-    if (data) {
+    if (prevEpochIdRef.current === null) {
+      prevEpochIdRef.current = epochId;
+    } else if (epochId !== prevEpochIdRef.current) {
+      // When the epoch changes, we want to refetch the data to update the current page
       refetchData();
     }
-  }, [epochId, data, refetchData]);
+
+    prevEpochIdRef.current = epochId;
+  }, [epochId, refetchData]);
 
   return (
     <AsyncRenderer


### PR DESCRIPTION
# Related issues 🔗

Closes #4862

# Description ℹ️

On the individual rewards page, a query meant to update data when an epoch changes would be triggered by the data being updated, creating a loop. To solve this, I've refined the conditions for when the refetch is called by keeping track of the epochId and only running the refetch when the epochId actually changes.
