### PR TITLE
fix(trading): missing wallet connect button

### DIFF
--- a/apps/trading/.env
+++ b/apps/trading/.env
@@ -12,6 +12,7 @@ NX_VEGA_WALLET_URL=http://localhost:1789
 NX_VEGA_DOCS_URL=https://docs.vega.xyz/testnet
 NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases
 NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/announcements/fairground/announcements.json
+NX_WALLETCONNECT_PROJECT_ID=fe8091dc35738863e509fc4947525c72
 NX_VEGA_INCIDENT_URL=https://blog.vega.xyz/tagged/vega-incident-reports
 NX_VEGA_CONSOLE_URL=https://console.fairground.wtf
 NX_CHROME_EXTENSION_URL=https://chrome.google.com/webstore/detail/vega-wallet-fairground/nmmjkiafpmphlikhefgjbblebfgclikn


### PR DESCRIPTION
# Description ℹ️

This fixes missing "Wallet Connect" button.

# Technical 👨‍🔧

Missing `projectId` was a root cause of this issue, re-adding that in this PR.
