### PR TITLE
chore(governance): sensible vote numbers

### DIFF
--- a/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.spec.tsx
@@ -8,7 +8,7 @@ import {
   networkParamsQueryMock,
   nextWeek,
 } from '../../test-helpers/mocks';
-import { VoteBreakdown } from './vote-breakdown';
+import { CompactVotes, VoteBreakdown } from './vote-breakdown';
 import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
 import type { MockedResponse } from '@apollo/client/testing';
 import {
@@ -344,5 +344,24 @@ describe('VoteBreakdown', () => {
     const element = screen.getByTestId('lp-participation-progress');
     const style = window.getComputedStyle(element);
     expect(style.width).toBe(`${expectedProgress}%`);
+  });
+});
+
+describe('CompactVotes', () => {
+  it.each([
+    [0, '0'],
+    [1, '1'],
+    [12, '12'],
+    [123, '123'],
+    [1234, '1.2K'],
+    [12345, '12.3K'],
+    [123456, '123.5K'],
+    [1234567, '1.2M'],
+    [12345678, '12.3M'],
+    [123456789, '123.5M'],
+    [1234567890, '1.2B'],
+  ])('compacts %s to %s', (input, output) => {
+    const { getByTestId } = render(<CompactVotes number={BigNumber(input)} />);
+    expect(getByTestId('compact-number').textContent).toBe(output);
   });
 });

--- a/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-breakdown/vote-breakdown.tsx
@@ -3,11 +3,21 @@ import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { useVoteInformation } from '../../hooks';
 import { Icon, Tooltip } from '@vegaprotocol/ui-toolkit';
-import { formatNumber, toBigNum } from '@vegaprotocol/utils';
+import { formatNumber } from '@vegaprotocol/utils';
 import { ProposalState } from '@vegaprotocol/types';
 import type { ReactNode } from 'react';
 import type { ProposalFieldsFragment } from '../../proposals/__generated__/Proposals';
 import type { ProposalQuery } from '../../proposal/__generated__/Proposal';
+import { CompactNumber } from '@vegaprotocol/react-helpers';
+
+export const CompactVotes = ({ number }: { number: BigNumber }) => (
+  <CompactNumber
+    number={number}
+    decimals={number.isGreaterThan(1000) ? 1 : 0}
+    compactAbove={1000}
+    compactDisplay="short"
+  />
+);
 
 interface VoteBreakdownProps {
   proposal: ProposalFieldsFragment | ProposalQuery['proposal'];
@@ -198,10 +208,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
                     )}
                   >
                     <button>
-                      {yesEquityLikeShareWeight
-                        .dividedBy(toBigNum(10 ** 6, 0))
-                        .toFixed(1)}
-                      M
+                      <CompactVotes number={yesEquityLikeShareWeight} />
                     </button>
                   </Tooltip>
                   <span>
@@ -226,10 +233,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
                     )}
                   >
                     <button>
-                      {noEquityLikeShareWeight
-                        .dividedBy(toBigNum(10 ** 6, 0))
-                        .toFixed(1)}
-                      M
+                      <CompactVotes number={noEquityLikeShareWeight} />
                     </button>
                   </Tooltip>
                   <span>
@@ -279,10 +283,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
                     )}
                   >
                     <button>
-                      {totalEquityLikeShareWeight
-                        .dividedBy(toBigNum(10 ** 6, 0))
-                        .toFixed(1)}
-                      M
+                      <CompactVotes number={totalEquityLikeShareWeight} />
                     </button>
                   </Tooltip>
                   <span>
@@ -321,7 +322,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
               <span>{t('tokenVotesFor')}:</span>
               <Tooltip description={formatNumber(yesTokens, defaultDP)}>
                 <button data-testid="num-votes-for">
-                  {yesTokens.dividedBy(toBigNum(10 ** 6, 0)).toFixed(1)}M
+                  <CompactVotes number={yesTokens} />
                 </button>
               </Tooltip>
               <span>
@@ -341,7 +342,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
               <span>{t('tokenVotesAgainst')}:</span>
               <Tooltip description={formatNumber(noTokens, defaultDP)}>
                 <button data-testid="num-votes-against">
-                  {noTokens.dividedBy(toBigNum(10 ** 6, 0)).toFixed(1)}M
+                  <CompactVotes number={noTokens} />
                 </button>
               </Tooltip>
               <span>
@@ -384,7 +385,7 @@ export const VoteBreakdown = ({ proposal }: VoteBreakdownProps) => {
               <span>{t('totalTokensVoted')}:</span>
               <Tooltip description={formatNumber(totalTokensVoted, defaultDP)}>
                 <button data-testid="total-voted">
-                  {totalTokensVoted.dividedBy(toBigNum(10 ** 6, 0)).toFixed(1)}M
+                  <CompactVotes number={totalTokensVoted} />
                 </button>
               </Tooltip>
               <span data-testid="total-voted-percentage">

--- a/libs/react-helpers/src/lib/format/number.tsx
+++ b/libs/react-helpers/src/lib/format/number.tsx
@@ -22,11 +22,13 @@ export const CompactNumber = ({
   decimals = 'infer',
   compactDisplay = 'short',
   testId = 'compact-number',
+  compactAbove = DEFAULT_COMPACT_ABOVE,
 }: {
   number: BigNumber;
   decimals?: number | 'infer';
   compactDisplay?: 'short' | 'long';
   testId?: string;
+  compactAbove?: number;
 }) => {
   if (!number.isFinite()) {
     return (
@@ -44,7 +46,7 @@ export const CompactNumber = ({
     return <span data-testid={testId}>{INFINITY}</span>;
   }
 
-  if (number.isLessThan(DEFAULT_COMPACT_ABOVE)) {
+  if (number.isLessThan(compactAbove)) {
     return (
       <span data-testid={testId}>{formatNumber(number, decimalPlaces)}</span>
     );


### PR DESCRIPTION
# Related issues 🔗

Closes #4873 

# Description ℹ️

* compacts votes into units of K, M, B, ...

# Demo 📺

N/A

# Technical 👨‍🔧

```
CompactVotes
    ✓ compacts 0 to 0 (20 ms)
    ✓ compacts 1 to 1 (2 ms)
    ✓ compacts 12 to 12 (1 ms)
    ✓ compacts 123 to 123 (4 ms)
    ✓ compacts 1234 to 1.2K (2 ms)
    ✓ compacts 12345 to 12.3K (1 ms)
    ✓ compacts 123456 to 123.5K (1 ms)
    ✓ compacts 1234567 to 1.2M (1 ms)
    ✓ compacts 12345678 to 12.3M (2 ms)
    ✓ compacts 123456789 to 123.5M (1 ms)
    ✓ compacts 1234567890 to 1.2B (2 ms)
```
