### PR TITLE
chore(ci): add mainnet compatible runner to release mainnet branch push actions

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -23,9 +23,14 @@ jobs:
         run: |
           if [ ${{ github.base_ref }} == 'main' ]; then
             echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
+          elif [ ${{ github.event_name }} == 'push' ] && [ ${{ contains(github.ref_name, 'release/mainnet') }} ]; then
+            echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
           else
             echo "runner=self-hosted-runner" >> $GITHUB_OUTPUT
           fi
+
+      - name: Print runner
+        run: echo ${{ steps.step.outputs.runner }}
 
   e2e:
     strategy:


### PR DESCRIPTION
# Description ℹ️

Some apps release process require push to release branch, and then cypress tests are being run. We need to run mainnet compatible runner for them. 