### PR TITLE
fix(accounts): fix key selection and validation, and add use max to transfers

### DIFF
--- a/libs/accounts/src/lib/transfer-container.tsx
+++ b/libs/accounts/src/lib/transfer-container.tsx
@@ -1,5 +1,5 @@
 import * as Schema from '@vegaprotocol/types';
-import { addDecimal, truncateByChars } from '@vegaprotocol/utils';
+import { truncateByChars } from '@vegaprotocol/utils';
 import { t } from '@vegaprotocol/i18n';
 import {
   NetworkParams,
@@ -12,7 +12,6 @@ import { useVegaWallet } from '@vegaprotocol/wallet';
 import { useCallback } from 'react';
 import { accountsDataProvider } from './accounts-data-provider';
 import { TransferForm } from './transfer-form';
-import sortBy from 'lodash/sortBy';
 import { Lozenge } from '@vegaprotocol/ui-toolkit';
 
 export const ALLOWED_ACCOUNTS = [

--- a/libs/accounts/src/lib/transfer-container.tsx
+++ b/libs/accounts/src/lib/transfer-container.tsx
@@ -42,18 +42,6 @@ export const TransferContainer = ({ assetId }: { assetId?: string }) => {
     ? data.filter((account) => ALLOWED_ACCOUNTS.includes(account.type))
     : [];
 
-  const assets = accounts
-    // Theres only one general account for each asset, this will give us a list
-    // of assets the user has accounts for
-    .filter((a) => a.type === Schema.AccountType.ACCOUNT_TYPE_GENERAL)
-    .map((account) => ({
-      id: account.asset.id,
-      symbol: account.asset.symbol,
-      name: account.asset.name,
-      decimals: account.asset.decimals,
-      balance: addDecimal(account.balance, account.asset.decimals),
-    }));
-
   return (
     <>
       <p className="mb-4 text-sm" data-testid="transfer-intro-text">
@@ -71,7 +59,6 @@ export const TransferContainer = ({ assetId }: { assetId?: string }) => {
       <TransferForm
         pubKey={pubKey}
         pubKeys={pubKeys ? pubKeys?.map((pk) => pk.publicKey) : null}
-        assets={sortBy(assets, 'name')}
         assetId={assetId}
         feeFactor={param}
         submitTransfer={transfer}

--- a/libs/accounts/src/lib/transfer-form.tsx
+++ b/libs/accounts/src/lib/transfer-form.tsx
@@ -75,6 +75,7 @@ export const TransferForm = ({
   } = useForm<FormFields>({
     defaultValues: {
       asset: initialAssetId,
+      toAddress: pubKey || '',
     },
   });
 
@@ -159,29 +160,23 @@ export const TransferForm = ({
       className="text-sm"
       data-testid="transfer-form"
     >
-      <TradingFormGroup label="Vega key" labelFor="toAddress">
+      <TradingFormGroup label="To Vega key" labelFor="toAddress">
         <AddressField
-          pubKeys={pubKeys}
           onChange={() => setValue('toAddress', '')}
           select={
-            <TradingSelect
-              {...register('toAddress')}
-              id="toAddress"
-              defaultValue=""
-            >
+            <TradingSelect {...register('toAddress')} id="toAddress">
               <option value="" disabled={true}>
                 {t('Please select')}
               </option>
-              {pubKeys?.length &&
-                pubKeys.map((pk) => {
-                  const text = pk === pubKey ? t('Current key: ') + pk : pk;
+              {pubKeys?.map((pk) => {
+                const text = pk === pubKey ? t('Current key: ') + pk : pk;
 
-                  return (
-                    <option key={pk} value={pk}>
-                      {text}
-                    </option>
-                  );
-                })}
+                return (
+                  <option key={pk} value={pk}>
+                    {text}
+                  </option>
+                );
+              })}
             </TradingSelect>
           }
           input={
@@ -442,40 +437,31 @@ export const TransferFee = ({
 };
 
 interface AddressInputProps {
-  pubKeys: string[] | null;
   select: ReactNode;
   input: ReactNode;
   onChange: () => void;
 }
 
 export const AddressField = ({
-  pubKeys,
   select,
   input,
   onChange,
 }: AddressInputProps) => {
-  const [isInput, setIsInput] = useState(() => {
-    if (pubKeys && pubKeys.length <= 1) {
-      return true;
-    }
-    return false;
-  });
+  const [isInput, setIsInput] = useState(false);
 
   return (
     <>
       {isInput ? input : select}
-      {pubKeys && pubKeys.length > 1 && (
-        <button
-          type="button"
-          onClick={() => {
-            setIsInput((curr) => !curr);
-            onChange();
-          }}
-          className="absolute top-0 right-0 ml-auto text-xs underline"
-        >
-          {isInput ? t('Select from wallet') : t('Enter manually')}
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => {
+          setIsInput((curr) => !curr);
+          onChange();
+        }}
+        className="absolute top-0 right-0 ml-auto text-xs underline"
+      >
+        {isInput ? t('Select from wallet') : t('Enter manually')}
+      </button>
     </>
   );
 };

--- a/libs/accounts/src/lib/transfer-form.tsx
+++ b/libs/accounts/src/lib/transfer-form.tsx
@@ -28,7 +28,7 @@ import { AssetOption, Balance } from '@vegaprotocol/assets';
 import { AccountType, AccountTypeMapping } from '@vegaprotocol/types';
 
 interface FormFields {
-  toAddress: string;
+  toVegaKey: string;
   asset: string;
   amount: string;
   fromAccount: AccountType;
@@ -75,11 +75,11 @@ export const TransferForm = ({
   } = useForm<FormFields>({
     defaultValues: {
       asset: initialAssetId,
-      toAddress: pubKey || '',
+      toVegaKey: pubKey || '',
     },
   });
 
-  const selectedPubKey = watch('toAddress');
+  const selectedPubKey = watch('toVegaKey');
   const amount = watch('amount');
   const assetId = watch('asset');
   const asset = assets.find((a) => a.id === assetId);
@@ -113,7 +113,7 @@ export const TransferForm = ({
         throw new Error('Submitted transfer with no amount selected');
       }
       const transfer = normalizeTransfer(
-        fields.toAddress,
+        fields.toVegaKey,
         transferAmount,
         fields.fromAccount,
         AccountType.ACCOUNT_TYPE_GENERAL, // field is readonly in the form
@@ -160,11 +160,11 @@ export const TransferForm = ({
       className="text-sm"
       data-testid="transfer-form"
     >
-      <TradingFormGroup label="To Vega key" labelFor="toAddress">
+      <TradingFormGroup label="To Vega key" labelFor="toVegaKey">
         <AddressField
-          onChange={() => setValue('toAddress', '')}
+          onChange={() => setValue('toVegaKey', '')}
           select={
-            <TradingSelect {...register('toAddress')} id="toAddress">
+            <TradingSelect {...register('toVegaKey')} id="toVegaKey">
               <option value="" disabled={true}>
                 {t('Please select')}
               </option>
@@ -183,9 +183,9 @@ export const TransferForm = ({
             <TradingInput
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={true} // focus input immediately after is shown
-              id="toAddress"
+              id="toVegaKey"
               type="text"
-              {...register('toAddress', {
+              {...register('toVegaKey', {
                 validate: {
                   required,
                   vegaPublicKey,
@@ -194,9 +194,9 @@ export const TransferForm = ({
             />
           }
         />
-        {errors.toAddress?.message && (
-          <TradingInputError forInput="toAddress">
-            {errors.toAddress.message}
+        {errors.toVegaKey?.message && (
+          <TradingInputError forInput="toVegaKey">
+            {errors.toVegaKey.message}
           </TradingInputError>
         )}
       </TradingFormGroup>

--- a/libs/accounts/src/lib/transfer-form.tsx
+++ b/libs/accounts/src/lib/transfer-form.tsx
@@ -70,19 +70,6 @@ export const TransferForm = ({
     },
   });
 
-  const selectedPubKey = watch('toVegaKey');
-  const amount = watch('amount');
-  const fromAccount = watch('fromAccount');
-  const assetId = watch('asset');
-
-  const account = accounts.find(
-    (a) => a.asset.id === assetId && a.type === fromAccount
-  );
-  const accountBalance =
-    account && addDecimal(account.balance, account.asset.decimals);
-
-  const asset = account?.asset;
-
   const assets = sortBy(
     accounts
       .filter((a) => a.type === AccountType.ACCOUNT_TYPE_GENERAL)
@@ -92,6 +79,19 @@ export const TransferForm = ({
       })),
     'name'
   );
+
+  const selectedPubKey = watch('toVegaKey');
+  const amount = watch('amount');
+  const fromAccount = watch('fromAccount');
+  const assetId = watch('asset');
+
+  const asset = assets.find((a) => a.id === assetId);
+
+  const account = accounts.find(
+    (a) => a.asset.id === assetId && a.type === fromAccount
+  );
+  const accountBalance =
+    account && addDecimal(account.balance, account.asset.decimals);
 
   // General account for the selected asset
   const generalAccount = accounts.find((a) => {


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Fixes
- Validation for amount was always using the general account. Now the validation will check the currently select 'from account'
- Key selection would default to manual text entry if the user only had one pubkey. Now we always default to using a select dropdown to make same key transfers easier. You can still switch to manual entry if needed

Adds
- Use max button which will set the amount to the maximum of the currently selected from account

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
