### PR TITLE
fix(trading): missing party ID when there is no SLA data

### DIFF
--- a/libs/liquidity/src/lib/liquidity-data-provider.spec.tsx
+++ b/libs/liquidity/src/lib/liquidity-data-provider.spec.tsx
@@ -119,6 +119,8 @@ describe('getLiquidityProvision', () => {
         createdAt: '2022-12-16T09:28:29.071781Z',
         id: 'dde288688af2aeb5feb349dd72d3679a7a9be34c7375f6a4a48ef2f6140e7e59',
         fee: '0.001',
+        partyId:
+          'dde288688af2aeb5feb349dd72d3679a7a9be34c7375f6a4a48ef2f6140e7e59',
         party: {
           __typename: 'Party',
           accountsConnection: {

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -5,17 +5,18 @@ import {
 } from '@vegaprotocol/data-provider';
 import * as Schema from '@vegaprotocol/types';
 import BigNumber from 'bignumber.js';
-
 import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
+
   LiquidityProviderFieldsFragment,
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,
   LiquidityProvisionsQuery,
-  LiquidityProvisionsQueryVariables,
+  LiquidityProvisionsQueryVariables} from './__generated__/MarketLiquidity';
+import type {
+  LiquidityProvisionFieldsFragment
 } from './__generated__/MarketLiquidity';
-import type { LiquidityProvisionFieldsFragment } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
   Schema.LiquiditySLAParameters & {

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -9,13 +9,14 @@ import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
   LiquidityProviderFieldsFragment,
+
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,
   LiquidityProvisionsQuery,
-  LiquidityProvisionsQueryVariables,
+  LiquidityProvisionsQueryVariables} from './__generated__/MarketLiquidity';
+import type {
+  LiquidityProvisionFieldsFragment
 } from './__generated__/MarketLiquidity';
-
-import type { LiquidityProvisionFieldsFragment } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
   Schema.LiquiditySLAParameters & {

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -9,16 +9,13 @@ import BigNumber from 'bignumber.js';
 import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
-} from './__generated__/MarketLiquidity';
-
-import type {
   LiquidityProviderFieldsFragment,
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,
-  LiquidityProvisionFieldsFragment,
   LiquidityProvisionsQuery,
   LiquidityProvisionsQueryVariables,
 } from './__generated__/MarketLiquidity';
+import type { LiquidityProvisionFieldsFragment } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
   Schema.LiquiditySLAParameters & {
@@ -163,7 +160,10 @@ export const getLiquidityProvision = (
       const liquidityProvider = liquidityProviders.find(
         (f) => liquidityProvision.party.id === f.partyId
       );
-      if (!liquidityProvider) return liquidityProvision;
+
+      if (!liquidityProvider)
+        {return { ...liquidityProvision, partyId: liquidityProvision.party.id };}
+
       const accounts = compact(
         liquidityProvision.party.accountsConnection?.edges
       ).map((e) => e.node);

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -9,13 +9,13 @@ import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
   LiquidityProviderFieldsFragment,
-
+} from './__generated__/MarketLiquidity';
+import type {
+  LiquidityProvisionFieldsFragment,
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,
   LiquidityProvisionsQuery,
-  LiquidityProvisionsQueryVariables} from './__generated__/MarketLiquidity';
-import type {
-  LiquidityProvisionFieldsFragment
+  LiquidityProvisionsQueryVariables,
 } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
@@ -126,8 +126,8 @@ export const matchFilter = (filter: Filter, lp: LiquidityProvisionData) => {
 
 export interface LiquidityProvisionData
   extends Omit<LiquidityProvisionFields, '__typename'>,
-    Partial<LiquidityProviderFieldsFragment>,
-    Omit<Schema.LiquiditySLAParameters, '__typename'> {
+  Partial<LiquidityProviderFieldsFragment>,
+  Omit<Schema.LiquiditySLAParameters, '__typename'> {
   assetDecimalPlaces?: number;
   balance?: number;
   averageEntryValuation?: string;

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -161,8 +161,12 @@ export const getLiquidityProvision = (
         (f) => liquidityProvision.party.id === f.partyId
       );
 
-      if (!liquidityProvider)
-        {return { ...liquidityProvision, partyId: liquidityProvision.party.id };}
+      if (!liquidityProvider) {
+        return {
+          ...liquidityProvision,
+          partyId: liquidityProvision.party.id,
+        };
+      }
 
       const accounts = compact(
         liquidityProvision.party.accountsConnection?.edges

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -5,20 +5,17 @@ import {
 } from '@vegaprotocol/data-provider';
 import * as Schema from '@vegaprotocol/types';
 import BigNumber from 'bignumber.js';
-
 import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
-
   LiquidityProviderFieldsFragment,
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,
   LiquidityProvisionsQuery,
-  LiquidityProvisionsQueryVariables} from './__generated__/MarketLiquidity';
-
-import type {
-  LiquidityProvisionFieldsFragment
+  LiquidityProvisionsQueryVariables,
 } from './__generated__/MarketLiquidity';
+
+import type { LiquidityProvisionFieldsFragment } from './__generated__/MarketLiquidity';
 
 export type LiquidityProvisionFields = LiquidityProvisionFieldsFragment &
   Schema.LiquiditySLAParameters & {

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -126,8 +126,8 @@ export const matchFilter = (filter: Filter, lp: LiquidityProvisionData) => {
 
 export interface LiquidityProvisionData
   extends Omit<LiquidityProvisionFields, '__typename'>,
-  Partial<LiquidityProviderFieldsFragment>,
-  Omit<Schema.LiquiditySLAParameters, '__typename'> {
+    Partial<LiquidityProviderFieldsFragment>,
+    Omit<Schema.LiquiditySLAParameters, '__typename'> {
   assetDecimalPlaces?: number;
   balance?: number;
   averageEntryValuation?: string;

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -8,9 +8,9 @@ import BigNumber from 'bignumber.js';
 import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
-  LiquidityProviderFieldsFragment,
 } from './__generated__/MarketLiquidity';
 import type {
+  LiquidityProviderFieldsFragment,
   LiquidityProvisionFieldsFragment,
   LiquidityProvidersQuery,
   LiquidityProvidersQueryVariables,

--- a/libs/liquidity/src/lib/liquidity-data-provider.ts
+++ b/libs/liquidity/src/lib/liquidity-data-provider.ts
@@ -5,6 +5,7 @@ import {
 } from '@vegaprotocol/data-provider';
 import * as Schema from '@vegaprotocol/types';
 import BigNumber from 'bignumber.js';
+
 import {
   LiquidityProvidersDocument,
   LiquidityProvisionsDocument,
@@ -14,6 +15,7 @@ import {
   LiquidityProvidersQueryVariables,
   LiquidityProvisionsQuery,
   LiquidityProvisionsQueryVariables} from './__generated__/MarketLiquidity';
+
 import type {
   LiquidityProvisionFieldsFragment
 } from './__generated__/MarketLiquidity';


### PR DESCRIPTION
# Related issues 🔗

Closes #5450 

# Description ℹ️

The LP table shows `-` for party ID when there was no SLA data. 
We did not have this mismatch before. 

# Demo 📺

<img width="1680" alt="Screenshot 2023-12-05 at 14 17 37" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/dbae85a7-1b42-4d42-a729-4ddc746f659e">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
