### PR TITLE
chore(trading): remove underlines on tooltips

### DIFF
--- a/apps/trading/components/header/header.tsx
+++ b/apps/trading/components/header/header.tsx
@@ -53,7 +53,7 @@ export const HeaderStat = ({
       <div data-testid="item-header" id={id}>
         {heading}
       </div>
-      <Tooltip description={description}>
+      <Tooltip description={description} underline>
         <div
           data-testid="item-value"
           aria-labelledby={id}

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -284,7 +284,6 @@ export const DealTicketMarginDetails = ({
                       assetDecimals
                     ) ?? '-'
                   }
-                  noUnderline
                 >
                   <div className="font-mono text-right">
                     {formatRange(

--- a/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
@@ -47,7 +47,7 @@ export const KeyValue = ({
       <Tooltip description={labelDescription}>
         <div className="text-muted">{label}</div>
       </Tooltip>
-      <Tooltip description={`${value ?? '-'} ${symbol || ''}`} noUnderline>
+      <Tooltip description={`${value ?? '-'} ${symbol || ''}`}>
         {valueElement}
       </Tooltip>
     </div>

--- a/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
+++ b/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
@@ -23,14 +23,10 @@ export interface TooltipProps {
 }
 
 export const TOOLTIP_TRIGGER_CLASS_NAME = (underline?: boolean) =>
-  classNames(
-    'cursor-help',
-    { 'underline underline-offset-2': underline },
-    {
-      'decoration-neutral-400 dark:decoration-neutral-400 decoration-dashed':
-        underline,
-    }
-  );
+  classNames({
+    'underline underline-offset-2 decoration-neutral-400 dark:decoration-neutral-400 decoration-dashed':
+      underline,
+  });
 
 // Conditionally rendered tooltip if description content is provided.
 export const Tooltip = ({

--- a/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
+++ b/libs/ui-toolkit/src/components/tooltip/tooltip.tsx
@@ -19,13 +19,17 @@ export interface TooltipProps {
   align?: 'start' | 'center' | 'end';
   side?: 'top' | 'right' | 'bottom' | 'left';
   sideOffset?: number;
-  noUnderline?: boolean;
+  underline?: boolean;
 }
 
-export const TOOLTIP_TRIGGER_CLASS_NAME = (noUnderline?: boolean) =>
+export const TOOLTIP_TRIGGER_CLASS_NAME = (underline?: boolean) =>
   classNames(
-    { 'underline underline-offset-2': !noUnderline },
-    'decoration-neutral-400 dark:decoration-neutral-400 decoration-dashed'
+    'cursor-help',
+    { 'underline underline-offset-2': underline },
+    {
+      'decoration-neutral-400 dark:decoration-neutral-400 decoration-dashed':
+        underline,
+    }
   );
 
 // Conditionally rendered tooltip if description content is provided.
@@ -36,12 +40,12 @@ export const Tooltip = ({
   sideOffset,
   align = 'start',
   side = 'bottom',
-  noUnderline,
+  underline,
 }: TooltipProps) =>
   description ? (
     <Provider delayDuration={200} skipDelayDuration={100}>
       <Root open={open}>
-        <Trigger asChild className={TOOLTIP_TRIGGER_CLASS_NAME(noUnderline)}>
+        <Trigger asChild className={TOOLTIP_TRIGGER_CLASS_NAME(underline)}>
           {children}
         </Trigger>
         {description && (


### PR DESCRIPTION
# Related issues 🔗

Closes #4733

# Description ℹ️

Remove underline from tooltip trigger by default. Make it parameterized. Merge to `main` branch

# Demo 📺

![Screenshot 2023-09-25 at 14 09 30](https://github.com/vegaprotocol/frontend-monorepo/assets/338931/a4ad9bef-ca89-4532-8a12-fbc9b4967050)

# Technical 👨‍🔧

- 
