### PR TITLE
fix(trading): fees page issues

### DIFF
--- a/apps/trading/components/fees-container/Fees.graphql
+++ b/apps/trading/components/fees-container/Fees.graphql
@@ -36,6 +36,22 @@ query Fees(
       }
     }
   }
+  referrer: referralSets(referrer: $partyId) {
+    edges {
+      node {
+        id
+        referrer
+      }
+    }
+  }
+  referee: referralSets(referee: $partyId) {
+    edges {
+      node {
+        id
+        referrer
+      }
+    }
+  }
   referralSetReferees(referee: $partyId) {
     edges {
       node {

--- a/apps/trading/components/fees-container/__generated__/Fees.ts
+++ b/apps/trading/components/fees-container/__generated__/Fees.ts
@@ -15,7 +15,7 @@ export type FeesQueryVariables = Types.Exact<{
 }>;
 
 
-export type FeesQuery = { __typename?: 'Query', epoch: { __typename?: 'Epoch', id: string }, volumeDiscountStats: { __typename?: 'VolumeDiscountStatsConnection', edges: Array<{ __typename?: 'VolumeDiscountStatsEdge', node: { __typename?: 'VolumeDiscountStats', atEpoch: number, discountFactor: string, runningVolume: string } } | null> }, referralSetReferees: { __typename?: 'ReferralSetRefereeConnection', edges: Array<{ __typename?: 'ReferralSetRefereeEdge', node: { __typename?: 'ReferralSetReferee', atEpoch: number } } | null> }, referralSetStats: { __typename?: 'ReferralSetStatsConnection', edges: Array<{ __typename?: 'ReferralSetStatsEdge', node: { __typename?: 'ReferralSetStats', atEpoch: number, discountFactor: string, referralSetRunningNotionalTakerVolume: string } } | null> } };
+export type FeesQuery = { __typename?: 'Query', epoch: { __typename?: 'Epoch', id: string }, volumeDiscountStats: { __typename?: 'VolumeDiscountStatsConnection', edges: Array<{ __typename?: 'VolumeDiscountStatsEdge', node: { __typename?: 'VolumeDiscountStats', atEpoch: number, discountFactor: string, runningVolume: string } } | null> }, referrer: { __typename?: 'ReferralSetConnection', edges: Array<{ __typename?: 'ReferralSetEdge', node: { __typename?: 'ReferralSet', id: string, referrer: string } } | null> }, referee: { __typename?: 'ReferralSetConnection', edges: Array<{ __typename?: 'ReferralSetEdge', node: { __typename?: 'ReferralSet', id: string, referrer: string } } | null> }, referralSetReferees: { __typename?: 'ReferralSetRefereeConnection', edges: Array<{ __typename?: 'ReferralSetRefereeEdge', node: { __typename?: 'ReferralSetReferee', atEpoch: number } } | null> }, referralSetStats: { __typename?: 'ReferralSetStatsConnection', edges: Array<{ __typename?: 'ReferralSetStatsEdge', node: { __typename?: 'ReferralSetStats', atEpoch: number, discountFactor: string, referralSetRunningNotionalTakerVolume: string } } | null> } };
 
 
 export const DiscountProgramsDocument = gql`
@@ -78,6 +78,22 @@ export const FeesDocument = gql`
         atEpoch
         discountFactor
         runningVolume
+      }
+    }
+  }
+  referrer: referralSets(referrer: $partyId) {
+    edges {
+      node {
+        id
+        referrer
+      }
+    }
+  }
+  referee: referralSets(referee: $partyId) {
+    edges {
+      node {
+        id
+        referrer
       }
     }
   }

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -78,6 +78,11 @@ export const FeesContainer = () => {
   const loading = paramsLoading || feesLoading || programLoading;
   const isConnected = Boolean(pubKey);
 
+  const isReferralProgramRunning = Boolean(programData?.currentReferralProgram);
+  const isVolumeDiscountProgramRunning = Boolean(
+    programData?.currentVolumeDiscountProgram
+  );
+
   return (
     <div className="grid auto-rows-min grid-cols-4 gap-3">
       {isConnected && (
@@ -102,12 +107,8 @@ export const FeesContainer = () => {
             <TotalDiscount
               referralDiscount={referralDiscount}
               volumeDiscount={volumeDiscount}
-              isReferralProgramRunning={Boolean(
-                programData?.currentReferralProgram
-              )}
-              isVolumeDiscountProgramRunning={Boolean(
-                programData?.currentVolumeDiscountProgram
-              )}
+              isReferralProgramRunning={isReferralProgramRunning}
+              isVolumeDiscountProgramRunning={isVolumeDiscountProgramRunning}
             />
           </FeeCard>
           <FeeCard
@@ -115,12 +116,18 @@ export const FeesContainer = () => {
             className="sm:col-span-2"
             loading={loading}
           >
-            <CurrentVolume
-              tiers={volumeTiers}
-              tierIndex={volumeTierIndex}
-              windowLengthVolume={volumeInWindow}
-              windowLength={volumeDiscountWindowLength}
-            />
+            {isVolumeDiscountProgramRunning ? (
+              <CurrentVolume
+                tiers={volumeTiers}
+                tierIndex={volumeTierIndex}
+                windowLengthVolume={volumeInWindow}
+                windowLength={volumeDiscountWindowLength}
+              />
+            ) : (
+              <p className="pt-3 text-sm text-muted">
+                {t('No volume discount program active')}
+              </p>
+            )}
           </FeeCard>
           <FeeCard
             title={t('Referral benefits')}
@@ -129,12 +136,16 @@ export const FeesContainer = () => {
           >
             {isReferrer ? (
               <ReferrerInfo code={code} />
-            ) : (
+            ) : isReferralProgramRunning ? (
               <ReferralBenefits
                 setRunningNotionalTakerVolume={referralVolumeInWindow}
                 epochsInSet={epochsInSet}
                 epochs={referralDiscountWindowLength}
               />
+            ) : (
+              <p className="pt-3 text-sm text-muted">
+                {t('No referral program active')}
+              </p>
             )}
           </FeeCard>
         </>

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -17,6 +17,14 @@ import { useReferralStats } from './use-referral-stats';
 import { formatPercentage, getAdjustedFee } from './utils';
 import { Table, Td, Th, THead, Tr } from './table';
 import BigNumber from 'bignumber.js';
+import { Links } from '../../lib/links';
+import { Link } from 'react-router-dom';
+import {
+  Tooltip,
+  VegaIcon,
+  VegaIconNames,
+  truncateMiddle,
+} from '@vegaprotocol/ui-toolkit';
 
 export const FeesContainer = () => {
   const { pubKey } = useVegaWallet();
@@ -56,11 +64,15 @@ export const FeesContainer = () => {
     referralTierIndex,
     referralTiers,
     epochsInSet,
+    code,
+    isReferrer,
   } = useReferralStats(
     feesData?.referralSetStats,
     feesData?.referralSetReferees,
     programData?.currentReferralProgram,
-    feesData?.epoch
+    feesData?.epoch,
+    feesData?.referrer,
+    feesData?.referee
   );
 
   const loading = paramsLoading || feesLoading || programLoading;
@@ -90,6 +102,12 @@ export const FeesContainer = () => {
             <TotalDiscount
               referralDiscount={referralDiscount}
               volumeDiscount={volumeDiscount}
+              isReferralProgramRunning={Boolean(
+                programData?.currentReferralProgram
+              )}
+              isVolumeDiscountProgramRunning={Boolean(
+                programData?.currentVolumeDiscountProgram
+              )}
             />
           </FeeCard>
           <FeeCard
@@ -109,11 +127,15 @@ export const FeesContainer = () => {
             className="sm:col-span-2"
             loading={loading}
           >
-            <ReferralBenefits
-              setRunningNotionalTakerVolume={referralVolumeInWindow}
-              epochsInSet={epochsInSet}
-              epochs={referralDiscountWindowLength}
-            />
+            {isReferrer ? (
+              <ReferrerInfo code={code} />
+            ) : (
+              <ReferralBenefits
+                setRunningNotionalTakerVolume={referralVolumeInWindow}
+                epochsInSet={epochsInSet}
+                epochs={referralDiscountWindowLength}
+              />
+            )}
           </FeeCard>
         </>
       )}
@@ -142,7 +164,7 @@ export const FeesContainer = () => {
         />
       </FeeCard>
       <FeeCard
-        title={t('Liquidity fees')}
+        title={t('Fees by market')}
         className="lg:col-span-full"
         loading={marketsLoading}
       >
@@ -325,26 +347,64 @@ const ReferralBenefits = ({
 const TotalDiscount = ({
   referralDiscount,
   volumeDiscount,
+  isReferralProgramRunning,
+  isVolumeDiscountProgramRunning,
 }: {
   referralDiscount: number;
   volumeDiscount: number;
+  isReferralProgramRunning: boolean;
+  isVolumeDiscountProgramRunning: boolean;
 }) => {
+  const totalDiscount = 1 - (1 - volumeDiscount) * (1 - referralDiscount);
+  const totalDiscountDescription = t(
+    'The total discount is calculated according to the following formula: '
+  );
+  const formula = (
+    <span className="italic">
+      1 - (1 - d<sub>volume</sub>) ⋇ (1 - d<sub>referral</sub>)
+    </span>
+  );
+
   return (
     <div>
       <Stat
-        value={formatPercentage(referralDiscount + volumeDiscount) + '%'}
+        description={
+          <>
+            {totalDiscountDescription}
+            {formula}
+          </>
+        }
+        value={formatPercentage(totalDiscount) + '%'}
         highlight={true}
       />
       <table className="w-full mt-0.5 text-xs text-muted">
         <tbody>
           <tr>
             <th className="font-normal text-left">{t('Volume discount')}</th>
-            <td className="text-right">{formatPercentage(volumeDiscount)}%</td>
+            <td className="text-right">
+              {formatPercentage(volumeDiscount)}%
+              {!isVolumeDiscountProgramRunning && (
+                <Tooltip description={t('No active volume discount programme')}>
+                  <span className="cursor-help">
+                    {' '}
+                    <VegaIcon name={VegaIconNames.INFO} size={12} />
+                  </span>
+                </Tooltip>
+              )}
+            </td>
           </tr>
           <tr>
             <th className="font-normal text-left ">{t('Referral discount')}</th>
             <td className="text-right">
               {formatPercentage(referralDiscount)}%
+              {!isReferralProgramRunning && (
+                <Tooltip description={t('No active referral programme')}>
+                  <span className="cursor-help">
+                    {' '}
+                    <VegaIcon name={VegaIconNames.INFO} size={12} />
+                  </span>
+                </Tooltip>
+              )}
             </td>
           </tr>
         </tbody>
@@ -491,3 +551,31 @@ const YourTier = () => {
     </span>
   );
 };
+
+const ReferrerInfo = ({ code }: { code?: string }) => (
+  <div className="pt-3 text-sm text-vega-clight-200 dark:vega-cdark-200">
+    <p className="mb-1">
+      {t('Connected key is owner of the referral set')}
+      {code && (
+        <>
+          {' '}
+          <span className="text-transparent bg-rainbow bg-clip-text">
+            {truncateMiddle(code)}
+          </span>
+        </>
+      )}
+      {'. '}
+      {t('As owner, it is eligible for commission not fee discounts.')}
+    </p>
+    <p>
+      {t('See')}{' '}
+      <Link
+        className="underline text-black dark:text-white"
+        to={Links.REFERRALS()}
+      >
+        {t('Referrals')}
+      </Link>{' '}
+      {t('for more information.')}
+    </p>
+  </div>
+);

--- a/apps/trading/components/fees-container/stat.tsx
+++ b/apps/trading/components/fees-container/stat.tsx
@@ -1,23 +1,31 @@
+import { Tooltip } from '@vegaprotocol/ui-toolkit';
 import classNames from 'classnames';
+import type { ReactNode } from 'react';
 
 export const Stat = ({
   value,
   text,
   highlight,
+  description,
 }: {
   value: string | number;
   text?: string;
   highlight?: boolean;
+  description?: ReactNode;
 }) => {
+  const val = (
+    <span
+      className={classNames('inline-block text-3xl leading-none', {
+        'text-transparent bg-rainbow bg-clip-text': highlight,
+        'cursor-help': description,
+      })}
+    >
+      {value}
+    </span>
+  );
   return (
     <p className="pt-3 leading-none first:pt-6">
-      <span
-        className={classNames('inline-block text-3xl leading-none', {
-          'text-transparent bg-rainbow bg-clip-text': highlight,
-        })}
-      >
-        {value}
-      </span>
+      {description ? <Tooltip description={description}>{val}</Tooltip> : val}
       {text && (
         <small className="block mt-0.5 text-xs text-muted">{text}</small>
       )}

--- a/apps/trading/components/fees-container/use-referral-stats.spec.ts
+++ b/apps/trading/components/fees-container/use-referral-stats.spec.ts
@@ -73,6 +73,8 @@ describe('useReferralStats', () => {
       referralTierIndex: -1,
       referralTiers: [],
       epochsInSet: 0,
+      code: undefined,
+      isReferrer: false,
     });
   });
 
@@ -93,6 +95,8 @@ describe('useReferralStats', () => {
       referralTierIndex: 1,
       referralTiers: program.benefitTiers,
       epochsInSet: Number(epoch.id) - set.atEpoch,
+      code: undefined,
+      isReferrer: false,
     });
   });
 

--- a/apps/trading/components/fees-container/use-referral-stats.ts
+++ b/apps/trading/components/fees-container/use-referral-stats.ts
@@ -2,12 +2,15 @@ import compact from 'lodash/compact';
 import maxBy from 'lodash/maxBy';
 import { getReferralBenefitTier } from './utils';
 import type { DiscountProgramsQuery, FeesQuery } from './__generated__/Fees';
+import { first } from 'lodash';
 
 export const useReferralStats = (
   setStats?: FeesQuery['referralSetStats'],
   setReferees?: FeesQuery['referralSetReferees'],
   program?: DiscountProgramsQuery['currentReferralProgram'],
-  epoch?: FeesQuery['epoch']
+  epoch?: FeesQuery['epoch'],
+  setIfReferrer?: FeesQuery['referrer'],
+  setIfReferee?: FeesQuery['referee']
 ) => {
   const referralTiers = program?.benefitTiers || [];
 
@@ -18,8 +21,17 @@ export const useReferralStats = (
       referralTierIndex: -1,
       referralTiers,
       epochsInSet: 0,
+      code: undefined,
+      isReferrer: false,
     };
   }
+
+  const setIfReferrerData = first(
+    compact(setIfReferrer?.edges).map((e) => e.node)
+  );
+  const setIfRefereeData = first(
+    compact(setIfReferee?.edges).map((e) => e.node)
+  );
 
   const referralSetsStats = compact(setStats.edges).map((e) => e.node);
   const referralSets = compact(setReferees.edges).map((e) => e.node);
@@ -48,5 +60,7 @@ export const useReferralStats = (
     referralTierIndex,
     referralTiers,
     epochsInSet,
+    code: (setIfReferrerData || setIfRefereeData)?.id,
+    isReferrer: Boolean(setIfReferrerData),
   };
 };

--- a/apps/trading/components/fees-container/utils.spec.ts
+++ b/apps/trading/components/fees-container/utils.spec.ts
@@ -21,7 +21,7 @@ describe('getAdjustedFee', () => {
       new BigNumber(referralDiscount),
     ];
 
-    // 1 - 0.5 - 0.5
+    // 1 - 0.5 = 0.5
     const v = new BigNumber(1).minus(new BigNumber(volumeDiscount));
 
     // 1 - 0.5 = 0.5
@@ -34,13 +34,15 @@ describe('getAdjustedFee', () => {
     // 0.1 + 0.1 + 0.1 = 0.3
     const totalFees = fees.reduce((sum, x) => sum.plus(x), new BigNumber(0));
 
-    // 0.3 * 0.75 = 0.225
-    const expected = new BigNumber(totalFees).times(factor).toNumber();
+    // (1 - 0.3) * 0.75 = 0.525
+    const expected = new BigNumber(totalFees)
+      .times(new BigNumber(1).minus(factor))
+      .toNumber();
 
     expect(getAdjustedFee(fees, discounts)).toBe(expected);
   });
 
-  it('combines discount factors multiplicativly', () => {
+  it('combines discount factors multiplicatively', () => {
     const volumeDiscount = 0.4;
     const referralDiscount = 0.1;
 
@@ -67,7 +69,9 @@ describe('getAdjustedFee', () => {
     // summed fees
     const totalFees = fees.reduce((sum, x) => sum.plus(x), new BigNumber(0));
 
-    const expected = new BigNumber(totalFees).times(factor).toNumber();
+    const expected = new BigNumber(totalFees)
+      .times(new BigNumber(1).minus(factor))
+      .toNumber();
 
     expect(getAdjustedFee(fees, discounts)).toBe(expected);
   });

--- a/apps/trading/components/fees-container/utils.ts
+++ b/apps/trading/components/fees-container/utils.ts
@@ -12,7 +12,9 @@ export const formatPercentage = (num: number) => {
   const pct = new BigNumber(num).times(100);
   const dps = pct.decimalPlaces();
   const formatter = new Intl.NumberFormat(getUserLocale(), {
-    minimumFractionDigits: dps || 0,
+    // set to 0 in order to remove the "trailing zeroes" for numbers such as:
+    // 0.123456789 -non-zero-min-> 12.3456800% -zero-min-> 12.34568%
+    minimumFractionDigits: 0,
     maximumFractionDigits: dps || 0,
   });
   return formatter.format(parseFloat(pct.toFixed(5)));

--- a/apps/trading/components/fees-container/utils.ts
+++ b/apps/trading/components/fees-container/utils.ts
@@ -103,5 +103,7 @@ export const getAdjustedFee = (fees: BigNumber[], discounts: BigNumber[]) => {
 
   const totalFactor = new BigNumber(1).minus(combinedFactors);
 
-  return totalFee.times(BigNumber.max(0, totalFactor)).toNumber();
+  return totalFee
+    .times(new BigNumber(1).minus(BigNumber.max(0, totalFactor)))
+    .toNumber();
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #5215

# Description ℹ️

* fixed total discount calculation
* removed trailing zeroes from "My trading fees"
* added tooltips:
   * explaining 0% when there's no program running (volume or referral)
   * explaining how total is being calculated
* replaced the contents of 4th tile with referral info if the connected pubkey is a referrer
* added "no program active" messages to 3rd and 4th tile
* fixed adjusted fee calculation

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/22785ade-e518-4a2b-8041-e5fd1b92bc9e)
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/3ce3fe20-0a6d-41a3-9879-9688a8bfb4b8)


# Technical 👨‍🔧

Adjusted fee formula:
`fee = total_fee * (1 - total_discount)`
