### PR TITLE
fix(trading): do not use stakeToCcyVolume to format fees value

### DIFF
--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -399,7 +399,7 @@ export const LiquidityTable = ({
             headerTooltip: t(
               `The liquidity fees accrued by each provider, which will be distributed at the end of the epoch after applying any penalties.`
             ),
-            valueFormatter: stakeToCcyVolumeQuantumFormatter,
+            valueFormatter: assetDecimalsQuantumFormatter,
             tooltipValueGetter: feesAccruedTooltip,
             cellClassRules: {
               'text-warning': ({ data }: { data: LiquidityProvisionData }) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #5279 

# Description ℹ️

Fees summed from ACCOUNT_TYPE_LP_LIQUIDITY_FEES were being multiplied by the stakeToCcyVolume network parameter. 