### PR TITLE
chore(governance): remove explorer market diff test

### DIFF
--- a/apps/explorer-e2e/src/integration/market.cy.js
+++ b/apps/explorer-e2e/src/integration/market.cy.js
@@ -136,12 +136,8 @@ context('Market page', { tags: '@regression' }, function () {
         .as('successorMarketId');
       cy.contains('Token test market').click();
       cy.getByTestId(marketHeaders).should('have.text', 'Token test market');
-      // Assertions commented out due to #4869
-      // cy.validate_proposal_change_type('Triggering Ratio', 'Added');
       cy.validate_element_from_table('Triggering Ratio', '0.7');
-      // cy.validate_proposal_change_type('Time Window', 'Added');
       cy.validate_element_from_table('Time Window', '3,600');
-      // cy.validate_proposal_change_type('Scaling Factor', 'Added');
       cy.validate_element_from_table('Scaling Factor', '10');
 
       cy.getByTestId(successionLineItem)

--- a/apps/governance-e2e/.env
+++ b/apps/governance-e2e/.env
@@ -21,6 +21,7 @@ NX_GITHUB_FEEDBACK_URL=https://github.com/vegaprotocol/feedback/discussions
 NX_WALLETCONNECT_PROJECT_ID=fe8091dc35738863e509fc4947525c72
 NX_VEGA_REST_URL=http://localhost:3008/api/v2/
 NX_SUCCESSOR_MARKETS=true
+NX_PRODUCT_PERPETUALS=true
 
 NX_VEGA_EXPLORER_URL=https://explorer.fairground.wtf
 NX_CHROME_EXTENSION_URL=https://chrome.google.com/webstore/detail/vega-wallet-fairground/nmmjkiafpmphlikhefgjbblebfgclikn

--- a/apps/governance-e2e/src/integration/flow/proposal-details.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/proposal-details.cy.ts
@@ -374,15 +374,12 @@ describe(
       });
 
       // 3003-PMAN-011
-      cy.get('.underline').contains('Parent Market ID').realHover();
+      cy.contains('Parent Market ID').realHover();
       cy.getByTestId('tooltip-content', { timeout: 8000 }).should(
         'contain.text',
         'The ID of the market this market succeeds.'
       );
-      cy.get('.underline')
-        .contains('Insurance Pool Fraction')
-        .realMouseUp()
-        .realHover();
+      cy.contains('Insurance Pool Fraction').realMouseUp().realHover();
       cy.getByTestId('tooltip-content', { timeout: 8000 }).should(
         'contain.text',
         'The fraction of the insurance pool balance that is carried over from the parent market to the successor.'

--- a/apps/governance-e2e/src/integration/flow/proposal-enacted.cy.ts
+++ b/apps/governance-e2e/src/integration/flow/proposal-enacted.cy.ts
@@ -65,7 +65,10 @@ context(
             cy.getByTestId(viewProposalButton).click();
           });
       });
-      cy.getByTestId('proposal-type').should('have.text', 'New market');
+      cy.getByTestId('proposal-type').should(
+        'have.text',
+        'New market - future'
+      );
       cy.getByTestId(proposalStatus).should('have.text', 'Enacted');
       cy.getByTestId(votesTable).within(() => {
         cy.contains('Voting has ended.').should('be.visible');


### PR DESCRIPTION
# Related issues 🔗

Closes #4869 

- Remove commented out assertions that are not needed anymore
- Fix failing tests from perpetual market changes