### PR TITLE
chore(trading): market python tests to jest

### DIFF
--- a/apps/trading/client-pages/markets/markets-page.spec.tsx
+++ b/apps/trading/client-pages/markets/markets-page.spec.tsx
@@ -1,0 +1,266 @@
+import { act, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { OpenMarkets } from './open-markets';
+import { MarketState } from '@vegaprotocol/types';
+import { subDays } from 'date-fns';
+import type { MockedResponse } from '@apollo/client/testing';
+import { MockedProvider } from '@apollo/client/testing';
+import { PropertyKeyType } from '@vegaprotocol/types';
+import type {
+  OracleSpecDataConnectionQuery,
+  MarketsDataQuery,
+  MarketsQuery,
+} from '@vegaprotocol/markets';
+import {
+  OracleSpecDataConnectionDocument,
+  MarketsDataDocument,
+  MarketsDocument,
+} from '@vegaprotocol/markets';
+import type { VegaWalletContextShape } from '@vegaprotocol/wallet';
+import { VegaWalletContext } from '@vegaprotocol/wallet';
+import {
+  createMarketFragment,
+  marketsQuery,
+  marketsDataQuery,
+  createMarketsDataFragment,
+} from '@vegaprotocol/mock';
+import userEvent from '@testing-library/user-event';
+
+describe('Open', () => {
+  let originalNow: typeof Date.now;
+  const mockNowTimestamp = 1672531200000;
+  const settlementDateMetaDate = subDays(
+    new Date(mockNowTimestamp),
+    3
+  ).toISOString();
+  const settlementDateTag = `settlement-expiry-date:${settlementDateMetaDate}`;
+  const pubKey = 'pubKey';
+  const marketId = 'market-0';
+  const settlementDataProperty = 'spec-binding';
+  const settlementDataId = 'settlement-data-oracle-id';
+
+  const market = createMarketFragment({
+    id: marketId,
+    state: MarketState.STATE_ACTIVE,
+    tradableInstrument: {
+      instrument: {
+        metadata: {
+          tags: [settlementDateTag],
+        },
+        product: {
+          __typename: 'Future',
+          dataSourceSpecForSettlementData: {
+            __typename: 'DataSourceSpec',
+            id: settlementDataId,
+            data: {
+              sourceType: {
+                __typename: 'DataSourceDefinitionExternal',
+                sourceType: {
+                  filters: [
+                    {
+                      __typename: 'Filter',
+                      key: {
+                        __typename: 'PropertyKey',
+                        name: settlementDataProperty,
+                        type: PropertyKeyType.TYPE_INTEGER,
+                        numberDecimalPlaces: 5,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          dataSourceSpecBinding: {
+            settlementDataProperty,
+          },
+        },
+      },
+    },
+  });
+  const marketsMock: MockedResponse<MarketsQuery> = {
+    request: {
+      query: MarketsDocument,
+    },
+    result: {
+      data: marketsQuery({
+        marketsConnection: {
+          edges: [
+            {
+              node: market,
+            },
+          ],
+        },
+      }),
+    },
+  };
+
+  const marketsData = createMarketsDataFragment({
+    __typename: 'MarketData',
+    market: {
+      __typename: 'Market',
+      id: marketId,
+    },
+    bestBidPrice: '1000',
+    bestOfferPrice: '2000',
+    markPrice: '1500',
+  });
+  const marketsDataMock: MockedResponse<MarketsDataQuery> = {
+    request: {
+      query: MarketsDataDocument,
+    },
+    result: {
+      data: marketsDataQuery({
+        marketsConnection: {
+          edges: [
+            {
+              node: {
+                data: marketsData,
+              },
+            },
+          ],
+        },
+      }),
+    },
+  };
+
+  // Create mock oracle data
+  const property = {
+    __typename: 'Property' as const,
+    name: settlementDataProperty,
+    value: '12345',
+  };
+  const oracleDataMock: MockedResponse<OracleSpecDataConnectionQuery> = {
+    request: {
+      query: OracleSpecDataConnectionDocument,
+      variables: {
+        oracleSpecId: settlementDataId,
+      },
+    },
+    result: {
+      data: {
+        oracleSpec: {
+          dataConnection: {
+            edges: [
+              {
+                node: {
+                  externalData: {
+                    data: {
+                      data: [property],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+
+  beforeAll(() => {
+    originalNow = Date.now;
+    Date.now = jest.fn().mockReturnValue(mockNowTimestamp);
+  });
+
+  afterAll(() => {
+    Date.now = originalNow;
+  });
+
+  it('renders correct headers', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MockedProvider
+            mocks={[marketsMock, marketsDataMock, oracleDataMock]}
+          >
+            <VegaWalletContext.Provider
+              value={{ pubKey } as VegaWalletContextShape}
+            >
+              <OpenMarkets />
+            </VegaWalletContext.Provider>
+          </MockedProvider>
+        </MemoryRouter>
+      );
+    });
+
+    const headers = screen.getAllByRole('columnheader');
+    const expectedHeaders = [
+      'Market',
+      'Description',
+      'Settlement asset',
+      'Trading mode',
+      'Status',
+      'Mark price',
+      '24h volume',
+      'Open Interest',
+      'Spread',
+      '', // Action row
+    ];
+    expect(headers).toHaveLength(expectedHeaders.length);
+    expect(headers.map((h) => h.textContent?.trim())).toEqual(expectedHeaders);
+  });
+
+  it('sort columns', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MockedProvider
+            mocks={[marketsMock, marketsDataMock, oracleDataMock]}
+          >
+            <VegaWalletContext.Provider
+              value={{ pubKey } as VegaWalletContextShape}
+            >
+              <OpenMarkets />
+            </VegaWalletContext.Provider>
+          </MockedProvider>
+        </MemoryRouter>
+      );
+    });
+
+    const headers = screen.getAllByRole('columnheader');
+    // eslint-disable-next-line no-console
+    console.log(headers);
+    const marketHeader = headers.find(
+      (h) => h.getAttribute('col-id') === 'tradableInstrument.instrument.code'
+    );
+    if (!marketHeader) {
+      throw new Error('No market header found');
+    }
+    expect(marketHeader).toHaveAttribute('aria-sort', 'none');
+    await userEvent.click(within(marketHeader).getByText(/market/i));
+    // 6001-MARK-064
+    expect(marketHeader).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests, jest/expect-expect
+  it.skip('renders row', async () => {
+    // TODO finish test to replace test_markets_content from apps/trading/e2e/tests/market/test_markets_all.py
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MockedProvider
+            mocks={[marketsMock, marketsDataMock, oracleDataMock]}
+          >
+            <VegaWalletContext.Provider
+              value={{ pubKey } as VegaWalletContextShape}
+            >
+              <OpenMarkets />
+            </VegaWalletContext.Provider>
+          </MockedProvider>
+        </MemoryRouter>
+      );
+    });
+
+    const container = within(
+      document.querySelector('.ag-center-cols-container') as HTMLElement
+    );
+    // eslint-disable-next-line no-console
+    console.log(container);
+    const row = container.getAllByRole('row')[0];
+    // eslint-disable-next-line no-console
+    console.log(row);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const marketCode = row.getAttribute('col-id') === 'code';
+  });
+});

--- a/apps/trading/e2e/tests/market/test_markets_all.py
+++ b/apps/trading/e2e/tests/market/test_markets_all.py
@@ -20,43 +20,6 @@ def create_markets(vega):
 
 
 @pytest.mark.usefixtures("risk_accepted")
-def test_table_headers(page: Page, create_markets):
-    page.goto(f"/#/markets/all")
-    headers = [
-        "Market",
-        "Description",
-        "Settlement asset",
-        "Trading mode",
-        "Status",
-        "Mark price",
-        "24h volume",
-        "Open Interest",
-        "Spread",
-        "",
-    ]
-    page.wait_for_selector('[data-testid="tab-open-markets"]', state="visible")
-    page_headers = (
-        page.get_by_test_id("tab-open-markets").locator(".ag-header-cell-text").all()
-    )
-    for i, header in enumerate(headers):
-        expect(page_headers[i]).to_have_text(header)
-
-
-@pytest.mark.usefixtures("risk_accepted")
-def test_markets_tab(page: Page, create_markets):
-    page.goto(f"/#/markets/all")
-    expect(page.get_by_test_id("Open markets")).to_have_attribute(
-        "data-state", "active"
-    )
-    expect(page.get_by_test_id("Proposed markets")).to_have_attribute(
-        "data-state", "inactive"
-    )
-    expect(page.get_by_test_id("Closed markets")).to_have_attribute(
-        "data-state", "inactive"
-    )
-
-
-@pytest.mark.usefixtures("risk_accepted")
 def test_markets_content(page: Page, create_markets):
     page.goto(f"/#/markets/all")
     row_selector = page.locator(
@@ -126,27 +89,6 @@ def test_market_actions(page: Page, create_markets):
 
     for i, action in enumerate(actions):
         expect(action_elements[i]).to_have_text(action)
-
-
-@pytest.mark.usefixtures("risk_accepted")
-def test_sort_markets(page: Page, create_markets):
-    # 6001-MARK-064
-
-    page.goto(f"/#/markets/all")
-    sorted_market_names = [
-        "AAPL.MF21",
-        "BTCUSD.MF21",
-        "ETHBTC.QM21",
-        "SOLUSD",
-    ]
-    page.locator('.ag-header-row [col-id="tradableInstrument.instrument.code"]').click()
-    for i, market_name in enumerate(sorted_market_names):
-        expect(
-            page.locator(
-                f'[row-index="{i}"] [col-id="tradableInstrument.instrument.name"]'
-            )
-        ).to_have_text(market_name)
-
 
 @pytest.mark.usefixtures("risk_accepted")
 def test_drag_and_drop_column(page: Page, create_markets):


### PR DESCRIPTION
Pr to migrate basic market rendering tests to jest.

There are two tests that I am struggling to migrate:

- Market actions drop down

- Render rows correctly.

I'm not sure if it's possible to create a jest test for drag and drop, or that we even want to as it's ag grid functionality.

But we currently have an e2e test that would be good to migrate or remove:
`@pytest.mark.usefixtures("risk_accepted")
def test_drag_and_drop_column(page: Page, create_markets):
    # 6001-MARK-065
    page.goto(f"/#/markets/all")
    col_instrument_code = '.ag-header-row [col-id="tradableInstrument.instrument.code"]'

    page.locator(col_instrument_code).drag_to(
        page.locator('.ag-header-row [col-id="data.bestBidPrice"]')
    )
    expect(page.locator(col_instrument_code)).to_have_attribute("aria-colindex", "9")
`