### PR TITLE
feat(trading): show full history of orders, fills and trades

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.spec.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.spec.tsx
@@ -109,7 +109,7 @@ describe('DealTicket', () => {
         variables: {
           partyId: 'pubKey',
           filter: { liveOnly: true },
-          pagination: { first: 5000 },
+          pagination: { first: 1000 },
         },
       },
       result: {

--- a/libs/fills/src/lib/Fills.graphql
+++ b/libs/fills/src/lib/Fills.graphql
@@ -42,8 +42,12 @@ fragment FillEdge on TradeEdge {
   cursor
 }
 
-query Fills($filter: TradesFilter, $pagination: Pagination) {
-  trades(filter: $filter, pagination: $pagination) {
+query Fills(
+  $filter: TradesFilter
+  $pagination: Pagination
+  $dateRange: DateRange
+) {
+  trades(filter: $filter, dateRange: $dateRange, pagination: $pagination) {
     edges {
       ...FillEdge
     }

--- a/libs/fills/src/lib/__generated__/Fills.ts
+++ b/libs/fills/src/lib/__generated__/Fills.ts
@@ -12,6 +12,7 @@ export type FillEdgeFragment = { __typename?: 'TradeEdge', cursor: string, node:
 export type FillsQueryVariables = Types.Exact<{
   filter?: Types.InputMaybe<Types.TradesFilter>;
   pagination?: Types.InputMaybe<Types.Pagination>;
+  dateRange?: Types.InputMaybe<Types.DateRange>;
 }>;
 
 
@@ -95,8 +96,8 @@ export const FillUpdateFieldsFragmentDoc = gql`
 }
     ${TradeFeeFieldsFragmentDoc}`;
 export const FillsDocument = gql`
-    query Fills($filter: TradesFilter, $pagination: Pagination) {
-  trades(filter: $filter, pagination: $pagination) {
+    query Fills($filter: TradesFilter, $pagination: Pagination, $dateRange: DateRange) {
+  trades(filter: $filter, dateRange: $dateRange, pagination: $pagination) {
     edges {
       ...FillEdge
     }
@@ -124,6 +125,7 @@ export const FillsDocument = gql`
  *   variables: {
  *      filter: // value for 'filter'
  *      pagination: // value for 'pagination'
+ *      dateRange: // value for 'dateRange'
  *   },
  * });
  */

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -1,11 +1,12 @@
 import type { AgGridReact } from 'ag-grid-react';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { t } from '@vegaprotocol/i18n';
 import { FillsTable } from './fills-table';
 import type { useDataGridEvents } from '@vegaprotocol/datagrid';
 import { useDataProvider } from '@vegaprotocol/data-provider';
 import type * as Schema from '@vegaprotocol/types';
 import { fillsWithMarketProvider } from './fills-data-provider';
+import { TradingButton as Button } from '@vegaprotocol/ui-toolkit';
 
 interface FillsManagerProps {
   partyId: string;
@@ -22,45 +23,68 @@ export const FillsManager = ({
   const filter: Schema.TradesFilter | Schema.TradesSubscriptionFilter = {
     partyIds: [partyId],
   };
-  const [dateRange, setDateRange] = useState<Schema.DateRange | null>(null);
-  const { data, error } = useDataProvider({
+  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
+    boolean | undefined
+  >(undefined);
+  const { data, error, load, pageInfo } = useDataProvider({
     dataProvider: fillsWithMarketProvider,
-    update: ({ data }) => {
-      if (data?.length && gridRef.current?.api) {
-        gridRef.current?.api.setRowData(data);
-        return true;
-      }
-      return false;
-    },
-    variables: { filter, dateRange },
+    variables: { filter },
   });
   const { onFilterChanged, ...props } = gridProps;
-  const overlayNoRowsTemplate = dateRange
-    ? t('No fills matching selected date range')
-    : t('No fills');
+  const onRowDataUpdated = useCallback(
+    ({ api }: { api: AgGridReact['api'] }) => {
+      let hasFilteredRows = false;
+      try {
+        api.forEachNodeAfterFilter(() => {
+          throw new Error();
+        });
+      } catch (e) {
+        hasFilteredRows = true;
+      }
+      setHasFilteredRowsCount(hasFilteredRows);
+    },
+    []
+  );
   return (
-    <FillsTable
-      ref={gridRef}
-      rowData={data}
-      onFilterChanged={(event) => {
-        const { api } = event;
-        const filterModel = api.getFilterModel();
-        if (filterModel['createdAt']?.value) {
-          if (
-            filterModel['createdAt'].value.start !== dateRange?.start ||
-            filterModel['createdAt'].value.end !== dateRange?.end
-          ) {
-            setDateRange(filterModel['createdAt'].value);
-          }
-        } else {
-          setDateRange(null);
-        }
-        onFilterChanged(event);
-      }}
-      partyId={partyId}
-      onMarketClick={onMarketClick}
-      overlayNoRowsTemplate={error ? error.message : overlayNoRowsTemplate}
-      {...props}
-    />
+    <div className="flex flex-col h-full">
+      <FillsTable
+        ref={gridRef}
+        rowData={data}
+        onFilterChanged={(event) => {
+          onRowDataUpdated(event);
+          onFilterChanged(event);
+        }}
+        onRowDataUpdated={onRowDataUpdated}
+        partyId={partyId}
+        onMarketClick={onMarketClick}
+        overlayNoRowsTemplate={error ? error.message : t('No fills')}
+        {...props}
+      />
+
+      <div className="flex justify-between border-t border-default p-1 items-center">
+        <div className="text-xs">
+          {t(
+            'Depending on data node retention you may not be able see the "full" history'
+          )}
+        </div>
+        <div className="flex text-xs items-center">
+          {data?.length && !pageInfo?.hasNextPage
+            ? t('all %s items loaded', [data.length.toString()])
+            : t('%s items loaded', [
+                data?.length ? data.length.toString() : ' ',
+              ])}
+          {pageInfo?.hasNextPage ? (
+            <Button size="extra-small" className="ml-1" onClick={() => load()}>
+              {t('Load more')}
+            </Button>
+          ) : null}
+        </div>
+        {data?.length && hasFilteredRows === false ? (
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
+            {t('No fills matching selected filters')}
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 };

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -1,5 +1,5 @@
 import type { AgGridReact } from 'ag-grid-react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { t } from '@vegaprotocol/i18n';
 import { FillsTable } from './fills-table';
 import type { useDataGridEvents } from '@vegaprotocol/datagrid';
@@ -22,6 +22,7 @@ export const FillsManager = ({
   const filter: Schema.TradesFilter | Schema.TradesSubscriptionFilter = {
     partyIds: [partyId],
   };
+  const [dateRange, setDateRange] = useState<Schema.DateRange | null>(null);
   const { data, error } = useDataProvider({
     dataProvider: fillsWithMarketProvider,
     update: ({ data }) => {
@@ -31,17 +32,35 @@ export const FillsManager = ({
       }
       return false;
     },
-    variables: { filter },
+    variables: { filter, dateRange },
   });
-
+  const { onFilterChanged, ...props } = gridProps;
+  const overlayNoRowsTemplate = dateRange
+    ? t('No fills matching selected date range')
+    : t('No fills');
   return (
     <FillsTable
       ref={gridRef}
       rowData={data}
+      onFilterChanged={(event) => {
+        const { api } = event;
+        const filterModel = api.getFilterModel();
+        if (filterModel['createdAt']?.value) {
+          if (
+            filterModel['createdAt'].value.start !== dateRange?.start ||
+            filterModel['createdAt'].value.end !== dateRange?.end
+          ) {
+            setDateRange(filterModel['createdAt'].value);
+          }
+        } else {
+          setDateRange(null);
+        }
+        onFilterChanged(event);
+      }}
       partyId={partyId}
       onMarketClick={onMarketClick}
-      overlayNoRowsTemplate={error ? error.message : t('No fills')}
-      {...gridProps}
+      overlayNoRowsTemplate={error ? error.message : overlayNoRowsTemplate}
+      {...props}
     />
   );
 };

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -23,28 +23,20 @@ export const FillsManager = ({
   const filter: Schema.TradesFilter | Schema.TradesSubscriptionFilter = {
     partyIds: [partyId],
   };
-  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
-    boolean | undefined
+  const [displayedRowCount, setDisplayedRowCount] = useState<
+    number | undefined
   >(undefined);
+  const { onFilterChanged, ...props } = gridProps || {};
+  const onRowDataUpdated = useCallback(
+    ({ api }: { api: AgGridReact['api'] }) => {
+      setDisplayedRowCount(api.getDisplayedRowCount());
+    },
+    []
+  );
   const { data, error, load, pageInfo } = useDataProvider({
     dataProvider: fillsWithMarketProvider,
     variables: { filter },
   });
-  const { onFilterChanged, ...props } = gridProps;
-  const onRowDataUpdated = useCallback(
-    ({ api }: { api: AgGridReact['api'] }) => {
-      let hasFilteredRows = false;
-      try {
-        api.forEachNodeAfterFilter(() => {
-          throw new Error();
-        });
-      } catch (e) {
-        hasFilteredRows = true;
-      }
-      setHasFilteredRowsCount(hasFilteredRows);
-    },
-    []
-  );
   return (
     <div className="flex flex-col h-full">
       <FillsTable
@@ -79,7 +71,7 @@ export const FillsManager = ({
             </Button>
           ) : null}
         </div>
-        {data?.length && hasFilteredRows === false ? (
+        {data?.length && displayedRowCount === 0 ? (
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
             {t('No fills matching selected filters')}
           </div>

--- a/libs/fills/src/lib/fills-manager.tsx
+++ b/libs/fills/src/lib/fills-manager.tsx
@@ -23,13 +23,13 @@ export const FillsManager = ({
   const filter: Schema.TradesFilter | Schema.TradesSubscriptionFilter = {
     partyIds: [partyId],
   };
-  const [displayedRowCount, setDisplayedRowCount] = useState<
-    number | undefined
-  >(undefined);
+  const [hasDisplayedRow, setHasDisplayedRow] = useState<boolean | undefined>(
+    undefined
+  );
   const { onFilterChanged, ...props } = gridProps || {};
   const onRowDataUpdated = useCallback(
     ({ api }: { api: AgGridReact['api'] }) => {
-      setDisplayedRowCount(api.getDisplayedRowCount());
+      setHasDisplayedRow(!!api.getDisplayedRowCount());
     },
     []
   );
@@ -71,7 +71,7 @@ export const FillsManager = ({
             </Button>
           ) : null}
         </div>
-        {data?.length && displayedRowCount === 0 ? (
+        {data?.length && hasDisplayedRow === false ? (
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
             {t('No fills matching selected filters')}
           </div>

--- a/libs/fills/src/lib/fills-table.tsx
+++ b/libs/fills/src/lib/fills-table.tsx
@@ -20,6 +20,7 @@ import {
   negativeClassNames,
   MarketNameCell,
   COL_DEFS,
+  DateRangeFilter,
 } from '@vegaprotocol/datagrid';
 import type {
   VegaValueFormatterParams,
@@ -120,6 +121,7 @@ export const FillsTable = forwardRef<AgGridReact, Props>(
         },
         {
           headerName: t('Date'),
+          filter: DateRangeFilter,
           field: 'createdAt',
           valueFormatter: ({
             value,

--- a/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
+++ b/libs/orders/src/lib/components/order-data-provider/order-data-provider.ts
@@ -166,7 +166,7 @@ export const ordersProvider = makeDataProvider<
   pagination: {
     getPageInfo,
     append,
-    first: 5000,
+    first: 1000,
   },
   resetDelay: 1000,
   additionalContext: { isEnlargedTimeout: true },

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.spec.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.spec.tsx
@@ -27,6 +27,7 @@ describe('OrderListManager', () => {
       flush: jest.fn(),
       reload: jest.fn(),
       load: jest.fn(),
+      pageInfo: null,
     });
     render(generateJsx());
 
@@ -45,6 +46,7 @@ describe('OrderListManager', () => {
       flush: jest.fn(),
       reload: jest.fn(),
       load: jest.fn(),
+      pageInfo: null,
     });
 
     render(generateJsx());
@@ -62,6 +64,7 @@ describe('OrderListManager', () => {
       flush: jest.fn(),
       reload: jest.fn(),
       load: jest.fn(),
+      pageInfo: null,
     });
 
     render(

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -80,21 +80,13 @@ export const OrderListManager = ({
     [create]
   );
 
-  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
-    boolean | undefined
+  const [displayedRowCount, setDisplayedRowCount] = useState<
+    number | undefined
   >(undefined);
   const { onFilterChanged, ...props } = gridProps || {};
   const onRowDataUpdated = useCallback(
     ({ api }: { api: AgGridReact['api'] }) => {
-      let hasFilteredRows = false;
-      try {
-        api.forEachNodeAfterFilter(() => {
-          throw new Error();
-        });
-      } catch (e) {
-        hasFilteredRows = true;
-      }
-      setHasFilteredRowsCount(hasFilteredRows);
+      setDisplayedRowCount(api.getDisplayedRowCount());
     },
     []
   );
@@ -129,9 +121,11 @@ export const OrderListManager = ({
           />
           <div className="flex justify-between border-t border-default p-1 items-center">
             <div className="text-xs">
-              {t(
-                'Depending on data node retention you may not be able see the "full" history'
-              )}
+              {variables.filter?.liveOnly
+                ? null
+                : t(
+                    'Depending on data node retention you may not be able see the "full" history'
+                  )}
             </div>
             {data ? (
               <div className="flex text-xs items-center">
@@ -151,7 +145,7 @@ export const OrderListManager = ({
                 ) : null}
               </div>
             ) : null}
-            {data?.length && hasFilteredRows === false ? (
+            {data?.length && displayedRowCount === 0 ? (
               <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
                 {t('No orders matching selected filters')}
               </div>

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -80,13 +80,13 @@ export const OrderListManager = ({
     [create]
   );
 
-  const [displayedRowCount, setDisplayedRowCount] = useState<
-    number | undefined
-  >(undefined);
+  const [hasDisplayedRow, setHasDisplayedRow] = useState<boolean | undefined>(
+    undefined
+  );
   const { onFilterChanged, ...props } = gridProps || {};
   const onRowDataUpdated = useCallback(
     ({ api }: { api: AgGridReact['api'] }) => {
-      setDisplayedRowCount(api.getDisplayedRowCount());
+      setHasDisplayedRow(!!api.getDisplayedRowCount());
     },
     []
   );
@@ -145,7 +145,7 @@ export const OrderListManager = ({
                 ) : null}
               </div>
             ) : null}
-            {data?.length && displayedRowCount === 0 ? (
+            {data?.length && hasDisplayedRow === false ? (
               <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
                 {t('No orders matching selected filters')}
               </div>

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -1,7 +1,6 @@
 import { t } from '@vegaprotocol/i18n';
 import { useCallback, useRef, useState, useEffect } from 'react';
 import type { AgGridReact } from 'ag-grid-react';
-import type { FilterChangedEvent } from 'ag-grid-community';
 import { OrderListTable } from '../order-list';
 import type { useDataGridEvents } from '@vegaprotocol/datagrid';
 import { useDataProvider } from '@vegaprotocol/data-provider';
@@ -12,7 +11,7 @@ import type { OrderTxUpdateFieldsFragment } from '@vegaprotocol/web3';
 import { OrderEditDialog } from '../order-list/order-edit-dialog';
 import type { Order } from '../order-data-provider';
 import { OrderViewDialog } from '../order-list/order-view-dialog';
-import { Splash } from '@vegaprotocol/ui-toolkit';
+import { Splash, TradingButton as Button } from '@vegaprotocol/ui-toolkit';
 
 export enum Filter {
   'Open' = 'Open',
@@ -48,7 +47,7 @@ export const OrderListManager = ({
       ? { partyId, filter: { liveOnly: true } }
       : { partyId };
 
-  const { data, error } = useDataProvider({
+  const { data, error, pageInfo, load } = useDataProvider({
     dataProvider: ordersWithMarketProvider,
     variables,
     update: ({ data }) => {
@@ -59,21 +58,6 @@ export const OrderListManager = ({
       return false;
     },
   });
-
-  const onFilterChanged = useCallback(
-    (event: FilterChangedEvent) => {
-      gridProps?.onFilterChanged?.(event);
-      if (event.api) {
-        const isEmpty = event.api.getDisplayedRowCount() === 0;
-        if (isEmpty) {
-          event.api.showNoRowsOverlay();
-        } else {
-          event.api.hideOverlay();
-        }
-      }
-    },
-    [gridProps]
-  );
 
   useEffect(() => {
     if (!data || !data.length) {
@@ -96,6 +80,25 @@ export const OrderListManager = ({
     [create]
   );
 
+  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
+    boolean | undefined
+  >(undefined);
+  const { onFilterChanged, ...props } = gridProps || {};
+  const onRowDataUpdated = useCallback(
+    ({ api }: { api: AgGridReact['api'] }) => {
+      let hasFilteredRows = false;
+      try {
+        api.forEachNodeAfterFilter(() => {
+          throw new Error();
+        });
+      } catch (e) {
+        hasFilteredRows = true;
+      }
+      setHasFilteredRowsCount(hasFilteredRows);
+    },
+    []
+  );
+
   if (error) {
     return <Splash>{t(`Something went wrong: ${error.message}`)}</Splash>;
   }
@@ -103,20 +106,58 @@ export const OrderListManager = ({
   return (
     <>
       <div className="h-full relative">
-        <OrderListTable
-          rowData={data}
-          ref={gridRef}
-          filter={filter}
-          onCancel={cancel}
-          onEdit={setEditOrder}
-          onView={setViewOrder}
-          onMarketClick={onMarketClick}
-          onOrderTypeClick={onOrderTypeClick}
-          isReadOnly={isReadOnly}
-          overlayNoRowsTemplate={noRowsMessage || t('No orders')}
-          {...gridProps}
-          onFilterChanged={onFilterChanged}
-        />
+        <div className="flex flex-col h-full">
+          <OrderListTable
+            rowData={data}
+            ref={gridRef}
+            filter={filter}
+            onCancel={cancel}
+            onEdit={setEditOrder}
+            onView={setViewOrder}
+            onMarketClick={onMarketClick}
+            onOrderTypeClick={onOrderTypeClick}
+            onFilterChanged={(event) => {
+              onRowDataUpdated(event);
+              if (onFilterChanged) {
+                onFilterChanged(event);
+              }
+            }}
+            onRowDataUpdated={onRowDataUpdated}
+            isReadOnly={isReadOnly}
+            overlayNoRowsTemplate={noRowsMessage || t('No orders')}
+            {...props}
+          />
+          <div className="flex justify-between border-t border-default p-1 items-center">
+            <div className="text-xs">
+              {t(
+                'Depending on data node retention you may not be able see the "full" history'
+              )}
+            </div>
+            {data ? (
+              <div className="flex text-xs items-center">
+                {data?.length && !pageInfo?.hasNextPage
+                  ? t('all %s items loaded', [data.length.toString()])
+                  : t('%s items loaded', [
+                      data?.length ? data.length.toString() : ' ',
+                    ])}
+                {pageInfo?.hasNextPage ? (
+                  <Button
+                    size="extra-small"
+                    className="ml-1"
+                    onClick={() => load()}
+                  >
+                    {t('Load more')}
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+            {data?.length && hasFilteredRows === false ? (
+              <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
+                {t('No orders matching selected filters')}
+              </div>
+            ) : null}
+          </div>
+        </div>
       </div>
       {editOrder && (
         <OrderEditDialog

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -50,13 +50,6 @@ export const OrderListManager = ({
   const { data, error, pageInfo, load } = useDataProvider({
     dataProvider: ordersWithMarketProvider,
     variables,
-    update: ({ data }) => {
-      if (data && gridRef.current?.api) {
-        gridRef.current.api.setRowData(data);
-        return true;
-      }
-      return false;
-    },
   });
 
   useEffect(() => {

--- a/libs/orders/src/lib/components/stop-orders-manager/stop-orders-manager.spec.tsx
+++ b/libs/orders/src/lib/components/stop-orders-manager/stop-orders-manager.spec.tsx
@@ -30,6 +30,7 @@ describe('StopOrdersManager', () => {
       flush: jest.fn(),
       reload: jest.fn(),
       load: jest.fn(),
+      pageInfo: null,
     });
     await act(async () => {
       render(generateJsx());

--- a/libs/trades/src/lib/trades-manager.tsx
+++ b/libs/trades/src/lib/trades-manager.tsx
@@ -4,10 +4,13 @@ import { TradesTable } from './trades-table';
 import { useDealTicketFormValues } from '@vegaprotocol/deal-ticket';
 import { t } from '@vegaprotocol/i18n';
 import type { useDataGridEvents } from '@vegaprotocol/datagrid';
+import { useCallback, useState } from 'react';
+import type { AgGridReact } from 'ag-grid-react';
+import { TradingButton as Button } from '@vegaprotocol/ui-toolkit';
 
 interface TradesContainerProps {
   marketId: string;
-  gridProps?: ReturnType<typeof useDataGridEvents>;
+  gridProps: ReturnType<typeof useDataGridEvents>;
 }
 
 export const TradesManager = ({
@@ -16,19 +19,68 @@ export const TradesManager = ({
 }: TradesContainerProps) => {
   const update = useDealTicketFormValues((state) => state.updateAll);
 
-  const { data, error } = useDataProvider({
+  const { data, error, load, pageInfo } = useDataProvider({
     dataProvider: tradesWithMarketProvider,
     variables: { marketId },
   });
+  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
+    boolean | undefined
+  >(undefined);
+  const { onFilterChanged, ...props } = gridProps;
+  const onRowDataUpdated = useCallback(
+    ({ api }: { api: AgGridReact['api'] }) => {
+      let hasFilteredRows = false;
+      try {
+        api.forEachNodeAfterFilter(() => {
+          throw new Error();
+        });
+      } catch (e) {
+        hasFilteredRows = true;
+      }
+      setHasFilteredRowsCount(hasFilteredRows);
+    },
+    []
+  );
 
   return (
-    <TradesTable
-      rowData={data}
-      onClick={(price?: string) => {
-        update(marketId, { price });
-      }}
-      overlayNoRowsTemplate={error ? error.message : t('No trades')}
-      {...gridProps}
-    />
+    <div className="flex flex-col h-full">
+      <TradesTable
+        rowData={data}
+        onClick={(price?: string) => {
+          update(marketId, { price });
+        }}
+        onFilterChanged={(event) => {
+          onRowDataUpdated(event);
+          onFilterChanged(event);
+        }}
+        onRowDataUpdated={onRowDataUpdated}
+        overlayNoRowsTemplate={error ? error.message : t('No trades')}
+        {...props}
+      />
+      <div className="flex justify-between border-t border-default p-1 items-center">
+        <div className="text-xs">
+          {t(
+            'Depending on data node retention you may not be able see the "full" history'
+          )}
+        </div>
+        <div className="flex text-xs items-center">
+          {data?.length && !pageInfo?.hasNextPage
+            ? t('all %s items loaded', [data.length.toString()])
+            : t('%s items loaded', [
+                data?.length ? data.length.toString() : ' ',
+              ])}
+          {pageInfo?.hasNextPage ? (
+            <Button size="extra-small" className="ml-1" onClick={() => load()}>
+              {t('Load more')}
+            </Button>
+          ) : null}
+        </div>
+        {data?.length && hasFilteredRows === false ? (
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
+            {t('No trades matching selected filters')}
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 };

--- a/libs/trades/src/lib/trades-manager.tsx
+++ b/libs/trades/src/lib/trades-manager.tsx
@@ -23,13 +23,13 @@ export const TradesManager = ({
     dataProvider: tradesWithMarketProvider,
     variables: { marketId },
   });
-  const [displayedRowCount, setDisplayedRowCount] = useState<
-    number | undefined
-  >(undefined);
+  const [hasDisplayedRow, setHasDisplayedRow] = useState<boolean | undefined>(
+    undefined
+  );
   const { onFilterChanged, ...props } = gridProps || {};
   const onRowDataUpdated = useCallback(
     ({ api }: { api: AgGridReact['api'] }) => {
-      setDisplayedRowCount(api.getDisplayedRowCount());
+      setHasDisplayedRow(!!api.getDisplayedRowCount());
     },
     []
   );
@@ -67,7 +67,7 @@ export const TradesManager = ({
             </Button>
           ) : null}
         </div>
-        {data?.length && displayedRowCount === 0 ? (
+        {data?.length && hasDisplayedRow === false ? (
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
             {t('No trades matching selected filters')}
           </div>

--- a/libs/trades/src/lib/trades-manager.tsx
+++ b/libs/trades/src/lib/trades-manager.tsx
@@ -23,21 +23,13 @@ export const TradesManager = ({
     dataProvider: tradesWithMarketProvider,
     variables: { marketId },
   });
-  const [hasFilteredRows, setHasFilteredRowsCount] = useState<
-    boolean | undefined
+  const [displayedRowCount, setDisplayedRowCount] = useState<
+    number | undefined
   >(undefined);
-  const { onFilterChanged, ...props } = gridProps;
+  const { onFilterChanged, ...props } = gridProps || {};
   const onRowDataUpdated = useCallback(
     ({ api }: { api: AgGridReact['api'] }) => {
-      let hasFilteredRows = false;
-      try {
-        api.forEachNodeAfterFilter(() => {
-          throw new Error();
-        });
-      } catch (e) {
-        hasFilteredRows = true;
-      }
-      setHasFilteredRowsCount(hasFilteredRows);
+      setDisplayedRowCount(api.getDisplayedRowCount());
     },
     []
   );
@@ -75,7 +67,7 @@ export const TradesManager = ({
             </Button>
           ) : null}
         </div>
-        {data?.length && hasFilteredRows === false ? (
+        {data?.length && displayedRowCount === 0 ? (
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-xs">
             {t('No trades matching selected filters')}
           </div>


### PR DESCRIPTION
# Related issues 🔗

Closes #4898, #5086

# Description ℹ️

Add option to load another page of trades and orders. Inform how many items where loaded. Make it clear that results are limited by filters applied.

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/365256c2-6437-4d4c-8ec8-f63af44eff48)

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/47306398-c3a4-4e0c-8688-aa0e56440c52)


