### PR TITLE
fix(trading): referrals next tier tiles

### DIFF
--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -27,6 +27,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { useCurrentEpochInfoQuery } from './hooks/__generated__/Epoch';
 import BigNumber from 'bignumber.js';
 import { t } from '@vegaprotocol/i18n';
+import maxBy from 'lodash/maxBy';
 
 export const ReferralStatistics = () => {
   const { pubKey } = useVegaWallet();
@@ -102,9 +103,9 @@ export const Statistics = ({
       !isNaN(t.discountFactor) &&
       t.discountFactor === discountFactorValue
   );
-  const nextBenefitTierValue =
-    currentBenefitTierValue &&
-    benefitTiers.find((t) => t.tier === currentBenefitTierValue.tier - 1);
+  const nextBenefitTierValue = currentBenefitTierValue
+    ? benefitTiers.find((t) => t.tier === currentBenefitTierValue.tier - 1)
+    : maxBy(benefitTiers, (bt) => bt.tier); // max tier number is lowest tier
   const epochsValue =
     !isNaN(currentEpoch) && refereeInfo?.atEpoch
       ? currentEpoch - refereeInfo?.atEpoch
@@ -189,7 +190,7 @@ export const Statistics = ({
 
   const currentBenefitTierTile = (
     <StatTile title={t('Current tier')}>
-      {currentBenefitTierValue?.tier || '-'}
+      {currentBenefitTierValue?.tier || 'None'}
     </StatTile>
   );
   const discountFactorTile = (
@@ -204,14 +205,24 @@ export const Statistics = ({
     <StatTile title={t('Epochs in set')}>{epochsValue}</StatTile>
   );
   const nextTierVolumeTile = (
-    <StatTile title={t('Volume to next tier')}>
+    <StatTile
+      title={t(
+        'Volume to next tier %s',
+        nextBenefitTierValue?.tier ? `(${nextBenefitTierValue.tier})` : ''
+      )}
+    >
       {nextBenefitTierVolumeValue <= 0
         ? '0'
         : compactNumFormat.format(nextBenefitTierVolumeValue)}
     </StatTile>
   );
   const nextTierEpochsTile = (
-    <StatTile title={t('Epochs to next tier')}>
+    <StatTile
+      title={t(
+        'Epochs to next tier %s',
+        nextBenefitTierValue?.tier ? `(${nextBenefitTierValue.tier})` : ''
+      )}
+    >
       {nextBenefitTierEpochsValue <= 0 ? '0' : nextBenefitTierEpochsValue}
     </StatTile>
   );


### PR DESCRIPTION
# Related issues 🔗

Closes #5140 

# Description ℹ️

* adds handling for next tier when there's no current tier
* adds next tier number in tiles
* replaces '-' with 'None'

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/a6bcaab1-3bf8-432b-bb3e-8f35fac775c3)

# Technical 👨‍🔧

N/A
