### PR TITLE
chore(ci): add conditions to run e2e tests

### DIFF
--- a/.github/workflows/ci-cd-trigger.yml
+++ b/.github/workflows/ci-cd-trigger.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - release/*
       - develop
+      - main
   pull_request:
     types:
       - opened
@@ -176,10 +177,33 @@ jobs:
   #   with:
   #     github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  cypress:
+  check-e2e-needed:
+    runs-on: ubuntu-latest
     needs: build-sources
+    name: '(CI) check if e2e needed'
+    outputs:
+      run-tests: ${{ steps.check-test.outputs.e2e-needed }}
+    steps:
+      - name: Check branch
+        id: check-test
+        run: |
+          if [ ${{ github.base_ref }} == 'develop' ]; then
+            echo "e2e-needed=true" >> $GITHUB_OUTPUT
+          elif [ ${{ github.base_ref }} == 'main' ]; then 
+            echo "e2e-needed=true" >> $GITHUB_OUTPUT
+          elif [ ${{ github.event_name }} == 'push' ] && [ ${{ contains(github.ref_name, 'release/') }} ]; then
+            echo "e2e-needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "e2e-needed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Print result
+        run: |
+          echo "e2e-needed: ${{ steps.check-test.outputs.e2e-needed }}"
+
+  cypress:
+    needs: [build-sources, check-e2e-needed]
     name: '(CI) cypress'
-    # if: ${{ needs.build-sources.outputs.projects-e2e != '[]' }}
+    if: ${{ needs.check-e2e-needed.outputs.run-tests == 'true' }}
     uses: ./.github/workflows/cypress-run.yml
     secrets: inherit
     with:


### PR DESCRIPTION
# Description ℹ️

We don't need to run e2e every time ci/cd job is triggered. Only if:
- pull request to main
- pull request to develop
- push to release branch

Also added push to main as trigger to do ci/cd job, as it didn't produce main image without that.
