### PR TITLE
fix(trading): hide funding tabs if market is not perp

### DIFF
--- a/apps/trading/client-pages/market/trade-panels.tsx
+++ b/apps/trading/client-pages/market/trade-panels.tsx
@@ -82,6 +82,13 @@ export const TradePanels = ({ market, pinnedAsset }: TradePanelsProps) => {
               'bg-vega-clight-500 dark:bg-vega-cdark-500': isActive,
             }
           );
+          if (
+            market?.tradableInstrument.instrument.product.__typename !==
+              'Perpetual' &&
+            (key === 'funding' || key === 'fundingPayments')
+          ) {
+            return null;
+          }
           return (
             <button
               data-testid={key}


### PR DESCRIPTION
# Related issues 🔗

Closes #5166 

# Description ℹ️

Simplest way to hide funding tabs if market is not a perpetual. 

# Demo 📺

<img width="951" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/8ac37305-bead-470e-bca2-35730e33b82c">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
