### PR TITLE
chore(ci): add logic for choosing correct runner for cypress tests depending on base branch

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -13,13 +13,28 @@ on:
         type: string
 
 jobs:
+  runner-choice:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.step.outputs.runner }}
+    steps:
+      - name: Check branch
+        id: step
+        run: |
+          if [ ${{ github.base_ref }} == 'main' ]; then
+            echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
+          else
+            echo "runner=self-hosted-runner" >> $GITHUB_OUTPUT
+          fi
+
   e2e:
     strategy:
       fail-fast: false
       matrix:
         project: ${{ fromJSON(inputs.projects) }}
     name: ${{ matrix.project }}
-    runs-on: mainnet-compatible-runner
+    needs: runner-choice
+    runs-on: ${{ needs.runner-choice.outputs.runner }}
     timeout-minutes: 120
     steps:
       # Checks if skip cache was requested


### PR DESCRIPTION
# Description ℹ️

Add logic for choosing correct runner for cypress tests depending on base branch.
main -> mainnet-compatible-runner
develop (or others) -> self-hosted-runner