### PR TITLE
chore(explorer): ignore errors on oracle page

### DIFF
--- a/apps/explorer/src/app/routes/oracles/home/index.tsx
+++ b/apps/explorer/src/app/routes/oracles/home/index.tsx
@@ -8,7 +8,9 @@ import { useScrollToLocation } from '../../../hooks/scroll-to-location';
 import filter from 'recursive-key-filter';
 
 const Oracles = () => {
-  const { data, loading, error } = useExplorerOracleSpecsQuery();
+  const { data, loading, error } = useExplorerOracleSpecsQuery({
+    errorPolicy: 'ignore',
+  });
 
   useDocumentTitle(['Oracles']);
   useScrollToLocation();


### PR DESCRIPTION
# Related issues 🔗

Closes #4705

# Description ℹ️

Ignores graphql errors on the Oracle page so that the page can render. I will cherry-pick this to develop after approval.