### PR TITLE
feat(governance): transfers destination field can fallback to type

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
@@ -237,7 +237,11 @@ export const ProposalHeader = ({
   );
 };
 
-const SuccessorCode = ({ proposalId }: { proposalId?: string | null }) => {
+export const SuccessorCode = ({
+  proposalId,
+}: {
+  proposalId?: string | null;
+}) => {
   const { t } = useTranslation();
   const successor = useSuccessorMarketProposalDetails(proposalId);
 
@@ -254,7 +258,11 @@ const SuccessorCode = ({ proposalId }: { proposalId?: string | null }) => {
   ) : null;
 };
 
-const NewTransferSummary = ({ proposalId }: { proposalId?: string | null }) => {
+export const NewTransferSummary = ({
+  proposalId,
+}: {
+  proposalId?: string | null;
+}) => {
   const { t } = useTranslation();
   const details = useNewTransferProposalDetails(proposalId);
 
@@ -265,14 +273,21 @@ const NewTransferSummary = ({ proposalId }: { proposalId?: string | null }) => {
       {GovernanceTransferKindMapping[details.kind.__typename]}{' '}
       {t('transfer from')}{' '}
       <Lozenge>
-        {truncateMiddle(details.source) || t(details.sourceType)}
+        {details.source
+          ? truncateMiddle(details.source)
+          : t(details.sourceType)}
       </Lozenge>{' '}
-      {t('to')} <Lozenge>{truncateMiddle(details.destination)}</Lozenge>
+      {t('to')}{' '}
+      <Lozenge>
+        {details.destination
+          ? truncateMiddle(details.destination)
+          : t(details.destinationType)}
+      </Lozenge>
     </span>
   );
 };
 
-const CancelTransferSummary = ({
+export const CancelTransferSummary = ({
   proposalId,
 }: {
   proposalId?: string | null;


### PR DESCRIPTION
# Related issues 🔗

Closes #5085

# Description ℹ️

To avoid this (valid) situation:

![Screenshot 2023-10-18 at 12 22 46](https://github.com/vegaprotocol/frontend-monorepo/assets/2410498/64134d12-eb43-49be-8f74-738c16a0977f)

We now fall back to the destination type, as we do for the source type if the source field isn't set.
