### PR TITLE
fix(trading): candles pagination and hide funding tabs

### DIFF
--- a/apps/trading/client-pages/market/trade-panels.tsx
+++ b/apps/trading/client-pages/market/trade-panels.tsx
@@ -82,6 +82,13 @@ export const TradePanels = ({ market, pinnedAsset }: TradePanelsProps) => {
               'bg-vega-clight-500 dark:bg-vega-cdark-500': isActive,
             }
           );
+          if (
+            market?.tradableInstrument.instrument.product.__typename !==
+              'Perpetual' &&
+            (key === 'funding' || key === 'fundingPayments')
+          ) {
+            return null;
+          }
           return (
             <button
               data-testid={key}

--- a/libs/candles-chart/src/lib/Candles.graphql
+++ b/libs/candles-chart/src/lib/Candles.graphql
@@ -20,7 +20,11 @@ query Candles($marketId: ID!, $interval: Interval!, $since: String!) {
         code
       }
     }
-    candlesConnection(interval: $interval, since: $since) {
+    candlesConnection(
+      interval: $interval
+      since: $since
+      pagination: { last: 5000 }
+    ) {
       edges {
         node {
           ...CandleFields

--- a/libs/candles-chart/src/lib/__generated__/Candles.ts
+++ b/libs/candles-chart/src/lib/__generated__/Candles.ts
@@ -46,7 +46,7 @@ export const CandlesDocument = gql`
         code
       }
     }
-    candlesConnection(interval: $interval, since: $since) {
+    candlesConnection(interval: $interval, since: $since, pagination: {last: 5000}) {
       edges {
         node {
           ...CandleFields

--- a/libs/markets/src/lib/__generated__/market-candles.ts
+++ b/libs/markets/src/lib/__generated__/market-candles.ts
@@ -37,7 +37,7 @@ export const MarketCandlesDocument = gql`
   marketsConnection(id: $marketId) {
     edges {
       node {
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/__generated__/markets-candles.ts
+++ b/libs/markets/src/lib/__generated__/markets-candles.ts
@@ -19,7 +19,7 @@ export const MarketsCandlesDocument = gql`
     edges {
       node {
         id
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(interval: $interval, since: $since, pagination: {last: 1000}) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/market-candles.graphql
+++ b/libs/markets/src/lib/market-candles.graphql
@@ -11,7 +11,11 @@ query MarketCandles($interval: Interval!, $since: String!, $marketId: ID!) {
   marketsConnection(id: $marketId) {
     edges {
       node {
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(
+          interval: $interval
+          since: $since
+          pagination: { last: 1000 }
+        ) {
           edges {
             node {
               ...MarketCandlesFields

--- a/libs/markets/src/lib/markets-candles.graphql
+++ b/libs/markets/src/lib/markets-candles.graphql
@@ -12,7 +12,11 @@ query MarketsCandles($interval: Interval!, $since: String!) {
     edges {
       node {
         id
-        candlesConnection(interval: $interval, since: $since) {
+        candlesConnection(
+          interval: $interval
+          since: $since
+          pagination: { last: 1000 }
+        ) {
           edges {
             node {
               ...MarketCandlesFields


### PR DESCRIPTION
# Related issues 🔗

Closes #5166 
Closes #5168 

# Description ℹ️

Fixes candles pagination (shows latest candles) and hides funding tabs if market is not a perp. 

# Demo 📺

<img width="909" alt="Screenshot 2023-11-06 at 10 37 38" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/a4b4660e-ef61-4d68-a61c-345dd490968f">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
