### PR TITLE
chore(ci): add missing quote marks that may have caused some workflow fails

### DIFF
--- a/.github/workflows/ci-cd-trigger.yml
+++ b/.github/workflows/ci-cd-trigger.yml
@@ -187,11 +187,11 @@ jobs:
       - name: Check branch
         id: check-test
         run: |
-          if [ ${{ github.base_ref }} == 'develop' ]; then
+          if [ '${{ github.base_ref }}' == 'develop' ]; then
             echo "e2e-needed=true" >> $GITHUB_OUTPUT
-          elif [ ${{ github.base_ref }} == 'main' ]; then 
+          elif [ '${{ github.base_ref }}' == 'main' ]; then 
             echo "e2e-needed=true" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.event_name }} == 'push'  &&  ${{ contains(github.ref_name, 'release/') }} ]]; then
+          elif [[ '${{ github.event_name }}' == 'push'  &&  ${{ contains(github.ref_name, 'release/') }} ]]; then
             echo "e2e-needed=true" >> $GITHUB_OUTPUT
           else
             echo "e2e-needed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Check branch
         id: step
         run: |
-          if [ ${{ github.base_ref }} == 'main' ]; then
+          if [ '${{ github.base_ref }}' == 'main' ]; then
             echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.base_ref }} == 'develop' && ${{ github.ref_name }} == 'main' ]]; then
+          elif [[ '${{ github.base_ref }}' == 'develop' && '${{ github.ref_name }}' == 'main' ]]; then
             echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.event_name }} == 'push' && ${{ contains(github.ref_name, 'release/mainnet') }} ]]; then
+          elif [[ '${{ github.event_name }}' == 'push' && ${{ contains(github.ref_name, 'release/mainnet') }} ]]; then
             echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
           else
             echo "runner=self-hosted-runner" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description ℹ️

There was some errors that may be caused by following example:

```
          if [ ${{ github.base_ref }} == 'main' ]; then
            echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
```
if `github.base_ref` was emtpy, then error may have occured.
Changed such cases to:
```
          if [ '${{ github.base_ref }}' == 'main' ]; then
            echo "runner=mainnet-compatible-runner" >> $GITHUB_OUTPUT
```

