### PR TITLE
chore(trading): add button for copying asset id

### DIFF
--- a/libs/assets/src/lib/asset-details-table.tsx
+++ b/libs/assets/src/lib/asset-details-table.tsx
@@ -57,7 +57,16 @@ export const rows: Rows = [
     key: AssetDetail.ID,
     label: t('ID'),
     tooltip: '',
-    value: (asset) => truncateMiddle(asset.id),
+    value: (asset) => (
+      <>
+        {truncateMiddle(asset.id)}{' '}
+        <CopyWithTooltip text={asset.id}>
+          <button title={t('Copy id to clipboard')}>
+            <VegaIcon size={14} name={VegaIconNames.COPY} />
+          </button>
+        </CopyWithTooltip>
+      </>
+    ),
   },
   {
     key: AssetDetail.TYPE,


### PR DESCRIPTION
# Related issues 🔗

Closes #5067

# Description ℹ️

Add missing button for easy copying is of the asset in asset detail dialog 

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/338931/4c1a24b6-7c8a-40a0-9fa7-f6ed85708b49)

# Technical 👨‍🔧

-
