### PR TITLE
fix(governance): remove restricted route from navigation

### DIFF
--- a/apps/governance/src/routes/routes.ts
+++ b/apps/governance/src/routes/routes.ts
@@ -34,10 +34,6 @@ export const TOP_LEVEL_ROUTES = [
     name: 'Rewards',
     path: Routes.REWARDS,
   },
-  {
-    name: 'Restricted',
-    path: Routes.RESTRICTED,
-  },
 ];
 
 export const TOKEN_DROPDOWN_ROUTES = [


### PR DESCRIPTION
# Description ℹ️
When the `/restricted` route got added, it was also added to the top navigation. It doesn't need to be there.

# Demo 📺

