### PR TITLE
fix(deal-ticket): prevent empty call estimate position

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -264,7 +264,11 @@ export const DealTicket = ({
     orders,
     collateralAvailable:
       marginAccountBalance || generalAccountBalance ? balance : undefined,
-    skip: !normalizedOrder,
+    skip:
+      !normalizedOrder ||
+      (normalizedOrder.type !== Schema.OrderType.TYPE_MARKET &&
+        (!normalizedOrder.price || normalizedOrder.price === '0')) ||
+      normalizedOrder.size === '0',
   });
 
   const assetSymbol = getAsset(market).symbol;

--- a/libs/deal-ticket/src/hooks/use-position-estimate.ts
+++ b/libs/deal-ticket/src/hooks/use-position-estimate.ts
@@ -30,9 +30,11 @@ export const usePositionEstimate = ({
     fetchPolicy: 'no-cache',
   });
   useEffect(() => {
-    if (data) {
+    if (skip) {
+      setEstimates(undefined);
+    } else if (data) {
       setEstimates(data);
     }
-  }, [data]);
+  }, [data, skip]);
   return estimates;
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #4948 

# Description ℹ️

Add checking price or size are 0 for prevent calls for estimates position

# Demo 📺

-

# Technical 👨‍🔧

-
