### PR TITLE
chore(governance): fix failing link test

### DIFF
--- a/apps/governance-e2e/src/integration/view/proposal.cy.ts
+++ b/apps/governance-e2e/src/integration/view/proposal.cy.ts
@@ -74,25 +74,12 @@ context(
     });
 
     it('should be able to see a working link for - find out more about Vega governance', function () {
-      // 3001-VOTE-001
+      // 3001-VOTE-001  // 3002-PROP-001
       cy.getByTestId(proposalDocumentationLink)
         .should('be.visible')
         .and('have.text', 'Find out more about Vega governance')
         .and('have.attr', 'href')
         .and('equal', governanceDocsUrl);
-
-      // 3002-PROP-001
-      cy.request(governanceDocsUrl)
-        .its('body')
-        .then((body) => {
-          if (!body.includes('Govern the network')) {
-            assert.include(
-              body,
-              'Govern the network',
-              `Checking that governance link destination includes 'Govern the network' text`
-            );
-          }
-        });
     });
 
     // 3007-PNE-021


### PR DESCRIPTION
A test has been failing recently due to a change on the vega website. 

The assertion has been removed as the test should not had been testing the contents of the vega website which is outside the scope of the test. 