### PR TITLE
feat(explorer): simplify party accounts page

### DIFF
--- a/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
+++ b/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
@@ -1,5 +1,5 @@
 import { useAssetDataProvider } from '@vegaprotocol/assets';
-import { addDecimalsFormatNumber } from '@vegaprotocol/utils';
+import { addDecimalsFixedFormatNumber } from '@vegaprotocol/utils';
 import { AssetLink } from '../links';
 
 export type AssetBalanceProps = {
@@ -23,12 +23,12 @@ const AssetBalance = ({
 
   const label =
     !loading && asset && asset.decimals
-      ? addDecimalsFormatNumber(price, asset.decimals)
+      ? addDecimalsFixedFormatNumber(price, asset.decimals)
       : price;
 
   return (
     <div className="inline-block">
-      <span>{label}</span>{' '}
+      <span className="font-mono">{label}</span>{' '}
       {showAssetLink && asset?.id ? (
         <AssetLink showAssetSymbol={showAssetSymbol} assetId={assetId} />
       ) : null}

--- a/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
+++ b/apps/explorer/src/app/routes/parties/id/components/party-accounts.tsx
@@ -1,6 +1,7 @@
-import { AccountManager } from '@vegaprotocol/accounts';
-import { useCallback } from 'react';
-import { useAssetDetailsDialogStore } from '@vegaprotocol/assets';
+import { useExplorerPartyAssetsQuery } from '../__generated__/Party-assets';
+import { AssetLink, MarketLink } from '../../../../components/links';
+import AssetBalance from '../../../../components/asset-balance/asset-balance';
+import { AccountTypeMapping } from '@vegaprotocol/types';
 
 interface PartyAccountsProps {
   partyId: string;
@@ -12,21 +13,71 @@ interface PartyAccountsProps {
  * appearing first and... tbd
  */
 export const PartyAccounts = ({ partyId }: PartyAccountsProps) => {
-  const { open: openAssetDetailsDialog } = useAssetDetailsDialogStore();
-  const onClickAsset = useCallback(
-    (assetId?: string) => {
-      assetId && openAssetDetailsDialog(assetId);
-    },
-    [openAssetDetailsDialog]
-  );
+  const { data } = useExplorerPartyAssetsQuery({
+    variables: { partyId },
+  });
+
+  const party = data?.partiesConnection?.edges[0]?.node;
+  const accounts =
+    party?.accountsConnection?.edges?.filter((edge) => edge?.node) || [];
 
   return (
     <div className="block min-h-44 h-60 4 w-full border-red-800 relative">
-      <AccountManager
-        partyId={partyId}
-        onClickAsset={onClickAsset}
-        isReadOnly={true}
-      />
+      <table>
+        <thead>
+          <tr>
+            <th className="text-right px-4">Balance</th>
+            <th className="text-left px-4">Type</th>
+            <th className="text-left px-4">Market</th>
+            <th className="text-left px-4">Asset</th>
+          </tr>
+        </thead>
+        <tbody>
+          {accounts
+            .sort((a, b) => {
+              // Sort by asset id, then market id, with general accounts first
+              if (!a) {
+                return 1;
+              }
+              if (!b) {
+                return -1;
+              }
+              if (a.node.asset.id !== b.node.asset.id) {
+                return a.node.asset.id.localeCompare(b.node.asset.id);
+              }
+              if (a.node.type === 'ACCOUNT_TYPE_GENERAL') return -1;
+              if (b.node.type === 'ACCOUNT_TYPE_GENERAL') return 1;
+              if (a.node.market && b.node.market) {
+                return a.node.market.id.localeCompare(b.node.market.id);
+              } else {
+                return a.node.type.localeCompare(b.node.type);
+              }
+            })
+            .map((e) => {
+              if (!e) return null;
+              const { type, asset, balance, market } = e.node;
+
+              return (
+                <tr className="border-t border-neutral-300 dark:border-neutral-600">
+                  <td className="px-4 text-right">
+                    <AssetBalance
+                      assetId={asset.id}
+                      price={balance}
+                      showAssetSymbol={true}
+                    />
+                  </td>
+                  <td className="px-4">{AccountTypeMapping[type]}</td>
+                  <td className="px-4">
+                    {market?.id ? <MarketLink id={market.id} /> : '-'}
+                  </td>
+                  <td className="px-4">
+                    <AssetLink assetId={asset.id} />
+                  </td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
     </div>
   );
 };


### PR DESCRIPTION
- chore: sort
- fix(explorer): final sort order

# Description
Closes #5209. Removes the 'Account breakdown' view of a party's assets, using a simple table of all of the party's accounts instead.

# Examples

Two examples to demonstrate how the sorting works

## Accounts for a party, sorted by asset (with General first)
<img width="711" alt="Screenshot 2023-11-09 at 18 14 57" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/f1c2a626-8bcc-48bd-84e1-1c94a8cd0362">

## Accounts for a party, sorted by asset, then by market
<img width="985" alt="Screenshot 2023-11-09 at 18 00 39" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/36eac4b0-14fd-4b69-b90f-4767fe7cc624">

