### PR TITLE
chore(ci): increase number of tests in parallel

### DIFF
--- a/.github/workflows/console-test-run.yml
+++ b/.github/workflows/console-test-run.yml
@@ -205,7 +205,7 @@ jobs:
       # run tests
       #----------------------------------------------
       - name: Run tests
-        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=15
+        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 6 --dist loadfile --durations=15
         working-directory: apps/trading/e2e
       #----------------------------------------------
       # upload traces


### PR DESCRIPTION
Increasing the number of tests running in parallel to 6. I believe the tests are stable at this number and it saves roughly 2 minutes in workflow time.