### PR TITLE
fix(trading): fix tabs covered by orderbook splash

### DIFF
--- a/libs/market-depth/src/lib/orderbook.tsx
+++ b/libs/market-depth/src/lib/orderbook.tsx
@@ -198,7 +198,7 @@ export const Orderbook = ({
             );
             return (
               <div
-                className="overflow-hidden grid"
+                className="overflow-hidden grid relative"
                 data-testid="orderbook-grid-element"
                 style={{
                   width,


### PR DESCRIPTION
# Description ℹ️

When there is no orders splash rendered by orderbook covered Orderbook, Trades tabs
