### PR TITLE
chore(ci): trigger lint-pr on repoened and sync

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,6 +6,8 @@ on:
     types:
       - opened
       - edited
+      - reopened
+      - synchronize
 
 jobs:
   lint_pr:


### PR DESCRIPTION
# Description ℹ️

Sometimes lint-pr is not triggered properly, added sync and reopened to fix that.