### PR TITLE
fix(wallet): dont show error state if user rejects connection

### DIFF
--- a/libs/wallet/src/connect-dialog/injected-connector-form.tsx
+++ b/libs/wallet/src/connect-dialog/injected-connector-form.tsx
@@ -131,7 +131,12 @@ const Error = ({
   );
 
   if (error) {
-    if (error.message === InjectedConnectorErrors.INVALID_CHAIN.message) {
+    if (error.message === InjectedConnectorErrors.USER_REJECTED.message) {
+      title = t('User rejected');
+      text = t('The user rejected the wallet connection');
+    } else if (
+      error.message === InjectedConnectorErrors.INVALID_CHAIN.message
+    ) {
       title = t('Wrong network');
       text = t(
         'To complete your wallet connection, set your wallet network in your app to "%s".',

--- a/libs/wallet/src/connectors/injected-connector.ts
+++ b/libs/wallet/src/connectors/injected-connector.ts
@@ -42,6 +42,7 @@ declare global {
 }
 
 export const InjectedConnectorErrors = {
+  USER_REJECTED: new Error('Connection denied'),
   VEGA_UNDEFINED: new Error('window.vega not found'),
   INVALID_CHAIN: new Error('Invalid chain'),
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #4441 

# Description ℹ️

Handles user rejection error so resulting UI doesn't show the error state

# Demo 📺

![Screenshot 2023-09-26 at 12 13 24](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/cf6cf97b-743f-46ff-97e8-f90ea8205d93)
