### PR TITLE
chore(trading): fix change keys edge case

### DIFF
--- a/apps/trading/e2e/actions/utils.py
+++ b/apps/trading/e2e/actions/utils.py
@@ -44,4 +44,5 @@ def truncate_middle(market_id, start=6, end=4):
 def change_keys(page: Page, vega:VegaServiceNull, key_name):
     page.get_by_test_id("manage-vega-wallet").click()
     page.get_by_test_id("key-" + vega.wallet.public_key(key_name)).click()
+    page.click(f'data-testid=key-{vega.wallet.public_key(key_name)} >> .inline-flex')
     page.reload()


### PR DESCRIPTION
Fixes a weird edge case where if the pub key for the key being switched to had "thinner" letter / numbers then the click would click the copy button rather than the key.

The change keys helper will now grab the child element.