### PR TITLE
fix(trading): fees accrued tooltip

### DIFF
--- a/libs/datagrid/src/lib/ag-grid/ag-grid-themed.tsx
+++ b/libs/datagrid/src/lib/ag-grid/ag-grid-themed.tsx
@@ -37,6 +37,9 @@ export const AgGridThemed = ({
     <div className={wrapperClasses}>
       <AgGridReact
         defaultColDef={defaultColDef}
+        overlayLoadingTemplate={t('Loading...')}
+        overlayNoRowsTemplate={t('No data')}
+        suppressDragLeaveHidesColumns
         ref={gridRef}
         {...defaultProps}
         {...props}

--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -106,9 +106,6 @@ export const LiquidityTable = ({
 
     const feesAccruedTooltip = ({ value, data }: ITooltipParams) => {
       if (!value) return '-';
-      const newValue = new BigNumber(value)
-        .times(Number(stakeToCcyVolume) || 1)
-        .toString();
       let lessThanFull = false,
         lessThanMinimum = false;
       if (data.sla) {
@@ -153,7 +150,7 @@ export const LiquidityTable = ({
           ]
         );
       }
-      return addDecimalsFormatNumber(newValue, assetDecimalPlaces ?? 0);
+      return addDecimalsFormatNumber(value, assetDecimalPlaces ?? 0);
     };
 
     const stakeToCcyVolumeQuantumFormatter = ({


### PR DESCRIPTION
# Related issues 🔗

Closes #5386 

# Description ℹ️

- [x] Fees accrued tooltip should not use stake to ccy param. This was fixed for the table field.
- [x] Suppress drag leave hides columns (merged in `develop`)

# Demo 📺

<img width="926" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/bd4034d9-fddd-47a9-8b7b-3fc91e3366f9">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
