### PR TITLE
fix(trading): required vol shown if current is zero

### DIFF
--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -312,16 +312,23 @@ export const CurrentVolume = ({
 }) => {
   const nextTier = tiers[tierIndex + 1];
   const requiredForNextTier = nextTier
-    ? Number(nextTier.minimumRunningNotionalTakerVolume) - windowLengthVolume
-    : 0;
+    ? new BigNumber(nextTier.minimumRunningNotionalTakerVolume).minus(
+        windowLengthVolume
+      )
+    : new BigNumber(0);
+  const currentVolume = new BigNumber(windowLengthVolume);
 
   return (
     <div>
       <Stat
-        value={formatNumberRounded(new BigNumber(windowLengthVolume))}
+        value={
+          currentVolume.isZero()
+            ? `<${formatNumberRounded(requiredForNextTier)}`
+            : formatNumberRounded(currentVolume)
+        }
         text={t('Past %s epochs', windowLength.toString())}
       />
-      {requiredForNextTier > 0 && (
+      {requiredForNextTier.isGreaterThan(0) && (
         <Stat
           value={formatNumber(requiredForNextTier)}
           text={t('Required for next tier')}


### PR DESCRIPTION
# Related issues 🔗

Closes #5447 

# Description ℹ️

 Shows less than the required volume if the current vol is 0. 

# Demo 📺

<img width="756" alt="Screenshot 2023-12-05 at 15 13 28" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/08149866-940e-4e28-86e6-1d17a3da089b">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
