### PR TITLE
feat(trading): referral preview update

### DIFF
--- a/apps/trading/client-pages/referrals/apply-code-form.tsx
+++ b/apps/trading/client-pages/referrals/apply-code-form.tsx
@@ -17,7 +17,7 @@ import { useReferral } from './hooks/use-referral';
 import { Routes } from '../../lib/links';
 import { useTransactionEventSubscription } from '@vegaprotocol/web3';
 import { t } from '@vegaprotocol/i18n';
-import { Statistics } from './referral-statistics';
+import { Statistics, useStats } from './referral-statistics';
 import { useReferralProgram } from './hooks/use-referral-program';
 
 const RELOAD_DELAY = 3000;
@@ -132,6 +132,8 @@ export const ApplyCodeForm = () => {
       }),
   });
 
+  const { epochsValue, nextBenefitTierValue } = useStats({ program });
+
   // go to main page when successfully applied
   useEffect(() => {
     if (status === 'successful') {
@@ -196,6 +198,10 @@ export const ApplyCodeForm = () => {
     };
   };
 
+  const nextBenefitTierEpochsValue = nextBenefitTierValue
+    ? nextBenefitTierValue.epochs - epochsValue
+    : 0;
+
   return (
     <>
       <div className="w-2/3 max-w-md mx-auto bg-vega-clight-800 dark:bg-vega-cdark-800 p-8 rounded-lg">
@@ -238,7 +244,12 @@ export const ApplyCodeForm = () => {
       ) : null}
       {previewData ? (
         <div className="mt-10">
-          <h2 className="text-2xl mb-5">{t('You are joining')}</h2>
+          <h2 className="text-2xl mb-5">
+            {t(
+              'You are joining the group shown, but will not have access to benefits until you have completed at least %s epochs.',
+              [nextBenefitTierEpochsValue.toString()]
+            )}
+          </h2>
           <Statistics data={previewData} program={program} as="referee" />
         </div>
       ) : null}

--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -25,7 +25,7 @@ import compact from 'lodash/compact';
 import { useReferralProgram } from './hooks/use-referral-program';
 import { useStakeAvailable } from './hooks/use-stake-available';
 import sortBy from 'lodash/sortBy';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useCurrentEpochInfoQuery } from './hooks/__generated__/Epoch';
 import BigNumber from 'bignumber.js';
 import { t } from '@vegaprotocol/i18n';
@@ -165,6 +165,11 @@ export const Statistics = ({
     nextBenefitTierEpochsValue,
   } = useStats({ data, program, as });
 
+  const isApplyCodePreview = useMemo(
+    () => data.referee === null,
+    [data.referee]
+  );
+
   const { benefitTiers } = useReferralProgram();
 
   const { stakeAvailable } = useStakeAvailable();
@@ -270,14 +275,16 @@ export const Statistics = ({
 
   const currentBenefitTierTile = (
     <StatTile title={t('Current tier')}>
-      {currentBenefitTierValue?.tier || benefitTiers[0]?.tier || 'None'}
+      {isApplyCodePreview
+        ? currentBenefitTierValue?.tier || benefitTiers[0]?.tier || 'None'
+        : currentBenefitTierValue?.tier || 'None'}
     </StatTile>
   );
   const discountFactorTile = (
     <StatTile title={t('Discount')}>
-      {discountFactorValue
-        ? discountFactorValue * 100
-        : benefitTiers[0].discountFactor * 100}
+      {isApplyCodePreview
+        ? benefitTiers[0].discountFactor * 100
+        : discountFactorValue * 100}
       %
     </StatTile>
   );


### PR DESCRIPTION
# Related issues 🔗

Closes #5221

# Description ℹ️

- [x]  Replace "You are joining" with "You are joining the group shown, but will not have access to benefits until you have completed at least epochs to next tier epochs
- [x]  On the apply code preview we show current tier NONE, we should be showing the tier of the set
- [x]  Discount is showing 0, it should be showing the discount you can get once you access the tier
- [x]  We need to flip the order of volume / referral discount tiers on both the referral page and fees page

# Demo 📺

<img width="1680" alt="Screenshot 2023-11-13 at 14 53 42" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/b18f3a6d-3b84-4bc8-b979-8dfb3fb3c379">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
