### PR TITLE
fix(ui-toolkit): sparkline appearing to go up when the price moved down

### DIFF
--- a/libs/ui-toolkit/src/components/sparkline/sparkline.stories.tsx
+++ b/libs/ui-toolkit/src/components/sparkline/sparkline.stories.tsx
@@ -72,7 +72,7 @@ LessThan24HoursIncrease.args = {
 
 export const LessThan24HoursDecrease = Template.bind({});
 LessThan24HoursDecrease.args = {
-  data: [20, 21, 22, 23, 24, 6, 7, 9, 11, 13, 11, 9],
+  data: [20990000, 20939973, 20980130],
   width: 110,
   height: 30,
 };

--- a/libs/ui-toolkit/src/components/sparkline/sparkline.tsx
+++ b/libs/ui-toolkit/src/components/sparkline/sparkline.tsx
@@ -44,14 +44,12 @@ export const SparklineView = ({
     return null;
   }
 
-  const midValue = (min + max) / 2;
-
   // Market may be less than 24hr old so padd the data array
   // with values that is the mid value (avg of min and max).
   // This will rendera  horizontal line until the real data shifts the line
-  const padCount = data.length < points ? points - data.length : 0;
-  const padArr = new Array(padCount).fill(midValue);
   const trimmedData = data.slice(-points);
+  const padCount = data.length < points ? points - data.length : 0;
+  const padArr = new Array(padCount).fill(trimmedData[0]);
 
   // Get the last 24 values if data has more than needed
   const lineData: [number, number][] = [...padArr, ...trimmedData].map(


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Fixes an edge case where the sparkline can appear to go up even if there is a price decrease, when the market is less than 24h old. This was happening because we were padding the sparkline values with average value instead of using the first value in the data set