### PR TITLE
feat(trading): liquidity provision current and pending on update

### DIFF
--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -39,9 +39,14 @@ export const liquidityProvisionsDataProvider = makeDataProvider<
       ?.filter((n) => !!n)
       .map((e) => {
         let node;
-        if (!e?.node.pending) {
+        if (!e?.node.pending && e?.node.current) {
           node = {
             ...e?.node.current,
+            ...responseData.market?.liquiditySLAParameters,
+          };
+        } else if (!e?.node.current && e?.node.pending) {
+          node = {
+            ...e?.node.pending,
             ...responseData.market?.liquiditySLAParameters,
           };
         } else {
@@ -49,7 +54,6 @@ export const liquidityProvisionsDataProvider = makeDataProvider<
             ...e?.node.pending,
             currentCommitmentAmount: e?.node.current.commitmentAmount,
             currentFee: e?.node.current.fee,
-            status: Schema.LiquidityProvisionStatus.STATUS_PENDING,
             ...responseData.market?.liquiditySLAParameters,
           };
         }

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -21,7 +21,10 @@ import type {
 } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
-  Schema.LiquiditySLAParameters;
+  Schema.LiquiditySLAParameters & {
+    currentCommitmentAmount?: string;
+    currentFee?: string;
+  };
 
 export const liquidityProvisionsDataProvider = makeDataProvider<
   LiquidityProvisionsQuery,
@@ -34,10 +37,24 @@ export const liquidityProvisionsDataProvider = makeDataProvider<
   getData: (responseData: LiquidityProvisionsQuery | null) => {
     return (responseData?.market?.liquidityProvisions?.edges
       ?.filter((n) => !!n)
-      .map((e) => ({
-        ...e?.node.current,
-        ...responseData.market?.liquiditySLAParameters,
-      })) ?? []) as LiquidityProvisionFields[];
+      .map((e) => {
+        let node;
+        if (!e?.node.pending) {
+          node = {
+            ...e?.node.current,
+            ...responseData.market?.liquiditySLAParameters,
+          };
+        } else {
+          node = {
+            ...e?.node.pending,
+            currentCommitmentAmount: e?.node.current.commitmentAmount,
+            currentFee: e?.node.current.fee,
+            status: Schema.LiquidityProvisionStatus.STATUS_PENDING,
+            ...responseData.market?.liquiditySLAParameters,
+          };
+        }
+        return node;
+      }) ?? []) as LiquidityProvisionFields[];
   },
 });
 
@@ -91,7 +108,8 @@ export const matchFilter = (filter: Filter, lp: LiquidityProvisionData) => {
   }
   if (
     filter.active === true &&
-    lp.status !== Schema.LiquidityProvisionStatus.STATUS_ACTIVE
+    lp.status !== Schema.LiquidityProvisionStatus.STATUS_ACTIVE &&
+    lp.status !== Schema.LiquidityProvisionStatus.STATUS_PENDING
   ) {
     return false;
   }
@@ -105,7 +123,7 @@ export const matchFilter = (filter: Filter, lp: LiquidityProvisionData) => {
 };
 
 export interface LiquidityProvisionData
-  extends Omit<LiquidityProvisionFieldsFragment, '__typename'>,
+  extends Omit<LiquidityProvisionFields, '__typename'>,
     Partial<LiquidityProviderFieldsFragment>,
     Omit<Schema.LiquiditySLAParameters, '__typename'> {
   assetDecimalPlaces?: number;
@@ -113,11 +131,12 @@ export interface LiquidityProvisionData
   averageEntryValuation?: string;
   equityLikeShare?: string;
   earmarkedFees?: number;
+  status: Schema.LiquidityProvisionStatus;
 }
 
 export const getLiquidityProvision = (
   liquidityProvisions: LiquidityProvisionFields[],
-  liquidityProvider: LiquidityProviderFieldsFragment[],
+  liquidityProviders: LiquidityProviderFieldsFragment[],
   filter?: Filter
 ): LiquidityProvisionData[] => {
   return liquidityProvisions
@@ -136,12 +155,14 @@ export const getLiquidityProvision = (
       }
       return true;
     })
-    .map((lp) => {
-      const lpObj = liquidityProvider.find((f) => lp.party.id === f.partyId);
-      if (!lpObj) return lp;
-      const accounts = compact(lp.party.accountsConnection?.edges).map(
-        (e) => e.node
+    .map((liquidityProvision) => {
+      const liquidityProvider = liquidityProviders.find(
+        (f) => liquidityProvision.party.id === f.partyId
       );
+      if (!liquidityProvider) return liquidityProvision;
+      const accounts = compact(
+        liquidityProvision.party.accountsConnection?.edges
+      ).map((e) => e.node);
       const bondAccounts = accounts?.filter(
         (a) => a?.type === Schema.AccountType.ACCOUNT_TYPE_BOND
       );
@@ -164,8 +185,8 @@ export const getLiquidityProvision = (
           )
           .toNumber() ?? 0;
       return {
-        ...lp,
-        ...lpObj,
+        ...liquidityProvision,
+        ...liquidityProvider,
         balance,
         earmarkedFees,
         __typename: undefined,

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -197,7 +197,7 @@ export const LiquidityTable = ({
               LiquidityProvisionData,
               'commitmentAmount'
             >) => {
-              if (!value || !data?.currentCommitmentAmount) return '-';
+              if (!value) return '-';
               const formattedCommitmentAmount = addDecimalsFormatNumberQuantum(
                 value,
                 assetDecimalPlaces ?? 0,

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -203,7 +203,10 @@ export const LiquidityTable = ({
                 assetDecimalPlaces ?? 0,
                 quantum ?? 0
               );
-              if (data?.currentCommitmentAmount) {
+              if (
+                data?.currentCommitmentAmount &&
+                data?.currentCommitmentAmount !== value
+              ) {
                 return `${addDecimalsFormatNumberQuantum(
                   data.currentCommitmentAmount,
                   assetDecimalPlaces ?? 0,
@@ -240,7 +243,7 @@ export const LiquidityTable = ({
               const formattedValue =
                 formatNumberPercentage(new BigNumber(value).times(100), 2) ||
                 '-';
-              if (data?.currentFee) {
+              if (data?.currentFee && data?.currentFee !== value) {
                 return `${formatNumberPercentage(
                   new BigNumber(data.currentFee).times(100),
                   2

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -6,7 +6,10 @@ import {
   getDateTimeFormat,
 } from '@vegaprotocol/utils';
 import { t } from '@vegaprotocol/i18n';
-import type { TypedDataAgGrid } from '@vegaprotocol/datagrid';
+import type {
+  TypedDataAgGrid,
+  VegaValueFormatterParams,
+} from '@vegaprotocol/datagrid';
 import { AgGrid } from '@vegaprotocol/datagrid';
 import {
   CopyWithTooltip,
@@ -22,7 +25,7 @@ import type {
   ValueFormatterParams,
 } from 'ag-grid-community';
 import BigNumber from 'bignumber.js';
-import type { LiquidityProvisionStatus } from '@vegaprotocol/types';
+import { LiquidityProvisionStatus } from '@vegaprotocol/types';
 import { LiquidityProvisionStatusMapping } from '@vegaprotocol/types';
 import type { LiquidityProvisionData } from './liquidity-data-provider';
 
@@ -187,7 +190,29 @@ export const LiquidityTable = ({
             headerTooltip: t(
               'The amount committed to the market by this liquidity provider.'
             ),
-            valueFormatter: assetDecimalsQuantumFormatter,
+            valueFormatter: ({
+              data,
+              value,
+            }: VegaValueFormatterParams<
+              LiquidityProvisionData,
+              'commitmentAmount'
+            >) => {
+              if (!value || !data?.currentCommitmentAmount) return '-';
+              const formattedCommitmentAmount = addDecimalsFormatNumberQuantum(
+                value,
+                assetDecimalPlaces ?? 0,
+                quantum ?? 0
+              );
+              if (data?.currentCommitmentAmount) {
+                return `${addDecimalsFormatNumberQuantum(
+                  data.currentCommitmentAmount,
+                  assetDecimalPlaces ?? 0,
+                  quantum ?? 0
+                )}/${formattedCommitmentAmount}`;
+              } else {
+                return formattedCommitmentAmount;
+              }
+            },
             tooltipValueGetter: assetDecimalsFormatter,
           },
           {
@@ -207,7 +232,22 @@ export const LiquidityTable = ({
             ),
             field: 'fee',
             type: 'rightAligned',
-            valueFormatter: percentageFormatter,
+            valueFormatter: ({
+              data,
+              value,
+            }: ValueFormatterParams<LiquidityProvisionData, 'fee'>) => {
+              if (!value) return '-';
+              const formattedValue =
+                formatNumberPercentage(new BigNumber(value).times(100), 2) ||
+                '-';
+              if (data?.currentFee) {
+                return `${formatNumberPercentage(
+                  new BigNumber(data.currentFee).times(100),
+                  2
+                )}/${formattedValue}`;
+              }
+              return formattedValue;
+            },
           },
           {
             headerName: t('Adjusted stake share'),
@@ -328,8 +368,17 @@ export const LiquidityTable = ({
             headerName: t('Status'),
             headerTooltip: t('The current status of this liquidity provision.'),
             field: 'status',
-            valueFormatter: ({ value }) => {
+            valueFormatter: ({
+              data,
+              value,
+            }: ValueFormatterParams<LiquidityProvisionData, 'status'>) => {
               if (!value) return value;
+              if (
+                data?.status === LiquidityProvisionStatus.STATUS_PENDING &&
+                (data?.currentCommitmentAmount || data?.currentFee)
+              ) {
+                return t('Update pending');
+              }
               return LiquidityProvisionStatusMapping[
                 value as LiquidityProvisionStatus
               ];

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -380,7 +380,7 @@ export const LiquidityTable = ({
                 data?.status === LiquidityProvisionStatus.STATUS_PENDING &&
                 (data?.currentCommitmentAmount || data?.currentFee)
               ) {
-                return t('Update pending');
+                return t('Updating next epoch');
               }
               return LiquidityProvisionStatusMapping[
                 value as LiquidityProvisionStatus


### PR DESCRIPTION
# Related issues 🔗

Closes #5031

# Description ℹ️

[Ensure market LP view can handle Core API changes to liquidity provision status](https://github.com/vegaprotocol/frontend-monorepo/issues/5031)

- [x] if a node has both `current` and `pending` entries then show `old-value/new-value` and `Update pending` status

# Demo 📺

<img width="1680" alt="Screenshot 2023-10-30 at 15 49 45" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/35828d7d-91f5-4788-b1d8-f8cf3daadf68">
<img width="1680" alt="Screenshot 2023-10-30 at 15 49 52" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/3c95955c-0db5-4e1a-8249-51203e610214">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
