### PR TITLE
chore(trading): set default sort order

### DIFF
--- a/libs/accounts/src/lib/breakdown-table.tsx
+++ b/libs/accounts/src/lib/breakdown-table.tsx
@@ -37,6 +37,7 @@ const BreakdownTable = forwardRef<AgGridReact, BreakdownTableProps>(
           headerName: t('Market'),
           field: 'market.tradableInstrument.instrument.code',
           minWidth: 200,
+          sort: 'desc',
           cellRenderer: ({
             value,
             data,
@@ -140,6 +141,7 @@ const BreakdownTable = forwardRef<AgGridReact, BreakdownTableProps>(
         tooltipShowDelay={500}
         defaultColDef={defaultColDef}
         columnDefs={coldefs}
+        domLayout="autoHeight"
       />
     );
   }


### PR DESCRIPTION
# Description ℹ️

Sets the usage breakdown to order by market desc, as previously it would flip flop between orders (making testing hard).

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/133853298/691edcd9-97d0-46dd-af19-8e64f38191f2)
