### PR TITLE
fix(trading): internal condition timestamp

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.spec.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.spec.tsx
@@ -135,7 +135,7 @@ describe('MarketInfoPanels', () => {
       render(<DataSourceProof dataSourceSpecId={''} {...props} />);
       expect(screen.getByText('Internal conditions')).toBeInTheDocument();
       const dateFromUnixTimestamp = condition.value
-        ? getDateTimeFormat().format(new Date(parseInt(condition.value)))
+        ? getDateTimeFormat().format(new Date(parseInt(condition.value) * 1000))
         : '-';
       expect(
         screen.getByText(

--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -1262,7 +1262,9 @@ export const DataSourceProof = ({
           {data.sourceType.sourceType?.conditions?.map((condition, i) => {
             if (!condition) return null;
             const dateFromUnixTimestamp = condition.value
-              ? getDateTimeFormat().format(new Date(parseInt(condition.value)))
+              ? getDateTimeFormat().format(
+                  new Date(parseInt(condition.value) * 1000)
+                )
               : '-';
             return (
               <p key={i}>


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

The expiry in the top ribbon is correctly formatted, but the one in market info is off by 3 trailing zeros (AKA 54 years)

# Demo 📺
Fixes: 
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/ef8cf445-a151-4473-89b9-15c754b5147e)

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
