### PR TITLE
feat(explorer): add timestamp to tx list

### DIFF
--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
@@ -82,7 +82,7 @@ describe('Txs infinite list item', () => {
     expect(screen.getByText('Missing vital data')).toBeInTheDocument();
   });
 
-  it('renders data correctly', () => {
+  it('renders data even with missing time', () => {
     render(
       <MockedProvider>
         <MemoryRouter>
@@ -105,5 +105,33 @@ describe('Txs infinite list item', () => {
     expect(screen.getByTestId('pub-key')).toHaveTextContent('testPubKey');
     expect(screen.getByTestId('tx-type')).toHaveTextContent('testType');
     expect(screen.getByTestId('tx-block')).toHaveTextContent('1');
+    expect(screen.getByTestId('tx-time')).toHaveTextContent('-');
+  });
+
+  it('renders data correctly', () => {
+    render(
+      <MockedProvider>
+        <MemoryRouter>
+          <table>
+            <tbody>
+              <TxsInfiniteListItem
+                type="testType"
+                submitter="testPubKey"
+                hash="testTxHash"
+                block="1"
+                code={0}
+                command={{}}
+                createdAt="1970-11-01T18:07:15Z"
+              />
+            </tbody>
+          </table>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+    expect(screen.getByTestId('tx-hash')).toHaveTextContent('testTxHash');
+    expect(screen.getByTestId('pub-key')).toHaveTextContent('testPubKey');
+    expect(screen.getByTestId('tx-type')).toHaveTextContent('testType');
+    expect(screen.getByTestId('tx-block')).toHaveTextContent('1');
+    expect(screen.getByTestId('tx-time').textContent).toMatch(/years ago/);
   });
 });

--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
@@ -9,6 +9,7 @@ import { PartyLink } from '../links';
 import { useScreenDimensions } from '@vegaprotocol/react-helpers';
 import type { Screen } from '@vegaprotocol/react-helpers';
 import { useMemo } from 'react';
+import { TimeAgo } from '../time-ago';
 
 const DEFAULT_TRUNCATE_LENGTH = 7;
 
@@ -32,6 +33,7 @@ export const TxsInfiniteListItem = ({
   type,
   block,
   command,
+  createdAt,
 }: Partial<BlockExplorerTransactionResult>) => {
   const { screenSize } = useScreenDimensions();
   const idTruncateLength = useMemo(
@@ -84,6 +86,9 @@ export const TxsInfiniteListItem = ({
           startChars={5}
           endChars={5}
         />
+      </td>
+      <td className="text-sm items-center font-mono" data-testid="tx-time">
+        {createdAt ? <TimeAgo date={createdAt} /> : '-'}
       </td>
     </tr>
   );

--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.tsx
@@ -87,9 +87,11 @@ export const TxsInfiniteListItem = ({
           endChars={5}
         />
       </td>
-      <td className="text-sm items-center font-mono" data-testid="tx-time">
-        {createdAt ? <TimeAgo date={createdAt} /> : '-'}
-      </td>
+      {['lg', 'xl', 'xxl', 'xxxl'].includes(screenSize) && (
+        <td className="text-sm items-center font-mono" data-testid="tx-time">
+          {createdAt ? <TimeAgo date={createdAt} /> : '-'}
+        </td>
+      )}
     </tr>
   );
 };

--- a/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
@@ -19,7 +19,16 @@ interface ItemProps {
 }
 
 const Item = ({ tx }: ItemProps) => {
-  const { hash, submitter, type, command, block, code, index: blockIndex } = tx;
+  const {
+    hash,
+    submitter,
+    type,
+    command,
+    block,
+    code,
+    createdAt,
+    index: blockIndex,
+  } = tx;
   return (
     <TxsInfiniteListItem
       type={type}
@@ -29,6 +38,7 @@ const Item = ({ tx }: ItemProps) => {
       hash={hash}
       block={block}
       index={blockIndex}
+      createdAt={createdAt}
     />
   );
 };
@@ -66,6 +76,7 @@ export const TxsInfiniteList = ({
             <th>{t('Type')}</th>
             <th className="text-left">{t('From')}</th>
             <th>{t('Block')}</th>
+            <th>{t('Time')}</th>
           </tr>
         </thead>
         <tbody>

--- a/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
@@ -3,6 +3,7 @@ import { TxsInfiniteListItem } from './txs-infinite-list-item';
 import type { BlockExplorerTransactionResult } from '../../routes/types/block-explorer-response';
 import EmptyList from '../empty-list/empty-list';
 import { Loader } from '@vegaprotocol/ui-toolkit';
+import { useScreenDimensions } from '@vegaprotocol/react-helpers';
 
 interface TxsInfiniteListProps {
   hasMoreTxs: boolean;
@@ -49,6 +50,7 @@ export const TxsInfiniteList = ({
   className,
   hasFilters = false,
 }: TxsInfiniteListProps) => {
+  const { screenSize } = useScreenDimensions();
   if (!txs || txs.length === 0) {
     if (!areTxsLoading) {
       return (
@@ -76,7 +78,9 @@ export const TxsInfiniteList = ({
             <th>{t('Type')}</th>
             <th className="text-left">{t('From')}</th>
             <th>{t('Block')}</th>
-            <th>{t('Time')}</th>
+            {['lg', 'xl', 'xxl', 'xxxl'].includes(screenSize) && (
+              <th>{t('Time')}</th>
+            )}
           </tr>
         </thead>
         <tbody>

--- a/apps/explorer/src/app/routes/types/block-explorer-response.d.ts
+++ b/apps/explorer/src/app/routes/types/block-explorer-response.d.ts
@@ -14,6 +14,10 @@ export interface BlockExplorerTransactionResult {
     value: string;
   };
   error?: string;
+  // These aren't strictly optional but are new in 0.73.0 so we need to make them optional
+  createdAt?: string;
+  version?: string;
+  pow?: string;
 }
 
 export interface BlockExplorerTransactions {


### PR DESCRIPTION
- feat(explorer): add time to tx list
- feat(explorer): tweak appearance of columns for small screens

# Related issues 🔗

Closes #4236

# Description ℹ️

Now it is available in the API, shows a timestamp on the TX list on larger screens. Hidden on smaller screens because it's quite a long string.

# Demo 📺

<img width="1268" alt="Screenshot 2023-11-01 at 18 34 47" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/a35b05f5-e3df-46ef-be10-4470c423c143">

<img width="537" alt="Screenshot 2023-11-01 at 18 34 53" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/7320be47-40d7-4871-8795-ba898ef9b4af">
