### PR TITLE
fix(deal-ticket): fees breakdown rendering issues

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal-referral-program-details/proposal-referral-program-details.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-referral-program-details/proposal-referral-program-details.spec.tsx
@@ -36,13 +36,13 @@ describe('ProposalReferralProgramDetails helper functions', () => {
   it('should format referral discount factor correctly', () => {
     const input = '0.05';
     const formatted = formatReferralDiscountFactor(input);
-    expect(formatted).toBe('5.00%');
+    expect(formatted).toBe('5%');
   });
 
   it('should format referral reward factor correctly', () => {
     const input = '0.1';
     const formatted = formatReferralRewardFactor(input);
-    expect(formatted).toBe('10.00%');
+    expect(formatted).toBe('10%');
   });
 
   it('should format minimum staked tokens correctly', () => {

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -79,7 +79,7 @@ export const DealTicketFeeDetails = ({
       }
       formattedValue={
         <>
-          {totalDiscountFactor && (
+          {totalDiscountFactor ? (
             <Pill size="xxs" intent={Intent.Warning} className="mr-1">
               -
               {formatNumberPercentage(
@@ -87,7 +87,7 @@ export const DealTicketFeeDetails = ({
                 2
               )}
             </Pill>
-          )}
+          ) : null}
           {totalDiscountedFeeAmount &&
             `~${formatValue(totalDiscountedFeeAmount, assetDecimals, quantum)}`}
         </>

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -93,8 +93,8 @@ export const DealTicketFeeDetails = ({
         </>
       }
       labelDescription={
-        <>
-          <p className="mb-2">
+        <div className="flex flex-col gap-2">
+          <p>
             {t(
               `An estimate of the most you would be expected to pay in fees, in the market's settlement asset ${assetSymbol}. Fees estimated are "taker" fees and will only be payable if the order trades aggressively. Rebate equal to the maker portion will be paid to the trader if the order trades passively.`
             )}
@@ -108,7 +108,7 @@ export const DealTicketFeeDetails = ({
             symbol={assetSymbol}
             decimals={assetDecimals}
           />
-        </>
+        </div>
       }
       symbol={assetSymbol}
     />

--- a/libs/deal-ticket/src/components/fees-breakdown/fees-breakdown.spec.tsx
+++ b/libs/deal-ticket/src/components/fees-breakdown/fees-breakdown.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { FeesBreakdown } from './fees-breakdown';
+
+describe('FeesBreakdown', () => {
+  it('formats fee factors correctly', () => {
+    const feeFactors = {
+      makerFee: '0.00005',
+      infrastructureFee: '0.001',
+      liquidityFee: '0.5',
+    };
+    const fees = {
+      makerFee: '100',
+      infrastructureFee: '100',
+      liquidityFee: '100',
+    };
+    const props = {
+      totalFeeAmount: '100',
+      fees,
+      feeFactors,
+      symbol: 'USD',
+      decimals: 2,
+      referralDiscountFactor: '0.01',
+      volumeDiscountFactor: '0.01',
+    };
+    render(<FeesBreakdown {...props} />);
+    expect(screen.getByText('Maker fee').nextElementSibling).toHaveTextContent(
+      '0.005%'
+    );
+    expect(
+      screen.getByText('Infrastructure fee').nextElementSibling
+    ).toHaveTextContent('0.1%');
+    expect(
+      screen.getByText('Liquidity fee').nextElementSibling
+    ).toHaveTextContent('50%');
+  });
+});

--- a/libs/deal-ticket/src/components/fees-breakdown/fees-breakdown.tsx
+++ b/libs/deal-ticket/src/components/fees-breakdown/fees-breakdown.tsx
@@ -33,7 +33,7 @@ const FeesBreakdownItem = ({
     <dt className="col-span-2">{label}</dt>
     {factor && (
       <dd className="text-right col-span-1">
-        {formatNumberPercentage(new BigNumber(factor).times(100), 2)}
+        {formatNumberPercentage(new BigNumber(factor).times(100))}
       </dd>
     )}
     <dd className="text-right col-span-3">

--- a/libs/markets/src/lib/market-utils.spec.tsx
+++ b/libs/markets/src/lib/market-utils.spec.tsx
@@ -72,10 +72,10 @@ describe('totalFeesFactorsPercentage', () => {
     makerFee: f[2].toString(),
   });
   it.each([
-    { i: createFee(0, 0, 1), o: '100.00%' },
-    { i: createFee(0, 1, 0), o: '100.00%' },
-    { i: createFee(1, 0, 0), o: '100.00%' },
-    { i: createFee(0.01, 0.02, 0.003), o: '3.30%' },
+    { i: createFee(0, 0, 1), o: '100%' },
+    { i: createFee(0, 1, 0), o: '100%' },
+    { i: createFee(1, 0, 0), o: '100%' },
+    { i: createFee(0.01, 0.02, 0.003), o: '3.3%' },
     { i: createFee(0.01, 0.056782, 0.003), o: '6.9782%' },
     { i: createFee(0.01, 0.056782, 0), o: '6.6782%' },
   ])('adds fees correctly', ({ i, o }) => {

--- a/libs/utils/src/lib/format/number.spec.ts
+++ b/libs/utils/src/lib/format/number.spec.ts
@@ -77,8 +77,8 @@ describe('number utils', () => {
     { v: new BigNumber(123.123), d: 3, o: '123.123%' },
     { v: new BigNumber(123.123), d: 6, o: '123.123%' },
     { v: new BigNumber(123.123), d: 0, o: '123%' },
-    { v: new BigNumber(123), d: undefined, o: '123.00%' }, // it default to 2 decimal places
-    { v: new BigNumber(30000), d: undefined, o: '30,000.00%' },
+    { v: new BigNumber(123), d: undefined, o: '123%' }, // it default to 2 decimal places
+    { v: new BigNumber(30000), d: undefined, o: '30,000%' },
     { v: new BigNumber(3.000001), d: undefined, o: '3.000001%' },
   ])('formats given number correctly', ({ v, d, o }) => {
     expect(formatNumberPercentage(v, d)).toStrictEqual(o);

--- a/libs/utils/src/lib/format/number.ts
+++ b/libs/utils/src/lib/format/number.ts
@@ -158,7 +158,7 @@ export const addDecimalsFixedFormatNumber = (
 
 export const formatNumberPercentage = (value: BigNumber, decimals?: number) => {
   const decimalPlaces =
-    typeof decimals === 'undefined' ? Math.max(value.dp() || 0, 2) : decimals;
+    typeof decimals === 'undefined' ? value.dp() || 0 : decimals;
   return `${formatNumber(value, decimalPlaces)}%`;
 };
 


### PR DESCRIPTION
# Related issues 🔗

Addresses #5165 

# Description ℹ️

- Fixes an issue with the rendering logic of the fee total. If the fee total was 0 we were getting the classic react issue where comparing with && on 0 ended up with the 0 being rendered.
- Fixes an issue where were rounding fee factors to 2 dps resulting in inaccurate information

# Demo 📺

N/A
