### PR TITLE
fix(trading): display funding rate when market in monitoring auction

### DIFF
--- a/libs/markets/src/lib/market-data-provider.ts
+++ b/libs/markets/src/lib/market-data-provider.ts
@@ -16,7 +16,7 @@ import type {
   MarketDataQueryVariables,
 } from './__generated__/market-data';
 import { getMarketPrice } from './get-price';
-import { isMarketInAuction } from './is-market-in-auction';
+import { MarketTradingMode } from '@vegaprotocol/types';
 
 export type MarketData = MarketDataFieldsFragment;
 
@@ -142,7 +142,11 @@ export const fundingRateProvider = makeDerivedDataProvider<
   MarketDataQueryVariables
 >([marketDataProvider], (parts) => {
   const marketData = parts[0] as ReturnType<typeof getData>;
-  return marketData && !isMarketInAuction(marketData.marketTradingMode)
+  return marketData &&
+    ![
+      MarketTradingMode.TRADING_MODE_OPENING_AUCTION,
+      MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE,
+    ].includes(marketData.marketTradingMode)
     ? marketData?.productData?.fundingRate || null
     : null;
 });


### PR DESCRIPTION
# Related issues 🔗

Closes #5035

# Description ℹ️

Don't hide funding rate when market in monitoring auction.

## Tasks

- [x] For opening auction >> Dash / Unknown
- [x] For liquidity auction >> normal funding rate / normal countdown
- [x] For price monitoring auction >> normal funding rate / normal countdown
- [x] For market suspended by governance >> Dash / unknown (I assume ... since we dont know when - if ever - that market might be restarted?)

# Demo 📺

<img width="1680" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/c5fc5f22-5821-409c-8adb-f05d644773d3">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
