### PR TITLE
fix(governance): disable penalty column in standby validator table

### DIFF
--- a/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
+++ b/apps/governance/src/routes/staking/home/validator-tables/standby-pending-validators-table.tsx
@@ -16,7 +16,6 @@ import {
   stakedTotalPercentage,
   ValidatorFields,
   ValidatorRenderer,
-  TotalPenaltiesRenderer,
   TotalStakeRenderer,
   StakeShareRenderer,
   PendingStakeRenderer,
@@ -241,13 +240,6 @@ export const StandbyPendingValidatorsTable = ({
         //   cellRenderer: StakeNeededForPromotionRenderer,
         //   width: 210,
         // },
-        {
-          field: ValidatorFields.TOTAL_PENALTIES,
-          headerName: t(ValidatorFields.TOTAL_PENALTIES).toString(),
-          headerTooltip: t('TotalPenaltiesDescription').toString(),
-          cellRenderer: TotalPenaltiesRenderer,
-          width: 120 + 210,
-        },
       ],
       []
     );


### PR DESCRIPTION
# Related issues 🔗

Closes #5191

# Description ℹ️

Fixing this in the specific way outlined in the ticket was hard, as so many of these values are calculated by munging
together bits of data from different APIs. So I undid all those changes and just hid the 'Penalties' column from the 
standby validators table.

# Demo 📺
<img width="906" alt="Screenshot 2023-12-04 at 16 09 11" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/5fecf44a-1076-4d17-869e-df1ba1040625">

