### PR TITLE
chore(trading): referrals stats tweaks

### DIFF
--- a/apps/trading/client-pages/referrals/hooks/use-referral.ts
+++ b/apps/trading/client-pages/referrals/hooks/use-referral.ts
@@ -71,7 +71,7 @@ export const useReferral = (args: UseReferralArgs) => {
     variables: {
       code: referralSet?.id as string,
       aggregationEpochs:
-        args.aggregationEpochs != null
+        args.aggregationEpochs !== null
           ? args.aggregationEpochs
           : DEFAULT_AGGREGATION_DAYS,
     },

--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -233,7 +233,12 @@ export const Statistics = ({
     <StatTile title={t('Discount')}>{discountFactorValue * 100}%</StatTile>
   );
   const runningVolumeTile = (
-    <StatTile title={t('Combined volume')}>
+    <StatTile
+      title={t(
+        'Combined volume (last %s epochs)',
+        details?.windowLength.toString()
+      )}
+    >
       {compactNumFormat.format(runningVolumeValue)}
     </StatTile>
   );
@@ -241,24 +246,14 @@ export const Statistics = ({
     <StatTile title={t('Epochs in set')}>{epochsValue}</StatTile>
   );
   const nextTierVolumeTile = (
-    <StatTile
-      title={t(
-        'Volume to next tier %s',
-        nextBenefitTierValue?.tier ? `(${nextBenefitTierValue.tier})` : ''
-      )}
-    >
+    <StatTile title={t('Volume to next tier')}>
       {nextBenefitTierVolumeValue <= 0
         ? '0'
         : compactNumFormat.format(nextBenefitTierVolumeValue)}
     </StatTile>
   );
   const nextTierEpochsTile = (
-    <StatTile
-      title={t(
-        'Epochs to next tier %s',
-        nextBenefitTierValue?.tier ? `(${nextBenefitTierValue.tier})` : ''
-      )}
-    >
+    <StatTile title={t('Epochs to next tier')}>
       {nextBenefitTierEpochsValue <= 0 ? '0' : nextBenefitTierEpochsValue}
     </StatTile>
   );

--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -3,6 +3,8 @@ import {
   VegaIcon,
   VegaIconNames,
   truncateMiddle,
+  ExternalLink,
+  Tooltip,
 } from '@vegaprotocol/ui-toolkit';
 
 import { useVegaWallet } from '@vegaprotocol/wallet';
@@ -28,6 +30,7 @@ import { useCurrentEpochInfoQuery } from './hooks/__generated__/Epoch';
 import BigNumber from 'bignumber.js';
 import { t } from '@vegaprotocol/i18n';
 import maxBy from 'lodash/maxBy';
+import { DocsLinks } from '@vegaprotocol/environment';
 
 export const ReferralStatistics = () => {
   const { pubKey } = useVegaWallet();
@@ -201,7 +204,7 @@ export const Statistics = ({
         'Total commission (last %s epochs)',
         (details?.windowLength || DEFAULT_AGGREGATION_DAYS).toString()
       )}
-      description={t('(qUSD)')}
+      description={<QUSDTooltip />}
     >
       {getNumberFormat(0).format(Number(totalCommissionValue))}
     </StatTile>
@@ -334,11 +337,10 @@ export const Statistics = ({
                 },
                 {
                   name: 'commission',
-                  displayName: t(
-                    'Commission earned (last %s epochs)',
-                    (
-                      details?.windowLength || DEFAULT_AGGREGATION_DAYS
-                    ).toString()
+                  displayName: (
+                    <>
+                      {t('Commission earned')} <QUSDTooltip />
+                    </>
                   ),
                 },
               ]}
@@ -368,3 +370,25 @@ export const Statistics = ({
     </>
   );
 };
+
+export const QUSDTooltip = () => (
+  <Tooltip
+    description={
+      <>
+        <p className="mb-1">
+          {t(
+            'qUSD provides a rough USD equivalent of balances across all assets using the value of "Quantum" for that asset'
+          )}
+        </p>
+        {DocsLinks && (
+          <ExternalLink href={DocsLinks.QUANTUM}>
+            {t('Find out more')}
+          </ExternalLink>
+        )}
+      </>
+    }
+    underline={true}
+  >
+    <span>{t('(qUSD)')}</span>
+  </Tooltip>
+);

--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -339,7 +339,13 @@ export const Statistics = ({
                   name: 'commission',
                   displayName: (
                     <>
-                      {t('Commission earned')} <QUSDTooltip />
+                      {t('Commission earned in')} <QUSDTooltip />{' '}
+                      {t(
+                        '(last %s epochs)',
+                        (
+                          details?.windowLength || DEFAULT_AGGREGATION_DAYS
+                        ).toString()
+                      )}
                     </>
                   ),
                 },
@@ -389,6 +395,6 @@ export const QUSDTooltip = () => (
     }
     underline={true}
   >
-    <span>{t('(qUSD)')}</span>
+    <span>{t('qUSD')}</span>
   </Tooltip>
 );

--- a/apps/trading/client-pages/referrals/table.tsx
+++ b/apps/trading/client-pages/referrals/table.tsx
@@ -1,10 +1,10 @@
 import { Tooltip, VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 import classNames from 'classnames';
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, type ReactNode, type HTMLAttributes } from 'react';
 import { BORDER_COLOR, GRADIENT } from './constants';
 
 type TableColumnDefinition = {
-  displayName?: string;
+  displayName?: ReactNode;
   name: string;
   tooltip?: string;
   className?: string;
@@ -46,7 +46,7 @@ export const Table = forwardRef<
                 INNER_BORDER_STYLE
               )}
             >
-              <span className="flex flex-row gap-2 items-center">
+              <span className="flex flex-row items-center gap-2">
                 <span>{displayName}</span>
                 {tooltip ? (
                   <Tooltip description={tooltip}>
@@ -108,7 +108,7 @@ export const Table = forwardRef<
                     displayName.length > 0 && (
                       <span
                         aria-hidden
-                        className="md:hidden  font-mono text-xs px-0 text-vega-clight-100 dark:text-vega-cdark-100"
+                        className="px-0 font-mono text-xs md:hidden text-vega-clight-100 dark:text-vega-cdark-100"
                       >
                         {displayName}
                       </span>

--- a/apps/trading/client-pages/referrals/table.tsx
+++ b/apps/trading/client-pages/referrals/table.tsx
@@ -102,17 +102,14 @@ export const Table = forwardRef<
                   key={`${i}-${name}`}
                 >
                   {/** display column name in mobile view */}
-                  {!noCollapse &&
-                    !noHeader &&
-                    displayName &&
-                    displayName.length > 0 && (
-                      <span
-                        aria-hidden
-                        className="px-0 font-mono text-xs md:hidden text-vega-clight-100 dark:text-vega-cdark-100"
-                      >
-                        {displayName}
-                      </span>
-                    )}
+                  {!noCollapse && !noHeader && displayName && (
+                    <span
+                      aria-hidden
+                      className="px-0 font-mono text-xs md:hidden text-vega-clight-100 dark:text-vega-cdark-100"
+                    >
+                      {displayName}
+                    </span>
+                  )}
                   <span>{d[name]}</span>
                 </td>
               ))}

--- a/apps/trading/client-pages/referrals/tile.tsx
+++ b/apps/trading/client-pages/referrals/tile.tsx
@@ -29,7 +29,7 @@ export const Tile = ({
 
 type StatTileProps = {
   title: string;
-  description?: string;
+  description?: ReactNode;
   children?: ReactNode;
 };
 export const StatTile = ({ title, description, children }: StatTileProps) => {
@@ -67,11 +67,11 @@ export const CodeTile = ({
       title={t('Your referral code')}
       description={createdAt ? t('(Created at: %s)', createdAt) : undefined}
     >
-      <div className="flex gap-2 items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <Tooltip
           description={
             <div className="break-all">
-              <span className="text-xl bg-rainbow bg-clip-text text-transparent">
+              <span className="text-xl text-transparent bg-rainbow bg-clip-text">
                 {code}
               </span>
             </div>

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -84,6 +84,7 @@ export const DocsLinks = VEGA_DOCS_URL
       ETH_DATA_SOURCES: `${VEGA_DOCS_URL}/concepts/trading-on-vega/data-sources#ethereum-data-sources`,
       ICEBERG_ORDERS: `${VEGA_DOCS_URL}/concepts/trading-on-vega/orders#iceberg-order`,
       POST_REDUCE_ONLY: `${VEGA_DOCS_URL}/concepts/trading-on-vega/orders#conditional-order-parameters`,
+      QUANTUM: `${VEGA_DOCS_URL}/concepts/assets/asset-framework#quantum`,
     }
   : undefined;
 


### PR DESCRIPTION
# Related issues 🔗

Partially addresses #5155 

# Description ℹ️

- Removes next tier indicators
- Show windowLength value for combined set volume on referee view
- Adds tooltips for qUSD

# Technical 👨‍🔧

TODO:
- [ ] Add additional query to get referral set stats for last 30 epochs so we can display total comission from the last 30 epochs rather than the last 3 (other values should still use last 3 epochs) 
