### PR TITLE
fix(trading): show deal ticket in sidebar by default

### DIFF
--- a/apps/trading/client-pages/markets/markets-sidebar.tsx
+++ b/apps/trading/client-pages/markets/markets-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { t } from '@vegaprotocol/i18n';
 import { VegaIconNames } from '@vegaprotocol/ui-toolkit';
 import {

--- a/apps/trading/client-pages/markets/markets-sidebar.tsx
+++ b/apps/trading/client-pages/markets/markets-sidebar.tsx
@@ -1,7 +1,5 @@
 import { Route, Routes, useParams } from 'react-router-dom';
-import { MarketState } from '@vegaprotocol/types';
 import { t } from '@vegaprotocol/i18n';
-import { useMarket } from '@vegaprotocol/markets';
 import { VegaIconNames } from '@vegaprotocol/ui-toolkit';
 import {
   SidebarButton,

--- a/apps/trading/client-pages/markets/markets-sidebar.tsx
+++ b/apps/trading/client-pages/markets/markets-sidebar.tsx
@@ -11,12 +11,7 @@ import {
 import { useGetCurrentRouteId } from '../../lib/hooks/use-get-current-route-id';
 
 export const MarketsSidebar = () => {
-  const { marketId } = useParams();
   const currentRouteId = useGetCurrentRouteId();
-  const { data } = useMarket(marketId);
-  const active =
-    data &&
-    [MarketState.STATE_ACTIVE, MarketState.STATE_PENDING].includes(data.state);
 
   return (
     <>

--- a/apps/trading/client-pages/markets/markets-sidebar.tsx
+++ b/apps/trading/client-pages/markets/markets-sidebar.tsx
@@ -44,14 +44,12 @@ export const MarketsSidebar = () => {
           element={
             <>
               <SidebarDivider />
-              {active && (
-                <SidebarButton
-                  view={ViewType.Order}
-                  icon={VegaIconNames.TICKET}
-                  tooltip={t('Order')}
-                  routeId={currentRouteId}
-                />
-              )}
+              <SidebarButton
+                view={ViewType.Order}
+                icon={VegaIconNames.TICKET}
+                tooltip={t('Order')}
+                routeId={currentRouteId}
+              />
               <SidebarButton
                 view={ViewType.Info}
                 icon={VegaIconNames.BREAKDOWN}


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

Fixes an issue where if a market was in a price monitoring auction the deal ticket isn't shown. This change makes the deal ticket button always show regardless of market state or trading mode

# Demo 📺

<img width="575" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/8d4af4f1-2d9e-4a0b-86fc-13b650e94da0">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
