### PR TITLE
fix(trading): fix percentage formatter rounding in liquidity table

### DIFF
--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import {
   addDecimalsFormatNumber,
   addDecimalsFormatNumberQuantum,
-  formatNumberPercentage,
   getDateTimeFormat,
 } from '@vegaprotocol/utils';
 import { t } from '@vegaprotocol/i18n';
@@ -28,6 +27,12 @@ import BigNumber from 'bignumber.js';
 import { LiquidityProvisionStatus } from '@vegaprotocol/types';
 import { LiquidityProvisionStatusMapping } from '@vegaprotocol/types';
 import type { LiquidityProvisionData } from './liquidity-data-provider';
+
+const formatNumberPercentage = (value: BigNumber, decimals?: number) => {
+  const decimalPlaces =
+    typeof decimals === 'undefined' ? value.dp() || 0 : decimals;
+  return `${value.toFixed(decimalPlaces, 1)}%`;
+};
 
 const percentageFormatter = ({ value }: ValueFormatterParams) => {
   if (!value) return '-';
@@ -126,11 +131,11 @@ export const LiquidityTable = ({
               new BigNumber(data.sla.currentEpochFractionOfTimeOnBook).times(
                 100
               ),
-              2
+              4
             ),
             formatNumberPercentage(
               new BigNumber(data.commitmentMinTimeFraction).times(100),
-              2
+              4
             ),
           ]
         );
@@ -143,7 +148,7 @@ export const LiquidityTable = ({
               new BigNumber(data.sla.currentEpochFractionOfTimeOnBook).times(
                 100
               ),
-              2
+              4
             ),
           ]
         );


### PR DESCRIPTION
# Related issues 🔗

Closes #5252

# Description ℹ️

Fix percentage formatter rounding in liquidity table.

# Demo 📺

After:
<img width="949" alt="Screenshot 2023-11-13 at 14 24 15" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/ed860037-03a4-4878-a0d5-6d4a717d5add">

Before: 
<img width="710" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/60449dc1-0cfc-4db1-9161-32b5a0b1094d">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
