### PR TITLE
fix(trading): quote base unit for size

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -273,7 +273,7 @@ export const DealTicket = ({
 
   const assetSymbol = getAsset(market).symbol;
 
-  const assetUnit = getBaseQuoteUnit(
+  const baseQuote = getBaseQuoteUnit(
     market.tradableInstrument.instrument.metadata.tags
   );
 
@@ -414,7 +414,7 @@ export const DealTicket = ({
                 id="order-size"
                 className="w-full"
                 type="number"
-                appendElement={assetUnit && <Pill size="xs">{assetUnit}</Pill>}
+                appendElement={baseQuote && <Pill size="xs">{baseQuote}</Pill>}
                 step={sizeStep}
                 min={sizeStep}
                 data-testid="order-size"
@@ -670,7 +670,7 @@ export const DealTicket = ({
         subLabel={`${formatValue(
           normalizedOrder.size,
           market.positionDecimalPlaces
-        )} ${assetUnit} @ ${
+        )} ${baseQuote} @ ${
           type === Schema.OrderType.TYPE_MARKET
             ? 'market'
             : `${formatValue(

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -273,7 +273,9 @@ export const DealTicket = ({
 
   const assetSymbol = getAsset(market).symbol;
 
-  const assetUnit = getQuoteName(market);
+  const assetUnit = getBaseQuoteUnit(
+    market.tradableInstrument.instrument.metadata.tags
+  );
 
   const summaryError = useMemo(() => {
     if (!pubKey) {


### PR DESCRIPTION
# Related issues 🔗

Closes #5048 

# Description ℹ️

The size should be in quote base unit coming from tags

# Demo 📺

Fix: 
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/92f3f6d9-0a85-43de-a8d6-ebc53167259e)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
