### PR TITLE
chore(ci): separate export docker image job in console-test workflow

### DIFF
--- a/.github/workflows/console-test-run.yml
+++ b/.github/workflows/console-test-run.yml
@@ -16,9 +16,9 @@ on:
           - develop
 
 jobs:
-  run-tests:
-    name: run-tests
-    runs-on: 8-cores
+  create-docker-image:
+    name: Create docker image for console-test
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       #----------------------------------------------
@@ -55,23 +55,68 @@ jobs:
       #----------------------------------------------
       #       build trading
       #----------------------------------------------
-      - name: Build affected spec
+      - name: Build trading app
         run: |
           yarn env-cmd -f ./apps/trading/.env.stagnet1 yarn nx export trading
+          DIST_LOCATION=dist/apps/trading/exported
+          mv $DIST_LOCATION dist-result
+          tree dist-result
+
       #----------------------------------------------
-      #       run trading server
+      #       export trading app docker image
       #----------------------------------------------
-      - name: Run trading server
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export to local Docker
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/node-outside-docker.Dockerfile
+          load: true
+          build-args: |
+            APP=trading
+            ENV_NAME=stagnet1
+          tags: ci/trading:local
+          outputs: type=docker,dest=/tmp/console-image.tar
+
+      - name: Verify docker image created
         run: |
-          docker run -d -p 80:4200 -v $PWD/docker/nginx.conf:/etc/nginx/conf.d/default.conf -v $PWD/dist/apps/trading/exported:/usr/share/nginx/html nginx:1.23-alpine@sha256:6318314189b40e73145a48060bff4783a116c34cc7241532d0d94198fb2c9629
-          sleep 5
-          docker ps
+          echo ${{ steps.docker_build.outputs.digest }}
+          echo ${{ steps.docker_build.outputs.imageid }}
+
+      - name: Upload docker image for console-test usage
+        uses: actions/upload-artifact@v3
+        with:
+          name: console-image
+          path: /tmp/console-image.tar
+
+  run-tests:
+    name: run-tests
+    runs-on: 8-cores
+    needs: create-docker-image
+    timeout-minutes: 20
+    steps:
       #----------------------------------------------
-      #       check if container persists between runs
+      #       load docker image
       #----------------------------------------------
-      - name: Check server
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download docker image from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: console-image
+          path: /tmp
+
+      - name: Load Docker image
         run: |
-          docker ps
+          docker load --input /tmp/console-image.tar
+          docker image ls -a
+
       #----------------------------------------------
       #       check-out tests repo
       #----------------------------------------------
@@ -80,45 +125,54 @@ jobs:
         with:
           repository: vegaprotocol/console-test
           ref: ${{ inputs.console-test-branch }}
-          path: './console-test'
 
       - name: Load console test envs
         id: console-test-env
         uses: falti/dotenv-action@v1.0.4
         with:
-          path: './console-test/.env.${{ inputs.console-test-branch }}'
+          path: '.env.${{ inputs.console-test-branch }}'
           export-variables: true
           keys-case: upper
           log-variables: true
 
       #----------------------------------------------
-      # install dependencies if cache does not exist
+      #  -----  Setup python  -----
+      #----------------------------------------------
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+
+      #----------------------------------------------
+      # install python dependencies
       #----------------------------------------------
       - name: Install dependencies
-        working-directory: ./console-test
         run: poetry install --no-interaction --no-root
       #----------------------------------------------
       # install vega binaries
       #----------------------------------------------
       - name: Install vega binaries
-        working-directory: ./console-test
         run: poetry run python -m vega_sim.tools.load_binaries --force --version ${{ env.VEGA_VERSION }}
       #----------------------------------------------
       # install playwright
       #----------------------------------------------
       - name: install playwright
         run: poetry run playwright install --with-deps chromium
-        working-directory: ./console-test
       #----------------------------------------------
       # run tests
       #----------------------------------------------
       - name: Run tests
-        working-directory: ./console-test
-        run: poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=15
-      - name: Check files
-        run: |
-          ls -al .
-          ls -al console-test
+        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=15
+
       #----------------------------------------------
       # upload traces
       #----------------------------------------------


### PR DESCRIPTION
# Related issues 🔗

Relates to  #4886 

# Description ℹ️

It creates a docker image of trading app on given branch, then pass it to console-test job to run tests against it. As a next step we could reuse images in other jobs in workflow.