### PR TITLE
chore(trading): ignore .next from lint

### DIFF
--- a/apps/trading/.eslintrc.json
+++ b/apps/trading/.eslintrc.json
@@ -5,7 +5,7 @@
     "next",
     "next/core-web-vitals"
   ],
-  "ignorePatterns": ["!**/*", "__generated__"],
+  "ignorePatterns": ["!**/*", "__generated__", ".next"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Fixes linting of unnecessary build files