### PR TITLE
chore(trading): make volume bars color match candle color

### DIFF
--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -110,8 +110,8 @@ html [data-theme='light'] {
   --pennant-color-depth-sell-fill: theme(colors.market.red.DEFAULT);
   --pennant-color-depth-sell-stroke: theme(colors.market.red.650);
 
-  --pennant-color-volume-buy: theme(colors.market.green.300);
-  --pennant-color-volume-sell: theme(colors.market.red.300);
+  --pennant-color-volume-buy: theme(colors.market.green.DEFAULT);
+  --pennant-color-volume-sell: theme(colors.market.red.DEFAULT);
 }
 
 html [data-theme='dark'] {
@@ -132,7 +132,7 @@ html [data-theme='dark'] {
   --pennant-color-depth-sell-stroke: theme(colors.market.red.DEFAULT);
 
   --pennant-color-volume-buy: theme(colors.market.green.600);
-  --pennant-color-volume-sell: theme(colors.market.red.650);
+  --pennant-color-volume-sell: theme(colors.market.red.DEFAULT);
 }
 
 /**


### PR DESCRIPTION
# Related issues 🔗

Closes #4823 

# Description ℹ️

Makes the volume bar colors match the candle fill colors

# Demo 📺

<img width="300" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/43a054eb-0e7b-475e-8fca-cfa896df5f5c" />

<img width="300" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/4f185620-3103-4d6e-b873-43272b34dfbd" />