### PR TITLE
feat(explorer): add type details to orders in tx list and details

### DIFF
--- a/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/deterministic-order-details.tsx
@@ -6,6 +6,7 @@ import { Time } from '../time';
 import { sideText, statusText, tifFull, tifShort } from './lib/order-labels';
 import SizeInMarket from '../size-in-market/size-in-market';
 import { TxOrderPeggedReference } from '../txs/details/order/tx-order-peg';
+import { OrderTypeMapping } from '@vegaprotocol/types';
 
 export interface DeterministicOrderDetailsProps {
   id: string;
@@ -69,7 +70,7 @@ const DeterministicOrderDetails = ({
             <span className="mx-5 text-base">@</span>
             <PriceInMarket price={o.price} marketId={o.market.id} />
           </h2>
-          <p className="text-gray-200">
+          <p className="text-gray-400 dark:text-gray-600">
             In <MarketLink id={o.market.id} /> at <Time date={o.createdAt} />.
           </p>
           {o.peggedOrder ? (
@@ -83,13 +84,12 @@ const DeterministicOrderDetails = ({
               />
             </p>
           ) : null}
-
           {o.reference ? (
             <p className="text-gray-500 mt-4">
               <span>{t('Reference')}</span>: {o.reference}
             </p>
           ) : null}
-          <div className="grid md:grid-cols-4 gap-x-6 mt-4">
+          <div className="grid md:grid-cols-5 gap-x-6 mt-4">
             <div className="mb-12 md:mb-0">
               <h2 className="text-2xl font-bold text-dark mb-4">
                 {t('Status')}
@@ -114,6 +114,16 @@ const DeterministicOrderDetails = ({
                 {o.version}
               </h5>
             </div>
+            {o.type ? (
+              <div className="">
+                <h2 className="text-2xl font-bold text-dark mb-4">
+                  {t('Type')}
+                </h2>
+                <h5 className="text-lg font-medium text-gray-500 mb-0">
+                  {OrderTypeMapping[o.type]}
+                </h5>
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -80,6 +80,12 @@ export function getLabelForOrderType(
     if (command.orderSubmission.icebergOpts) {
       return 'Iceberg';
     }
+    if (command.orderSubmission.type === 'TYPE_MARKET') {
+      return 'Market order';
+    }
+    if (command.orderSubmission.type === 'TYPE_LIMIT') {
+      return 'Limit order';
+    }
   }
   return 'Order';
 }


### PR DESCRIPTION
# Related issues 🔗

Closes #4656

# Description ℹ️

Adds details about an order's type to the TX list and details page. Also tweaks a minor text contrast issue in the deterministic order details view.

# Demo 📺
## TX List is now more specific
<img width="745" alt="Screenshot 2023-12-04 at 15 15 18" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/d7f387eb-aef6-45a1-bc60-bbee816dd696">

## Limit order is now described as such explicitly
<img width="611" alt="Screenshot 2023-12-04 at 15 15 37" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/e3c77b64-2026-4655-a803-c68b7874366c">

## Market order is now more clearly a market order
<img width="679" alt="Screenshot 2023-12-04 at 15 15 28" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/32ab8ddb-353c-430a-87fe-fce5210c1e49">

## It fits fine on mobile/dark view too
<img width="462" alt="Screenshot 2023-12-04 at 15 18 22" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/a404d78b-2dd3-4697-a2a2-d7898fc6eb79">



