### PR TITLE
fix(governance): ensuring eagerconnect does not block loading of the app

### DIFF
--- a/apps/governance/src/app-loader.tsx
+++ b/apps/governance/src/app-loader.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import { toBigNum } from '@vegaprotocol/utils';
 import { Splash } from '@vegaprotocol/ui-toolkit';
-import { useVegaWallet, useEagerConnect } from '@vegaprotocol/wallet';
+import { useVegaWallet } from '@vegaprotocol/wallet';
 import { FLAGS, useEnvironment } from '@vegaprotocol/environment';
 import { useWeb3React } from '@web3-react/core';
 import React from 'react';
@@ -15,19 +15,6 @@ import {
 } from './contexts/app-state/app-state-context';
 import { useContracts } from './contexts/contracts/contracts-context';
 import { useRefreshAssociatedBalances } from './hooks/use-refresh-associated-balances';
-import { Connectors } from './lib/vega-connectors';
-import { useSearchParams } from 'react-router-dom';
-
-const useVegaWalletEagerConnect = () => {
-  const vegaConnecting = useEagerConnect(Connectors);
-  const { pubKey, connect } = useVegaWallet();
-  const [searchParams] = useSearchParams();
-  const [query] = React.useState(searchParams.get('address'));
-  if (query && !pubKey) {
-    connect(Connectors['view']);
-  }
-  return vegaConnecting;
-};
 
 export const AppLoader = ({ children }: { children: React.ReactElement }) => {
   const { t } = useTranslation();
@@ -38,9 +25,8 @@ export const AppLoader = ({ children }: { children: React.ReactElement }) => {
   const { token, staking, vesting } = useContracts();
   const setAssociatedBalances = useRefreshAssociatedBalances();
   const [balancesLoaded, setBalancesLoaded] = React.useState(false);
-  const vegaConnecting = useVegaWalletEagerConnect();
 
-  const loaded = balancesLoaded && !vegaConnecting;
+  const loaded = balancesLoaded;
 
   React.useEffect(() => {
     const run = async () => {


### PR DESCRIPTION
# Related issues 🔗

Closes #4896

# Description ℹ️

Governance was waiting for eagerconnect to complete before proceeding with loading of the app. If a wallet (eg CLI) was locked, the wallet would be prompting the user to connect, but the app was hanging, leading to confusion. 

This change ensure the app doesn't hang, and if the user doesn't notice the connection prompt, everything works fine. They can still connect their wallet at a later point.