### PR TITLE
fix(trading): update filter for market selector to include suspended via governance

### DIFF
--- a/apps/trading/components/market-state/market-state.tsx
+++ b/apps/trading/components/market-state/market-state.tsx
@@ -7,6 +7,8 @@ import * as Schema from '@vegaprotocol/types';
 import { HeaderStat } from '../header';
 import { useCallback, useRef, useState } from 'react';
 import * as constants from '../constants';
+import { DocsLinks } from '@vegaprotocol/environment';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 
 export const MarketState = ({ market }: { market: Market | null }) => {
   const [marketState, setMarketState] = useState<Schema.MarketState | null>(
@@ -87,6 +89,21 @@ const getMarketStateTooltip = (state: Schema.MarketState | null) => {
   if (state === Schema.MarketState.STATE_TRADING_TERMINATED) {
     return t(
       'Trading has been terminated as a result of the product definition'
+    );
+  }
+
+  if (state === Schema.MarketState.STATE_SUSPENDED_VIA_GOVERNANCE) {
+    return (
+      <p>
+        {t(
+          `This market has been suspended via a governance vote and can be resumed or terminated by further votes.`
+        )}
+        {DocsLinks && (
+          <ExternalLink href={DocsLinks.MARKET_LIFECYCLE} className="ml-1">
+            {t('Find out more')}
+          </ExternalLink>
+        )}
+      </p>
     );
   }
 

--- a/apps/trading/lib/utils/index.ts
+++ b/apps/trading/lib/utils/index.ts
@@ -5,6 +5,7 @@ const MARKET_TEMPLATE = [
   MarketState.STATE_ACTIVE,
   MarketState.STATE_SUSPENDED,
   MarketState.STATE_PENDING,
+  MarketState.STATE_SUSPENDED_VIA_GOVERNANCE,
 ];
 
 export const isMarketActive = (state: MarketState) => {

--- a/libs/deal-ticket/src/components/trading-mode-tooltip/trading-mode-tooltip.tsx
+++ b/libs/deal-ticket/src/components/trading-mode-tooltip/trading-mode-tooltip.tsx
@@ -114,6 +114,20 @@ export const TradingModeTooltip = ({
         </section>
       );
     }
+    case Schema.MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE: {
+      return (
+        <section data-testid="trading-mode-suspended-via-governance">
+          {t(
+            `This market has been suspended via a governance vote and can be resumed or terminated by further votes.`
+          )}
+          {DocsLinks && (
+            <ExternalLink href={DocsLinks.MARKET_LIFECYCLE} className="ml-1">
+              {t('Find out more')}
+            </ExternalLink>
+          )}
+        </section>
+      );
+    }
     case Schema.MarketTradingMode.TRADING_MODE_MONITORING_AUCTION: {
       switch (trigger) {
         case Schema.AuctionTrigger.AUCTION_TRIGGER_LIQUIDITY_TARGET_NOT_MET: {

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -80,6 +80,7 @@ export const DocsLinks = VEGA_DOCS_URL
       LIQUIDITY: `${VEGA_DOCS_URL}/concepts/liquidity/provision`,
       WITHDRAWAL_LIMITS: `${VEGA_DOCS_URL}/concepts/assets/deposits-withdrawals#withdrawal-limits`,
       VALIDATOR_SCORES_REWARDS: `${VEGA_DOCS_URL}/concepts/vega-chain/validator-scores-and-rewards`,
+      MARKET_LIFECYCLE: `${VEGA_DOCS_URL}/concepts/trading-on-vega/market-lifecycle`,
     }
   : undefined;
 


### PR DESCRIPTION
# Related issues 🔗

Closes #4955 

# Description ℹ️

- [x] update tooltip with "This market has been suspended via a governance vote and can be resumed or terminated by further votes. [Find out more](https://docs.vega.xyz/testnet/concepts/trading-on-vega/market-lifecycle)"

- [x] update filter for market selector to include suspended via governance

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
