### PR TITLE
fix: live  time fraction zero

### DIFF
--- a/libs/liquidity/src/lib/liquidity-table.tsx
+++ b/libs/liquidity/src/lib/liquidity-table.tsx
@@ -412,14 +412,9 @@ export const LiquidityTable = ({
               },
               'text-red-500': ({ data }: { data: LiquidityProvisionData }) => {
                 if (!data.sla) return false;
-                return (
-                  new BigNumber(
-                    data.sla.currentEpochFractionOfTimeOnBook
-                  ).isLessThan(data.commitmentMinTimeFraction) &&
-                  new BigNumber(
-                    data.sla.currentEpochFractionOfTimeOnBook
-                  ).isGreaterThan(0)
-                );
+                return new BigNumber(
+                  data.sla.currentEpochFractionOfTimeOnBook
+                ).isLessThan(data.commitmentMinTimeFraction);
               },
             },
           },


### PR DESCRIPTION
# Related issues 🔗

Closes #5418 

# Description ℹ️

Live time fraction is zero should display red warning

# Demo 📺

<img width="1680" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/44c02791-8235-416d-a131-a9a609b5c597">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
