### PR TITLE
chore: change runner for mainnet compatible vega version

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         project: ${{ fromJSON(inputs.projects) }}
     name: ${{ matrix.project }}
-    runs-on: self-hosted-runner
+    runs-on: mainnet-compatible-runner
     timeout-minutes: 120
     steps:
       # Checks if skip cache was requested


### PR DESCRIPTION
THat change would allow us to use "old" version of vega nad vegacapsule for PRs targeted to `main`. Need to remember to be cautious about it when merging with develop, or add some logic that decide which runner version should be used.