### PR TITLE
fix(trading): pagination limit for candles

### DIFF
--- a/libs/candles-chart/src/lib/Candles.graphql
+++ b/libs/candles-chart/src/lib/Candles.graphql
@@ -20,7 +20,11 @@ query Candles($marketId: ID!, $interval: Interval!, $since: String!) {
         code
       }
     }
-    candlesConnection(interval: $interval, since: $since) {
+    candlesConnection(
+      interval: $interval
+      since: $since
+      pagination: { last: 1000 }
+    ) {
       edges {
         node {
           ...CandleFields

--- a/libs/candles-chart/src/lib/Candles.graphql
+++ b/libs/candles-chart/src/lib/Candles.graphql
@@ -23,7 +23,7 @@ query Candles($marketId: ID!, $interval: Interval!, $since: String!) {
     candlesConnection(
       interval: $interval
       since: $since
-      pagination: { last: 1000 }
+      pagination: { last: 5000 }
     ) {
       edges {
         node {

--- a/libs/candles-chart/src/lib/__generated__/Candles.ts
+++ b/libs/candles-chart/src/lib/__generated__/Candles.ts
@@ -46,7 +46,7 @@ export const CandlesDocument = gql`
         code
       }
     }
-    candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
+    candlesConnection(interval: $interval, since: $since, pagination: {last: 5000}) {
       edges {
         node {
           ...CandleFields

--- a/libs/candles-chart/src/lib/__generated__/Candles.ts
+++ b/libs/candles-chart/src/lib/__generated__/Candles.ts
@@ -46,7 +46,7 @@ export const CandlesDocument = gql`
         code
       }
     }
-    candlesConnection(interval: $interval, since: $since) {
+    candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
       edges {
         node {
           ...CandleFields

--- a/libs/markets/src/lib/__generated__/market-candles.ts
+++ b/libs/markets/src/lib/__generated__/market-candles.ts
@@ -37,7 +37,7 @@ export const MarketCandlesDocument = gql`
   marketsConnection(id: $marketId) {
     edges {
       node {
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/__generated__/markets-candles.ts
+++ b/libs/markets/src/lib/__generated__/markets-candles.ts
@@ -19,7 +19,7 @@ export const MarketsCandlesDocument = gql`
     edges {
       node {
         id
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/market-candles.graphql
+++ b/libs/markets/src/lib/market-candles.graphql
@@ -11,7 +11,11 @@ query MarketCandles($interval: Interval!, $since: String!, $marketId: ID!) {
   marketsConnection(id: $marketId) {
     edges {
       node {
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(
+          interval: $interval
+          since: $since
+          pagination: { last: 1000 }
+        ) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/markets-candles.graphql
+++ b/libs/markets/src/lib/markets-candles.graphql
@@ -12,7 +12,11 @@ query MarketsCandles($interval: Interval!, $since: String!) {
     edges {
       node {
         id
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(
+          interval: $interval
+          since: $since
+          pagination: { last: 1000 }
+        ) {
           edges {
             node {
               ...MarketCandlesFields


### PR DESCRIPTION
# Related issues 🔗

Closes #5168

# Description ℹ️

By adding `{ pagination: { last: 1000}` to the query we're able to get the latest candles. 

# Demo 📺

After: 

<img width="1680" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/195781ef-f2c9-4f39-a549-12d9e8f89a8d">


Before: 

<img width="1680" alt="Screenshot 2023-11-01 at 14 37 42" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/71d554d4-46a3-4945-a778-411b4973eb7f">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
