### PR TITLE
chore(trading): update generic data provider

### DIFF
--- a/libs/data-provider/src/generic-data-provider.ts
+++ b/libs/data-provider/src/generic-data-provider.ts
@@ -153,7 +153,8 @@ interface DataProviderParams<
   pagination?: {
     getPageInfo: GetPageInfo<QueryData>;
     append: Append<Data>;
-    first: number;
+    first?: number;
+    last?: number;
   };
   fetchPolicy?: FetchPolicy;
   resetDelay?: number;

--- a/libs/trades/src/lib/trades-data-provider.ts
+++ b/libs/trades/src/lib/trades-data-provider.ts
@@ -98,7 +98,6 @@ export const tradesProvider = makeDataProvider<
   pagination: {
     getPageInfo,
     append,
-    // first: MAX_TRADES,
     last: MAX_TRADES,
   },
   fetchPolicy: 'no-cache',

--- a/libs/trades/src/lib/trades-data-provider.ts
+++ b/libs/trades/src/lib/trades-data-provider.ts
@@ -98,7 +98,8 @@ export const tradesProvider = makeDataProvider<
   pagination: {
     getPageInfo,
     append,
-    first: MAX_TRADES,
+    // first: MAX_TRADES,
+    last: MAX_TRADES,
   },
   fetchPolicy: 'no-cache',
   getSubscriptionVariables: ({ marketId }) => ({ marketId }),


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️ & Technical 👨‍🔧

- [x] update generic data provider pagination object to contain `last` field
- [x] when using `last` we can get the most recent records from the API
Note: this should be used since there is a limit between 1k and 5k records that can be retrieved (i.e. candles query)


