### PR TITLE
feat(deal-ticket): fix margin and fees alignment

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -273,7 +273,7 @@ export const DealTicketMarginDetails = ({
                 key={'value-dropdown'}
                 className="flex items-center justify-between w-full gap-2"
               >
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-1 text-left">
                   <Tooltip description={MARGIN_DIFF_TOOLTIP_TEXT(assetSymbol)}>
                     <span className="text-muted">{t('Margin required')}</span>
                   </Tooltip>

--- a/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
@@ -25,11 +25,11 @@ export const KeyValue = ({
 }: KeyValuePros) => {
   const displayValue = `${formattedValue ?? '-'} ${symbol || ''}`;
   const valueElement = onClick ? (
-    <button onClick={onClick} className="font-mono">
+    <button onClick={onClick} className="font-mono ml-auto">
       {displayValue}
     </button>
   ) : (
-    <div className="font-mono">{displayValue}</div>
+    <div className="font-mono ml-auto">{displayValue}</div>
   );
   return (
     <div
@@ -40,12 +40,12 @@ export const KeyValue = ({
       }`}
       key={typeof label === 'string' ? label : 'value-dropdown'}
       className={classnames(
-        'text-xs flex justify-between items-center gap-4 flex-wrap',
+        'text-xs flex justify-between items-center gap-4 flex-wrap text-right',
         { 'ml-2': indent }
       )}
     >
       <Tooltip description={labelDescription}>
-        <div className="text-muted">{label}</div>
+        <div className="text-muted text-left">{label}</div>
       </Tooltip>
       <Tooltip description={`${value ?? '-'} ${symbol || ''}`}>
         {valueElement}


### PR DESCRIPTION
# Description ℹ️

closes #4973

Label and values are wrongly aligned when value is too long to fit in one line

Before

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/5392b8e5-ccf9-41d3-a4bf-1e36cf77580c)

After

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/e19c10ed-db33-41e8-8ee1-2c2da078bcdd)
