### PR TITLE
feat(trading): close position stopped and IOC behaviour update

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -685,7 +685,7 @@ export const DealTicket = ({
         subLabel={`${formatValue(
           normalizedOrder.size,
           market.positionDecimalPlaces
-        )} ${baseQuote} @ ${
+        )} ${baseQuote || ''} @ ${
           type === Schema.OrderType.TYPE_MARKET
             ? 'market'
             : `${formatValue(

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -148,6 +148,7 @@ export const OrderListManager = ({
               expiresAt: editOrder.expiresAt,
               side: editOrder.side,
               marketId: editOrder.market.id,
+              remaining: editOrder.remaining,
             };
             create({ orderAmendment }, originalOrder);
             setEditOrder(null);

--- a/libs/orders/src/lib/components/order-list/order-list.tsx
+++ b/libs/orders/src/lib/components/order-list/order-list.tsx
@@ -1,4 +1,5 @@
 import {
+  MAXGOINT64,
   addDecimalsFormatNumber,
   getDateTimeFormat,
   isNumeric,
@@ -144,11 +145,22 @@ export const OrderListTable = memo<
               if (!data?.market || !isNumeric(data.size)) {
                 return '-';
               }
+
               const prefix = data
                 ? data.side === Schema.Side.SIDE_BUY
                   ? '+'
                   : '-'
                 : '';
+
+              if (
+                data.size === MAXGOINT64 &&
+                data.timeInForce ===
+                  Schema.OrderTimeInForce.TIME_IN_FORCE_IOC &&
+                data.reduceOnly
+              ) {
+                return t('MAX');
+              }
+
               return (
                 prefix +
                 addDecimalsFormatNumber(

--- a/libs/web3/src/lib/TransactionResult.graphql
+++ b/libs/web3/src/lib/TransactionResult.graphql
@@ -65,6 +65,7 @@ fragment OrderTxUpdateFields on OrderUpdate {
   expiresAt
   side
   marketId
+  remaining
 }
 
 subscription OrderTxUpdate($partyId: ID!) {

--- a/libs/web3/src/lib/__generated__/TransactionResult.ts
+++ b/libs/web3/src/lib/__generated__/TransactionResult.ts
@@ -21,14 +21,14 @@ export type WithdrawalBusEventSubscriptionVariables = Types.Exact<{
 
 export type WithdrawalBusEventSubscription = { __typename?: 'Subscription', busEvents?: Array<{ __typename?: 'BusEvent', event: { __typename?: 'Deposit' } | { __typename?: 'TimeUpdate' } | { __typename?: 'TransactionResult' } | { __typename?: 'Withdrawal', id: string, status: Types.WithdrawalStatus, amount: string, createdTimestamp: any, withdrawnTimestamp?: any | null, txHash?: string | null, pendingOnForeignChain: boolean, asset: { __typename?: 'Asset', id: string, name: string, symbol: string, decimals: number, status: Types.AssetStatus, source: { __typename?: 'BuiltinAsset' } | { __typename?: 'ERC20', contractAddress: string } }, details?: { __typename?: 'Erc20WithdrawalDetails', receiverAddress: string } | null } }> | null };
 
-export type OrderTxUpdateFieldsFragment = { __typename?: 'OrderUpdate', type?: Types.OrderType | null, id: string, status: Types.OrderStatus, rejectionReason?: Types.OrderRejectionReason | null, createdAt: any, size: string, price: string, timeInForce: Types.OrderTimeInForce, expiresAt?: any | null, side: Types.Side, marketId: string };
+export type OrderTxUpdateFieldsFragment = { __typename?: 'OrderUpdate', type?: Types.OrderType | null, id: string, status: Types.OrderStatus, rejectionReason?: Types.OrderRejectionReason | null, createdAt: any, size: string, price: string, timeInForce: Types.OrderTimeInForce, expiresAt?: any | null, side: Types.Side, marketId: string, remaining: string };
 
 export type OrderTxUpdateSubscriptionVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
 
 
-export type OrderTxUpdateSubscription = { __typename?: 'Subscription', orders?: Array<{ __typename?: 'OrderUpdate', type?: Types.OrderType | null, id: string, status: Types.OrderStatus, rejectionReason?: Types.OrderRejectionReason | null, createdAt: any, size: string, price: string, timeInForce: Types.OrderTimeInForce, expiresAt?: any | null, side: Types.Side, marketId: string }> | null };
+export type OrderTxUpdateSubscription = { __typename?: 'Subscription', orders?: Array<{ __typename?: 'OrderUpdate', type?: Types.OrderType | null, id: string, status: Types.OrderStatus, rejectionReason?: Types.OrderRejectionReason | null, createdAt: any, size: string, price: string, timeInForce: Types.OrderTimeInForce, expiresAt?: any | null, side: Types.Side, marketId: string, remaining: string }> | null };
 
 export type DepositBusEventFieldsFragment = { __typename?: 'Deposit', id: string, status: Types.DepositStatus, amount: string, createdTimestamp: any, creditedTimestamp?: any | null, txHash?: string | null, asset: { __typename?: 'Asset', id: string, symbol: string, decimals: number } };
 
@@ -88,6 +88,7 @@ export const OrderTxUpdateFieldsFragmentDoc = gql`
   expiresAt
   side
   marketId
+  remaining
 }
     `;
 export const DepositBusEventFieldsFragmentDoc = gql`

--- a/libs/web3/src/lib/use-vega-transaction-store.spec.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-store.spec.tsx
@@ -56,6 +56,7 @@ describe('useVegaTransactionStore', () => {
     side: Side.SIDE_BUY,
     marketId:
       '3aa2a828687cc3d59e92445d294891cbbd40e2165bbfb15674158ef5d4e8848d',
+    remaining: '12',
   };
 
   const processedTransactionUpdate = {

--- a/libs/web3/src/lib/use-vega-transaction-toasts.spec.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.spec.tsx
@@ -193,6 +193,7 @@ const submitOrder: VegaStoredTxState = {
     createdAt: new Date(),
     marketId: 'market-1',
     status: OrderStatus.STATUS_ACTIVE,
+    remaining: '10',
   },
 };
 
@@ -249,6 +250,7 @@ const editOrder: VegaStoredTxState = {
     createdAt: new Date(),
     marketId: 'market-1',
     status: OrderStatus.STATUS_ACTIVE,
+    remaining: '10',
   },
 };
 
@@ -489,6 +491,7 @@ describe('getRejectionReason', () => {
         timeInForce: Types.OrderTimeInForce.TIME_IN_FORCE_FOK,
         side: Types.Side.SIDE_BUY,
         marketId: '',
+        remaining: '',
       })
     ).toBe('Insufficient asset balance');
   });
@@ -505,6 +508,7 @@ describe('getRejectionReason', () => {
         timeInForce: Types.OrderTimeInForce.TIME_IN_FORCE_FOK,
         side: Types.Side.SIDE_BUY,
         marketId: '',
+        remaining: '',
       })
     ).toBe(
       'Your Fill or Kill (FOK) order was not filled and it has been stopped'

--- a/libs/web3/src/lib/use-vega-transaction-toasts.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.tsx
@@ -586,6 +586,23 @@ export const VegaTransactionDetails = ({ tx }: { tx: VegaStoredTxState }) => {
         <Panel>
           {t('Close position for')}{' '}
           <strong>{market.tradableInstrument.instrument.code}</strong>
+          {tx.order?.remaining && (
+            <p>
+              {t('Filled')}{' '}
+              <SizeAtPrice
+                meta={{
+                  positionDecimalPlaces: market.positionDecimalPlaces,
+                  decimalPlaces: market.decimalPlaces,
+                  asset: getAsset(market).symbol,
+                }}
+                side={tx.order.side}
+                size={(
+                  BigInt(tx.order.size) - BigInt(tx.order.remaining)
+                ).toString()}
+                price={tx.order.price}
+              />
+            </p>
+          )}
         </Panel>
       );
     }

--- a/libs/web3/src/lib/use-vega-transaction-toasts.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.tsx
@@ -41,6 +41,7 @@ import {
   toBigNum,
   truncateByChars,
   formatTrigger,
+  MAXGOINT64,
 } from '@vegaprotocol/utils';
 import { t } from '@vegaprotocol/i18n';
 import { useAssetsMapProvider } from '@vegaprotocol/assets';
@@ -953,7 +954,19 @@ export const getVegaTransactionContentIntent = (tx: VegaStoredTxState) => {
     isWithdrawTransaction(tx.body) &&
     Intent.Warning;
 
+  // Toast for an IOC should go green when it is stopped,
+  // because stopping an IOC once all available volume has filled is the correct behaviour (it is immediate or cancel),
+  // this behaviour should apply to all IOC, not just those created due to "Close position"
+  const intentForClosedPosition =
+    tx.order &&
+    tx.order.status === Schema.OrderStatus.STATUS_STOPPED &&
+    tx.order.timeInForce === Schema.OrderTimeInForce.TIME_IN_FORCE_IOC &&
+    tx.order.size === MAXGOINT64 &&
+    // isClosePositionTransaction(tx) &&
+    Intent.Success;
+
   const intent =
+    intentForClosedPosition ||
     intentForRejectedOrder ||
     intentForCompletedWithdrawal ||
     intentMap[tx.status];

--- a/libs/web3/src/lib/use-vega-transaction-updater.spec.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-updater.spec.tsx
@@ -76,6 +76,7 @@ const orderUpdate: OrderTxUpdateFieldsFragment = {
   createdAt: '2022-07-05T14:25:47.815283706Z',
   expiresAt: '2022-07-05T14:25:47.815283706Z',
   size: '10',
+  remaining: '10',
   price: '300000',
   timeInForce: OrderTimeInForce.TIME_IN_FORCE_GTC,
   side: Side.SIDE_BUY,


### PR DESCRIPTION
# Related issues 🔗

Closes #5110

# Description ℹ️ & Demo 📺

- [x] Toast should detect reduce only + size of 9223372036854775807 (might already do this)
- [x] Toast should show "close position" - it seems to actually do this already
- [x] Toast for an IOC should go green when it is stopped, because stopping an IOC once all available volume has filled is the correct behaviour (it is immediate or cancel), this behaviour should apply to all IOC, not just those created due to "Close position"
- [x] Toast for IOC should show on it how much has filled before it was stopped, just the same as a completed IOC, ie. "+0.10 @ ~ USDT"

<img width="332" alt="Screenshot 2023-11-08 at 10 17 39" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/e270aa1f-cd6e-40d4-a2b2-148cbbf9a597">

<img width="1680" alt="Screenshot 2023-11-07 at 17 01 23" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/85838770-c9a2-4142-8d55-ff0d02cb4cd3">

- [x] The order table should also detect reduce only + size of 9223372036854775807 and instead of showing the size should show "MAX"

<img width="1392" alt="Screenshot 2023-11-07 at 16 56 37" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/066b35bb-936e-4ba3-9e6e-c34d96a12f7d">



# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
