### PR TITLE
chore(trading): black formatting and removed double fixtures

### DIFF
--- a/apps/trading/e2e/tests/assets/test_assets.py
+++ b/apps/trading/e2e/tests/assets/test_assets.py
@@ -56,11 +56,12 @@ label_value_tooltip_pairs = [
 
 def tooltip(page: Page, index: int, test_id: str, tooltip: str):
     page.locator(f"data-testid={index}_{test_id}").hover()
-    expect(page.locator('[role="tooltip"]').locator("div")).to_have_text(tooltip)
+    expect(page.locator('[role="tooltip"]').locator(
+        "div")).to_have_text(tooltip)
     page.get_by_test_id("dialog-title").click()
 
 
-@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("continuous_market", "auth", "risk_accepted")
 def test_asset_details(page: Page):
     page.goto("/#/portfolio")
     page.locator('[data-testid="tab-collateral"] >> text=tDAI').click()
@@ -73,17 +74,22 @@ def test_asset_details(page: Page):
         value = pair.get("value", "")
         label_tooltip = pair.get("labelTooltip", "")
         value_tooltip = pair.get("valueToolTip", "")
-    
+
         if label == "ID":
-            expect(page.get_by_role("button", name="Copy id to clipboard")).to_be_visible()
-            asset_id_text = page.locator(f"[data-testid='{index}_value']").inner_text()
+            expect(page.get_by_role(
+                "button", name="Copy id to clipboard")).to_be_visible()
+            asset_id_text = page.locator(
+                f"[data-testid='{index}_value']").inner_text()
             pattern = r"^[0-9a-f]{6}\u2026[0-9a-f]{4}"
 
-            assert re.match(pattern, asset_id_text), f"Expected ID to match pattern but got {asset_id_text}"
+            assert re.match(
+                pattern, asset_id_text), f"Expected ID to match pattern but got {asset_id_text}"
 
         else:
-            expect(page.locator(f"[data-testid='{index}_label']")).to_have_text(label)
-            expect(page.locator(f"[data-testid='{index}_value']")).to_have_text(value)
+            expect(page.locator(
+                f"[data-testid='{index}_label']")).to_have_text(label)
+            expect(page.locator(
+                f"[data-testid='{index}_value']")).to_have_text(value)
 
         if label_tooltip:
             tooltip(page, index, "label", label_tooltip)

--- a/apps/trading/e2e/tests/deal_ticket/test_basic_submit.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_basic_submit.py
@@ -14,19 +14,16 @@ market_order = "order-type-Market"
 tif = "order-tif"
 expire = "expire"
 
-
 @pytest.fixture(scope="module")
 def vega(request):
     with init_vega(request) as vega:
         yield vega
 
-
 @pytest.fixture(scope="module")
 def continuous_market(vega):
     return setup_continuous_market(vega)
 
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_buy_order_GTT(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(tif).select_option("Good 'til Time (GTT)")
@@ -54,8 +51,7 @@ def test_limit_buy_order_GTT(continuous_market, vega: VegaService, page: Page):
         "BTC:DAI_2023Futr10+10LimitFilled120.00GTT:"
     )
 
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_buy_order(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     
@@ -72,8 +68,7 @@ def test_limit_buy_order(continuous_market, vega: VegaService, page: Page):
         "BTC:DAI_2023Futr10+10LimitFilled120.00GTC"
     )
 
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_sell_order(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(order_size).fill("10")
@@ -97,8 +92,7 @@ def test_limit_sell_order(continuous_market, vega: VegaService, page: Page):
         "BTC:DAI_2023Futr10-10LimitFilled100.00GFN"
     )
 
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_market_sell_order(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(market_order).click()
@@ -122,8 +116,7 @@ def test_market_sell_order(continuous_market, vega: VegaService, page: Page):
         "BTC:DAI_2023Futr10-10MarketFilled-IOC"
     )
 
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_market_buy_order(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(market_order).click()

--- a/apps/trading/e2e/tests/deal_ticket/test_deal_ticket_basics.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_deal_ticket_basics.py
@@ -13,7 +13,7 @@ def continuous_market(vega):
     return setup_continuous_market(vega)
 
 @pytest.mark.skip("We currently can't approve wallet connection through Sim")
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_connect_vega_wallet(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("order-price").fill("101")
@@ -25,7 +25,7 @@ def test_connect_vega_wallet(continuous_market, page: Page):
     expect(page.get_by_test_id("order-type-Limit")).to_be_checked()
     expect(page.get_by_test_id("order-price")).to_have_value("101")
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_sidebar_should_be_open_after_reload(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     expect(page.get_by_test_id("deal-ticket-form")).to_be_visible()

--- a/apps/trading/e2e/tests/deal_ticket/test_fees_margin_estimations.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_fees_margin_estimations.py
@@ -12,7 +12,7 @@ market_trading_mode = "market-trading-mode"
 
 
 @pytest.mark.skip("tbd")
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_margin_and_fees_estimations(continuous_market, vega: VegaService, page: Page):
     # setup continuous trading market with one user buy trade
     market_id = continuous_market

--- a/apps/trading/e2e/tests/deal_ticket/test_stop_order.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_stop_order.py
@@ -38,7 +38,6 @@ timeInForce_col = '[col-id="submission.timeInForce"]'
 updatedAt_col = '[col-id="updatedAt"]'
 close_toast = "toast-close"
 
-
 def create_position(vega: VegaService, market_id):
     submit_order(vega, "Key 1", market_id, "SIDE_SELL", 100, 110)
     submit_order(vega, "Key 1", market_id, "SIDE_BUY", 100, 110)
@@ -46,7 +45,7 @@ def create_position(vega: VegaService, market_id):
     vega.wait_fn(1)
     vega.wait_for_total_catchup
 
-@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_stop_order_form_error_validation(continuous_market, page: Page):
     # 7002-SORD-032
     page.goto(f"/#/markets/{continuous_market}")
@@ -69,7 +68,7 @@ def test_stop_order_form_error_validation(continuous_market, page: Page):
     )
 
 @pytest.mark.skip("core issue")
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(stop_orders_tab).click()
@@ -107,7 +106,7 @@ def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: 
     ).not_to_be_empty()
 
 @pytest.mark.skip("core issue")
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_market_order_triggered(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -165,7 +164,7 @@ def test_submit_stop_market_order_triggered(
     ).not_to_be_empty()
 
 @pytest.mark.skip("core issue")
-@pytest.mark.usefixtures("continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_limit_order_pending(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -226,7 +225,7 @@ def test_submit_stop_limit_order_pending(
     ).not_to_be_empty()
 
 @pytest.mark.skip("core issue")
-@pytest.mark.usefixtures("continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_limit_order_cancel(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -270,7 +269,7 @@ class TestStopOcoValidation:
     def continuous_market(self, vega):
         return setup_continuous_market(vega)
 
-    @pytest.mark.usefixtures("page", "auth", "risk_accepted")
+    @pytest.mark.usefixtures("auth", "risk_accepted")
     def test_stop_market_order_form_validation(self, continuous_market, page: Page):
         # 7002-SORD-052
         # 7002-SORD-055
@@ -303,7 +302,7 @@ class TestStopOcoValidation:
         expect(page.get_by_test_id(order_size)).to_be_empty
         expect(page.get_by_test_id(order_price)).not_to_be_visible()
 
-    @pytest.mark.usefixtures("page", "auth", "risk_accepted")
+    @pytest.mark.usefixtures("auth", "risk_accepted")
     def test_stop_limit_order_form_validation(self, continuous_market, page: Page):
         # 7002-SORD-020
         # 7002-SORD-021
@@ -347,7 +346,7 @@ class TestStopOcoValidation:
         expect(page.get_by_test_id(order_price)).to_be_empty()
 
     @pytest.mark.skip("core issue")
-    @pytest.mark.usefixtures("page", "auth", "risk_accepted")
+    @pytest.mark.usefixtures("auth", "risk_accepted")
     def test_maximum_number_of_active_stop_orders(
         self, continuous_market, vega: VegaService, page: Page
     ):

--- a/apps/trading/e2e/tests/deal_ticket/test_stop_order_oco.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_stop_order_oco.py
@@ -4,7 +4,6 @@ from vega_sim.service import VegaService
 from actions.vega import submit_order
 from actions.utils import wait_for_toast_confirmation
 
-
 stop_order_btn = "order-type-Stop"
 stop_limit_order_btn = "order-type-StopLimit"
 stop_market_order_btn = "order-type-StopMarket"
@@ -50,7 +49,7 @@ def create_position(vega: VegaService, market_id):
     vega.wait_for_total_catchup
 
 
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_order_market_oco_rejected(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -127,7 +126,7 @@ def test_submit_stop_order_market_oco_rejected(
     assert trigger_price_list.sort() == trigger_value_list.sort()
 
 
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_oco_market_order_triggered(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -204,7 +203,7 @@ def test_submit_stop_oco_market_order_triggered(
     assert trigger_price_list.sort() == trigger_value_list.sort()
 
 
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_oco_market_order_pending(
     continuous_market, vega: VegaService, page: Page
 ):  
@@ -236,7 +235,7 @@ def test_submit_stop_oco_market_order_pending(
         "PendingOCO"
     )
 
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
 def test_submit_stop_oco_limit_order_pending(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -287,7 +286,7 @@ def test_submit_stop_oco_limit_order_pending(
     assert trigger_price_list.sort() == trigger_value_list.sort()
 
 
-@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_submit_stop_oco_limit_order_cancel(
     continuous_market, vega: VegaService, page: Page
 ):
@@ -325,5 +324,3 @@ def test_submit_stop_oco_limit_order_cancel(
     expect(
         page.locator(".ag-center-cols-container").locator('[col-id="status"]').last
     ).to_have_text("CancelledOCO")
-
-

--- a/apps/trading/e2e/tests/deal_ticket/test_trading_deal_ticket_submit_account.py
+++ b/apps/trading/e2e/tests/deal_ticket/test_trading_deal_ticket_submit_account.py
@@ -5,8 +5,6 @@ from actions.utils import change_keys
 from conftest import init_vega
 from fixtures.market import setup_continuous_market
 
-
-
 order_size = "order-size"
 order_price = "order-price"
 place_order = "place-order"
@@ -18,13 +16,12 @@ def vega(request):
     with init_vega(request) as vega:
         yield vega
 
-
 @pytest.fixture(scope="module")
 def continuous_market(vega):
     return setup_continuous_market(vega)
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
-def test_should_display_info_and_button_for_deposit(continuous_market, vega: VegaService, page: Page):
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_should_display_info_and_button_for_deposit(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(order_size).fill("200000")
     page.get_by_test_id(order_price).fill("20")
@@ -35,7 +32,7 @@ def test_should_display_info_and_button_for_deposit(continuous_market, vega: Veg
     page.get_by_test_id(deal_ticket_deposit_dialog_button).nth(0).click()
     expect(page.get_by_test_id("sidebar-content")).to_contain_text("DepositFrom")
     
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_should_show_an_error_if_your_balance_is_zero(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     vega.create_key("key_empty")

--- a/apps/trading/e2e/tests/get_started/test_get_started.py
+++ b/apps/trading/e2e/tests/get_started/test_get_started.py
@@ -10,20 +10,16 @@ import logging
 
 logger = logging.getLogger()
 
-
 @pytest.fixture(scope="class")
 def vega():
     with init_vega() as vega:
         yield vega
 
-
-# we can reuse vega market-sim service and market in almost all tests
 @pytest.fixture(scope="class")
 def simple_market(vega: VegaService):
     return setup_simple_market(vega)
 
 class TestGetStarted:
-    @pytest.mark.usefixtures("page")
     def test_get_started_interactive(self, vega: VegaService, page: Page):
         page.goto("/")
         # 0007-FUGS-001
@@ -134,8 +130,7 @@ class TestGetStarted:
         # Assert dialog isn't visible
         expect(page.get_by_test_id("welcome-dialog")).not_to_be_visible()
         
-        
-    @pytest.mark.usefixtures("page", "risk_accepted")
+    @pytest.mark.usefixtures("risk_accepted")
     def test_get_started_seen_already(self, simple_market, page: Page):
         page.goto(f"/#/markets/{simple_market}")
         get_started_locator = page.get_by_test_id("connect-vega-wallet")
@@ -148,8 +143,6 @@ class TestGetStarted:
         # 0007-FUGS-007
         expect(page.get_by_test_id("dialog-content").nth(1)).to_be_visible()
 
-
-    @pytest.mark.usefixtures("page")
     def test_browser_wallet_installed(self, simple_market, page: Page):
         page.add_init_script("window.vega = {}")
         page.goto(f"/#/markets/{simple_market}")
@@ -159,14 +152,13 @@ class TestGetStarted:
         expect(locator).to_be_visible
         expect(locator).to_have_text("Connect")
 
-
-    @pytest.mark.usefixtures("page", "risk_accepted")
+    @pytest.mark.usefixtures("risk_accepted")
     def test_get_started_deal_ticket(self,simple_market, page: Page):
         page.goto(f"/#/markets/{simple_market}")
         expect(page.get_by_test_id("order-connect-wallet")).to_have_text("Connect wallet")
 
 
-    @pytest.mark.usefixtures("page", "risk_accepted")
+    @pytest.mark.usefixtures("risk_accepted")
     def test_browser_wallet_installed_deal_ticket(simple_market, page: Page):
         page.add_init_script("window.vega = {}")
         page.goto(f"/#/markets/{simple_market}")
@@ -174,7 +166,6 @@ class TestGetStarted:
         page.wait_for_selector('[data-testid="sidebar-content"]', state="visible")
         expect(page.get_by_test_id("get-started-banner")).not_to_be_visible()
 
-    @pytest.mark.usefixtures("page")
     def test_redirect_default_market(self, continuous_market, vega: VegaService, page: Page):
         page.goto("/")
         # 0007-FUGS-012
@@ -186,7 +177,6 @@ class TestGetStarted:
         expect(page.get_by_test_id("welcome-dialog")).not_to_be_visible()
 
 class TestBrowseAll: 
-    @pytest.mark.usefixtures("page")
     def test_get_started_browse_all(self, simple_market, vega: VegaService, page: Page):
         page.goto("/")
         print(simple_market)

--- a/apps/trading/e2e/tests/iceberg_orders/test_iceberg_orders.py
+++ b/apps/trading/e2e/tests/iceberg_orders/test_iceberg_orders.py
@@ -11,7 +11,6 @@ def hover_and_assert_tooltip(page: Page, element_text):
     element.hover()
     expect(page.get_by_role("tooltip")).to_be_visible()
 
-
 class TestIcebergOrdersValidations:
     @pytest.fixture(scope="class")
     def vega(self, request):
@@ -22,7 +21,7 @@ class TestIcebergOrdersValidations:
     def continuous_market(self, vega):
         return setup_continuous_market(vega)
 
-    @pytest.mark.usefixtures("page", "auth", "risk_accepted")
+    @pytest.mark.usefixtures("auth", "risk_accepted")
     def test_iceberg_submit(self, continuous_market, vega: VegaService, page: Page):
         page.goto(f"/#/markets/{continuous_market}")
         page.get_by_test_id("iceberg").click()
@@ -47,7 +46,7 @@ class TestIcebergOrdersValidations:
             (page.get_by_role("row").locator('[col-id="type"]')).nth(1)
         ).to_have_text("Limit (Iceberg)")
 
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_iceberg_open_order(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
 

--- a/apps/trading/e2e/tests/liquidity_provision/test_liquidity_provision.py
+++ b/apps/trading/e2e/tests/liquidity_provision/test_liquidity_provision.py
@@ -17,27 +17,34 @@ def continuous_market(vega):
     return setup_continuous_market(vega)
 
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_liquidity_provision_amendment(continuous_market, vega: VegaService, page: Page):
     # TODO Refactor asserting the grid
     page.goto(f"/#/liquidity/{continuous_market}")
     change_keys(page, vega, "market_maker")
-    row = page.get_by_test_id("tab-myLP").locator(".ag-center-cols-container .ag-row").first
+    row = page.get_by_test_id(
+        "tab-myLP").locator(".ag-center-cols-container .ag-row").first
     expect(row).to_contain_text(
         "Active"
     )
     # 5002-LIQP-006
-    expect(page.get_by_test_id("target-stake")).to_have_text("Target stake5.82757 tDAI")
+    expect(page.get_by_test_id("target-stake")
+           ).to_have_text("Target stake5.82757 tDAI")
     # 5002-LIQP-007
-    expect(page.get_by_test_id("supplied-stake")).to_have_text("Supplied stake10,000.00 tDAI")
+    expect(page.get_by_test_id("supplied-stake")
+           ).to_have_text("Supplied stake10,000.00 tDAI")
     # 5002-LIQP-008
-    expect(page.get_by_test_id("liquidity-supplied")).to_have_text("Liquidity supplied 171,598.11%")
+    expect(page.get_by_test_id("liquidity-supplied")
+           ).to_have_text("Liquidity supplied 171,598.11%")
     expect(page.get_by_test_id("fees-paid")).to_have_text("Fees paid-")
     # 5002-LIQP-009
-    expect(page.get_by_test_id("liquidity-market-id")).to_have_text("Market ID" + truncate_middle(continuous_market))
-    expect(page.get_by_test_id("liquidity-learn-more")).to_have_text("Learn moreProviding liquidity")
+    expect(page.get_by_test_id("liquidity-market-id")
+           ).to_have_text("Market ID" + truncate_middle(continuous_market))
+    expect(page.get_by_test_id("liquidity-learn-more")
+           ).to_have_text("Learn moreProviding liquidity")
     # 002-LIQP-010
-    expect(page.get_by_test_id("liquidity-learn-more").get_by_test_id("external-link")).to_have_attribute("href", "https://docs.vega.xyz/testnet/concepts/liquidity/provision")
+    expect(page.get_by_test_id("liquidity-learn-more").get_by_test_id("external-link")
+           ).to_have_attribute("href", "https://docs.vega.xyz/testnet/concepts/liquidity/provision")
 
     vega.submit_simple_liquidity(
         key_name="market_maker",
@@ -50,26 +57,32 @@ def test_liquidity_provision_amendment(continuous_market, vega: VegaService, pag
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
     page.reload()
-    row = page.get_by_test_id("tab-myLP").locator(".ag-center-cols-container .ag-row").first
+    row = page.get_by_test_id(
+        "tab-myLP").locator(".ag-center-cols-container .ag-row").first
     expect(row).to_contain_text(
         "Updating next epoch"
     )
     next_epoch(vega=vega)
     page.reload()
-    expect(page.get_by_test_id("supplied-stake")).to_have_text("Supplied stake1.00001 tDAI")
-    expect(page.get_by_test_id("liquidity-supplied")).to_have_text("Liquidity supplied 17.16%")
-    row = page.get_by_test_id("tab-myLP").locator(".ag-center-cols-container .ag-row").first
+    expect(page.get_by_test_id("supplied-stake")
+           ).to_have_text("Supplied stake1.00001 tDAI")
+    expect(page.get_by_test_id("liquidity-supplied")
+           ).to_have_text("Liquidity supplied 17.16%")
+    row = page.get_by_test_id(
+        "tab-myLP").locator(".ag-center-cols-container .ag-row").first
     expect(row).to_contain_text(
         "Active"
     )
 
+
 @pytest.mark.skip("Waiting for the ability to cancel LP")
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_liquidity_provision_inactive(continuous_market, vega: VegaService, page: Page):
     # TODO Refactor asserting the grid
     page.goto(f"/#/liquidity/{continuous_market}")
-    change_keys(page,vega, "market_maker")
-    row = page.get_by_test_id("tab-myLP").locator(".ag-center-cols-container .ag-row").first
+    change_keys(page, vega, "market_maker")
+    row = page.get_by_test_id(
+        "tab-myLP").locator(".ag-center-cols-container .ag-row").first
     expect(row).to_contain_text(
         "Active"
     )
@@ -82,4 +95,3 @@ def test_liquidity_provision_inactive(continuous_market, vega: VegaService, page
     )
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
-    

--- a/apps/trading/e2e/tests/market/test_closed_markets.py
+++ b/apps/trading/e2e/tests/market/test_closed_markets.py
@@ -12,6 +12,7 @@ def vega():
     with init_vega() as vega:
         yield vega
 
+
 @pytest.fixture(scope="class")
 def create_settled_market(vega: VegaService):
     market_id = setup_continuous_market(vega)
@@ -73,8 +74,9 @@ class TestSettledMarket:
         # 6001-MARK-010
         pattern = r"(\d+)\s+(months|hours|days)\s+ago"
         date_text = row_selector.locator('[col-id="settlementDate"]').inner_text()
-        assert re.match(pattern, date_text), f"Expected text to match pattern but got {date_text}"
-       
+        assert re.match(
+            pattern, date_text
+        ), f"Expected text to match pattern but got {date_text}"
 
         expected_pattern = re.compile(r"https://.*?/oracles/[a-f0-9]{64}")
         actual_href = row_selector.locator(
@@ -87,12 +89,12 @@ class TestSettledMarket:
         expect(row_selector.locator('[col-id="bestBidPrice"]')).to_have_text("0.00")
         # 6001-MARK-012
         expect(row_selector.locator('[col-id="bestOfferPrice"]')).to_have_text("0.00")
-        # 6001-MARK-013 
+        # 6001-MARK-013
         expect(row_selector.locator('[col-id="markPrice"]')).to_have_text("110.00")
         # 6001-MARK-014
         # 6001-MARK-015
         # 6001-MARK-016
-        #tbd currently we have value unknown 
+        # tbd currently we have value unknown
         # expect(row_selector.locator('[col-id="settlementDataOracleId"]')).to_have_text(
         #     "110.00"
         # )
@@ -107,7 +109,9 @@ class TestSettledMarket:
         # 6001-MARK-018
         expect(row_selector.locator('[col-id="settlementAsset"]')).to_have_text("tDAI")
         # 6001-MARK-020
-        assert re.match(pattern, date_text), f"Expected text to match pattern but got {date_text}"
+        assert re.match(
+            pattern, date_text
+        ), f"Expected text to match pattern but got {date_text}"
 
 
 @pytest.mark.usefixtures("risk_accepted", "auth")

--- a/apps/trading/e2e/tests/market/test_market.py
+++ b/apps/trading/e2e/tests/market/test_market.py
@@ -31,7 +31,7 @@ initial_spread: float = 0.1
 market_name = "BTC:DAI_2023"
 
 
-@pytest.mark.usefixtures("vega", "page", "simple_market", "risk_accepted", "auth")
+@pytest.mark.usefixtures("risk_accepted", "auth")
 def test_price_monitoring(simple_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/all")
     expect(page.locator(table_row_selector).locator(trading_mode_col)).to_have_text(
@@ -75,7 +75,7 @@ def test_price_monitoring(simple_market, vega: VegaService, page: Page):
         time_in_force="TIME_IN_FORCE_GTC",
         volume=99,
     )
-    #6002-MDET-009
+    # 6002-MDET-009
     expect(
         page.get_by_test_id(liquidity_supplied).get_by_test_id(item_value)
     ).to_have_text("0.00 (0.00%)")
@@ -154,7 +154,7 @@ def test_price_monitoring(simple_market, vega: VegaService, page: Page):
 
     vega.forward("10s")
     vega.wait_fn(1)
-    vega.wait_for_total_catchup() 
+    vega.wait_for_total_catchup()
     expect(
         page.get_by_test_id(price_monitoring_bounds_row).first.get_by_text(
             "135.44204 BTC"
@@ -191,22 +191,28 @@ def test_price_monitoring(simple_market, vega: VegaService, page: Page):
     )
     # commented out because we have an issue #4233
     # expect(page.get_by_text("Opening auction")).to_be_hidden()
-    
-    #6002-MDET-009
+
+    # 6002-MDET-009
     expect(
         page.get_by_test_id(liquidity_supplied).get_by_test_id(item_value)
     ).to_have_text("50.00 (>100%)")
 
+
 COL_ID_FEE = ".ag-center-cols-container [col-id='fee'] .ag-cell-value"
 
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "risk_accepted", "auth")
+
+@pytest.mark.usefixtures("risk_accepted", "auth")
 def test_auction_uncross_fees(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("Fills").click()
     expect(page.locator(COL_ID_FEE)).to_have_text("0.00 tDAI")
     page.locator(COL_ID_FEE).hover()
-    expect(page.get_by_test_id("fee-breakdown-tooltip")).to_have_text("If the market was suspendedIf the market is in monitoring auction, half of the infrastructure and liquidity fees will be paid.Infrastructure fee0.00 tDAILiquidity fee0.00 tDAIMaker fee0.00 tDAITotal fees0.00 tDAI")
-    change_keys(page,vega, "market_maker")
+    expect(page.get_by_test_id("fee-breakdown-tooltip")).to_have_text(
+        "If the market was suspendedIf the market is in monitoring auction, half of the infrastructure and liquidity fees will be paid.Infrastructure fee0.00 tDAILiquidity fee0.00 tDAIMaker fee0.00 tDAITotal fees0.00 tDAI"
+    )
+    change_keys(page, vega, "market_maker")
     expect(page.locator(COL_ID_FEE)).to_have_text("0.00 tDAI")
     page.locator(COL_ID_FEE).hover()
-    expect(page.get_by_test_id("fee-breakdown-tooltip")).to_have_text("If the market was suspendedIf the market is in monitoring auction, half of the infrastructure and liquidity fees will be paid.Infrastructure fee0.00 tDAILiquidity fee0.00 tDAIMaker fee0.00 tDAITotal fees0.00 tDAI")
+    expect(page.get_by_test_id("fee-breakdown-tooltip")).to_have_text(
+        "If the market was suspendedIf the market is in monitoring auction, half of the infrastructure and liquidity fees will be paid.Infrastructure fee0.00 tDAILiquidity fee0.00 tDAIMaker fee0.00 tDAITotal fees0.00 tDAI"
+    )

--- a/apps/trading/e2e/tests/market/test_market_info.py
+++ b/apps/trading/e2e/tests/market/test_market_info.py
@@ -3,7 +3,6 @@ import pytest
 from playwright.sync_api import Page, expect
 from vega_sim.service import VegaService
 from fixtures.market import setup_continuous_market
-
 from conftest import init_page, init_vega, risk_accepted_setup
 
 market_title_test_id = "accordion-title"
@@ -15,7 +14,6 @@ def vega():
         yield vega
 
 
-# setting up everything in this single fixture, as all of the tests need the same setup, so no point in creating separate ones
 @pytest.fixture(scope="module")
 def page(vega, browser, request, local_server):
     with init_page(vega, browser, request,  local_server) as page:
@@ -122,7 +120,9 @@ def test_market_info_instrument(page: Page):
 
 
 # @pytest.mark.skip("oracle test to be fixed")
-def test_market_info_oracle(page: Page, vega: VegaService):
+
+
+def test_market_info_oracle(page: Page):
     # 6002-MDET-203
     page.get_by_test_id(market_title_test_id).get_by_text("Oracle").click()
     expect(

--- a/apps/trading/e2e/tests/market/test_market_selector.py
+++ b/apps/trading/e2e/tests/market/test_market_selector.py
@@ -2,7 +2,7 @@ import pytest
 from playwright.sync_api import expect, Page
 
 
-@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_market_selector(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     expect(page.get_by_test_id("market-selector")).not_to_be_visible()
@@ -27,7 +27,7 @@ def test_market_selector(continuous_market, page: Page):
     expect(btc_market.locator('[data-testid="sparkline-svg"]')).not_to_be_visible
 
 
-@pytest.mark.usefixtures("page", "continuous_market", "simple_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("simple_market", "auth", "risk_accepted")
 @pytest.mark.parametrize(
     "simple_market",
     [

--- a/apps/trading/e2e/tests/market/test_markets_no_markets.py
+++ b/apps/trading/e2e/tests/market/test_markets_no_markets.py
@@ -1,6 +1,5 @@
 import pytest
 from playwright.sync_api import Page, expect
-from vega_sim.service import VegaService
 
 from conftest import init_page, init_vega, risk_accepted_setup
 

--- a/apps/trading/e2e/tests/market/test_markets_proposed.py
+++ b/apps/trading/e2e/tests/market/test_markets_proposed.py
@@ -5,7 +5,7 @@ from playwright.sync_api import Page, expect
 from vega_sim.service import VegaService
 from conftest import init_vega
 from fixtures.market import setup_simple_market
-from wallet_config import MM_WALLET, MM_WALLET2, TERMINATE_WALLET, wallets
+from wallet_config import MM_WALLET
 
 row_selector = '[data-testid="tab-proposed-markets"] .ag-center-cols-container .ag-row'
 col_market_id = '[col-id="market"] [data-testid="stack-cell-primary"]'
@@ -15,6 +15,7 @@ col_market_id = '[col-id="market"] [data-testid="stack-cell-primary"]'
 def vega(request):
     with init_vega(request) as vega:
         yield vega
+
 
 @pytest.fixture(scope="module")
 def proposed_market(vega: VegaService):

--- a/apps/trading/e2e/tests/market/test_monitoring_auction_price_volatility_market.py
+++ b/apps/trading/e2e/tests/market/test_monitoring_auction_price_volatility_market.py
@@ -7,6 +7,7 @@ from conftest import init_vega
 from actions.utils import wait_for_toast_confirmation
 from wallet_config import MM_WALLET, MM_WALLET2
 
+
 @pytest.fixture(scope="module")
 def vega(request):
     with init_vega(request) as vega:
@@ -16,6 +17,7 @@ def vega(request):
 @pytest.fixture(scope="module")
 def simple_market(vega):
     return setup_simple_market(vega)
+
 
 @pytest.fixture(scope="module")
 def setup_market_monitoring_auction(vega: VegaService, simple_market):
@@ -48,12 +50,18 @@ def setup_market_monitoring_auction(vega: VegaService, simple_market):
         volume=99,
     )
 
-
     # add orders to provide liquidity
     submit_order(vega, MM_WALLET.name, simple_market, "SIDE_BUY", 1, 1)
     submit_order(vega, MM_WALLET.name, simple_market, "SIDE_SELL", 1, 1)
-    submit_order(vega,MM_WALLET.name,simple_market, "SIDE_BUY",1,1 + 0.1 / 2,)
-    submit_order(vega,MM_WALLET.name,simple_market,"SIDE_SELL",1,1 + 0.1 / 2)
+    submit_order(
+        vega,
+        MM_WALLET.name,
+        simple_market,
+        "SIDE_BUY",
+        1,
+        1 + 0.1 / 2,
+    )
+    submit_order(vega, MM_WALLET.name, simple_market, "SIDE_SELL", 1, 1 + 0.1 / 2)
     submit_order(vega, MM_WALLET2.name, simple_market, "SIDE_SELL", 1, 1)
 
     vega.forward("10s")
@@ -71,9 +79,11 @@ def setup_market_monitoring_auction(vega: VegaService, simple_market):
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
-@pytest.mark.usefixtures("page", "risk_accepted", "simple_market", "auth", "setup_market_monitoring_auction")
-def test_market_monitoring_auction_price_volatility_limit_order(page: Page, simple_market, vega: VegaService):
-    
+
+@pytest.mark.usefixtures("risk_accepted", "auth", "setup_market_monitoring_auction")
+def test_market_monitoring_auction_price_volatility_limit_order(
+    page: Page, simple_market, vega: VegaService
+):
     page.goto(f"/#/markets/{simple_market}")
     page.get_by_test_id("order-size").clear()
     page.get_by_test_id("order-size").type("1")
@@ -82,10 +92,14 @@ def test_market_monitoring_auction_price_volatility_limit_order(page: Page, simp
     page.get_by_test_id("order-tif").select_option("Fill or Kill (FOK)")
     page.get_by_test_id("place-order").click()
 
-    expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_have_text("This market is in auction due to high price volatility. Until the auction ends, you can only place GFA, GTT, or GTC limit orders.")
+    expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_have_text(
+        "This market is in auction due to high price volatility. Until the auction ends, you can only place GFA, GTT, or GTC limit orders."
+    )
     expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_be_visible()
 
-    expect(page.get_by_test_id("deal-ticket-warning-auction")).to_have_text("Any orders placed now will not trade until the auction ends")
+    expect(page.get_by_test_id("deal-ticket-warning-auction")).to_have_text(
+        "Any orders placed now will not trade until the auction ends"
+    )
     expect(page.get_by_test_id("deal-ticket-warning-auction")).to_be_visible()
 
     page.get_by_test_id("order-tif").select_option("Good 'til Cancelled (GTC)")
@@ -103,8 +117,11 @@ def test_market_monitoring_auction_price_volatility_limit_order(page: Page, simp
         "BTC:DAI_2023Futr0+1LimitActive110.00GTC"
     )
 
-@pytest.mark.usefixtures("page", "risk_accepted", "simple_market", "auth", "setup_market_monitoring_auction")
-def test_market_monitoring_auction_price_volatility_market_order(page: Page, simple_market):
+
+@pytest.mark.usefixtures("risk_accepted", "auth", "setup_market_monitoring_auction")
+def test_market_monitoring_auction_price_volatility_market_order(
+    page: Page, simple_market
+):
     page.goto(f"/#/markets/{simple_market}")
     page.get_by_test_id("order-type-Market").click()
     page.get_by_test_id("order-size").clear()
@@ -112,8 +129,12 @@ def test_market_monitoring_auction_price_volatility_market_order(page: Page, sim
     # 7002-SORD-060
     page.get_by_test_id("place-order").click()
 
-    expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_have_text("This market is in auction due to high price volatility. Until the auction ends, you can only place GFA, GTT, or GTC limit orders.")
+    expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_have_text(
+        "This market is in auction due to high price volatility. Until the auction ends, you can only place GFA, GTT, or GTC limit orders."
+    )
     expect(page.get_by_test_id("deal-ticket-error-message-tif")).to_be_visible()
 
-    expect(page.get_by_test_id("deal-ticket-error-message-type")).to_have_text("This market is in auction due to high price volatility. Only limit orders are permitted when market is in auction.")
+    expect(page.get_by_test_id("deal-ticket-error-message-type")).to_have_text(
+        "This market is in auction due to high price volatility. Only limit orders are permitted when market is in auction."
+    )
     expect(page.get_by_test_id("deal-ticket-error-message-type")).to_be_visible()

--- a/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
+++ b/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
@@ -9,8 +9,7 @@ from actions.utils import next_epoch
 from wallet_config import MM_WALLET, MM_WALLET2, GOVERNANCE_WALLET
 
 
-
-@pytest.mark.usefixtures("vega", "page", "proposed_market", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     # 7002-SORD-001
     # 7002-SORD-002
@@ -27,8 +26,12 @@ def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     # 6002-MDET-002
     expect(page.get_by_test_id("market-expiry")).to_have_text("ExpiryNot time-based")
     page.get_by_test_id("market-expiry").hover()
-    expect(page.get_by_test_id("expiry-tooltip").first).to_have_text("This market expires when triggered by its oracle, not on a set date.View oracle specification")
-    expect(page.get_by_test_id("expiry-tooltip").first.get_by_test_id("link")).to_have_attribute("href", re.compile('.*'))
+    expect(page.get_by_test_id("expiry-tooltip").first).to_have_text(
+        "This market expires when triggered by its oracle, not on a set date.View oracle specification"
+    )
+    expect(
+        page.get_by_test_id("expiry-tooltip").first.get_by_test_id("link")
+    ).to_have_attribute("href", re.compile(".*"))
     # 6002-MDET-003
     expect(page.get_by_test_id("market-price")).to_have_text("Mark Price0.00")
     # 6002-MDET-004
@@ -36,18 +39,30 @@ def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     # 6002-MDET-005
     expect(page.get_by_test_id("market-volume")).to_have_text("Volume (24h)-")
     # 6002-MDET-008
-    expect(page.get_by_test_id("market-settlement-asset")).to_have_text("Settlement assettDAI")
-    expect(page.get_by_test_id("liquidity-supplied")).to_have_text("Liquidity supplied 0.00 (0.00%)")
+    expect(page.get_by_test_id("market-settlement-asset")).to_have_text(
+        "Settlement assettDAI"
+    )
+    expect(page.get_by_test_id("liquidity-supplied")).to_have_text(
+        "Liquidity supplied 0.00 (0.00%)"
+    )
     page.get_by_test_id("liquidity-supplied").hover()
-    expect(page.get_by_test_id("liquidity-supplied-tooltip").first).to_have_text("Supplied stake0.00Target stake0.00View liquidity provision tableLearn about providing liquidity")
-    expect(page.get_by_test_id("liquidity-supplied-tooltip").first.get_by_test_id("link").first).to_have_text("View liquidity provision table")
+    expect(page.get_by_test_id("liquidity-supplied-tooltip").first).to_have_text(
+        "Supplied stake0.00Target stake0.00View liquidity provision tableLearn about providing liquidity"
+    )
+    expect(
+        page.get_by_test_id("liquidity-supplied-tooltip")
+        .first.get_by_test_id("link")
+        .first
+    ).to_have_text("View liquidity provision table")
     # check that market is in proposed state
     # 6002-MDET-006
     # 6002-MDET-007
     # 7002-SORD-061
     expect(trading_mode).to_have_text("No trading")
     trading_mode.hover()
-    expect(page.get_by_test_id("trading-mode-tooltip").first).to_have_text("No trading enabled for this market.")
+    expect(page.get_by_test_id("trading-mode-tooltip").first).to_have_text(
+        "No trading enabled for this market."
+    )
     expect(market_state).to_have_text("Proposed")
 
     # approve market

--- a/apps/trading/e2e/tests/order/test_order_details.py
+++ b/apps/trading/e2e/tests/order/test_order_details.py
@@ -48,8 +48,9 @@ def verify_order_value(
     else:
         expect(element).to_have_text(expected_text)
 
+
 @pytest.mark.skip("tbd")
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_order_details_are_correctly_displayed(
     continuous_market, vega: VegaService, page: Page
 ):

--- a/apps/trading/e2e/tests/order/test_order_match.py
+++ b/apps/trading/e2e/tests/order/test_order_match.py
@@ -8,6 +8,7 @@ from actions.vega import submit_order
 
 logger = logging.getLogger()
 
+
 # Could be turned into a helper function in the future.
 def verify_data_grid(page: Page, data_test_id, expected_pattern):
     page.get_by_test_id(data_test_id).click()
@@ -49,9 +50,7 @@ def submit_order(vega: VegaService, wallet_name, market_id, side, volume, price)
     )
 
 
-@pytest.mark.usefixtures(
-    "vega", "page", "opening_auction_market", "auth", "risk_accepted"
-)
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_order_trade_open_order(
     opening_auction_market, vega: VegaService, page: Page
 ):
@@ -80,7 +79,7 @@ def test_limit_order_trade_open_order(
     verify_data_grid(page, "Open", expected_open_order)
 
 
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_order_trade_open_position(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
 
@@ -148,7 +147,7 @@ def test_limit_order_trade_open_position(continuous_market, page: Page):
     expect(unrealisedPNL).to_have_text(position["unrealised_pnl"])
 
 
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_limit_order_trade_order_trade_away(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     # Assert that the order is no longer on the orderbook

--- a/apps/trading/e2e/tests/orderbook/test_orderbook.py
+++ b/apps/trading/e2e/tests/orderbook/test_orderbook.py
@@ -6,6 +6,7 @@ from conftest import init_vega
 from fixtures.market import setup_simple_market
 from wallet_config import MM_WALLET, MM_WALLET2
 
+
 @pytest.fixture(scope="module")
 def vega():
     with init_vega() as vega:
@@ -78,8 +79,9 @@ def verify_prices_descending(page: Page):
     prices = [float(price.text_content()) for price in prices_locator.all()]
     assert prices == sorted(prices, reverse=True)
 
+
 @pytest.mark.skip("tbd")
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_orderbook_grid_content(setup_market, page: Page):
     vega = setup_market[0]
     market_id = setup_market[1]
@@ -138,7 +140,7 @@ def test_orderbook_grid_content(setup_market, page: Page):
     verify_prices_descending(page)
 
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_orderbook_resolution_change(setup_market, page: Page):
     market_id = setup_market[1]
     # 6003-ORDB-008
@@ -188,7 +190,7 @@ def test_orderbook_resolution_change(setup_market, page: Page):
     #     verify_orderbook_grid(page, resolution[1])
 
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_orderbook_price_size_copy(setup_market, page: Page):
     market_id = setup_market[1]
     # 6003-ORDB-009
@@ -206,8 +208,9 @@ def test_orderbook_price_size_copy(setup_market, page: Page):
         volume.click()
         expect(page.get_by_test_id("order-size")).to_have_value(volume.text_content())
 
+
 @pytest.mark.skip("tbd")
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_orderbook_price_movement(setup_market, page: Page):
     vega = setup_market[0]
     market_id = setup_market[1]

--- a/apps/trading/e2e/tests/perpetual_market/test_perpetuals.py
+++ b/apps/trading/e2e/tests/perpetual_market/test_perpetuals.py
@@ -138,11 +138,11 @@ def test_perps_market_terminated(page: Page, vega: VegaService):
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
-    page.goto(f"/#/markets/{perpetual_market}") 
-    # TODO cahnge back to have text once bug #5465 is fixed
+    page.goto(f"/#/markets/{perpetual_market}")
+    # TODO change back to have text once bug #5465 is fixed
     expect(page.get_by_test_id("market-price")).to_have_text("Mark Price100.00")
-    expect(page.get_by_test_id("market-change")).to_have_text("Change (24h)-")
-    expect(page.get_by_test_id("market-volume")).to_have_text("Volume (24h)-")
+    expect(page.get_by_test_id("market-change")).to_contain_text("Change (24h)-")
+    expect(page.get_by_test_id("market-volume")).to_contain_text("Volume (24h)-")
     expect(page.get_by_test_id("market-trading-mode")).to_have_text(
         "Trading modeNo trading"
     )

--- a/apps/trading/e2e/tests/perpetual_market/test_perpetuals.py
+++ b/apps/trading/e2e/tests/perpetual_market/test_perpetuals.py
@@ -13,8 +13,8 @@ from wallet_config import MM_WALLET, MM_WALLET2, TERMINATE_WALLET
 row_selector = '[data-testid="tab-funding-payments"] .ag-center-cols-container .ag-row'
 col_amount = '[col-id="amount"]'
 
-class TestPerpetuals:
 
+class TestPerpetuals:
     @pytest.fixture(scope="class")
     def vega(self, request):
         with init_vega(request) as vega:
@@ -53,31 +53,33 @@ class TestPerpetuals:
         vega.wait_for_total_catchup()
         return perps_market
 
-    @pytest.mark.usefixtures("page","risk_accepted", "auth")
+    @pytest.mark.usefixtures("risk_accepted", "auth")
     def test_funding_payment_profit(self, perps_market, page: Page):
-        page.goto(f"/#/markets/{perps_market}")    
+        page.goto(f"/#/markets/{perps_market}")
         page.get_by_test_id("Funding payments").click()
         row = page.locator(row_selector)
         expect(row.locator(col_amount)).to_have_text("9.00 tDAI")
 
-    @pytest.mark.usefixtures("page","risk_accepted", "auth")
+    @pytest.mark.usefixtures("risk_accepted", "auth")
     def test_funding_payment_loss(self, perps_market, page: Page, vega):
-        page.goto(f"/#/markets/{perps_market}")   
+        page.goto(f"/#/markets/{perps_market}")
         change_keys(page, vega, "market_maker")
         page.get_by_test_id("Funding payments").click()
         row = page.locator(row_selector)
         expect(row.locator(col_amount)).to_have_text("-27.00 tDAI")
-        
-    @pytest.mark.usefixtures("page","risk_accepted", "auth")
+
+    @pytest.mark.usefixtures("risk_accepted", "auth")
     def test_funding_header(self, perps_market, page: Page):
         page.goto(f"/#/markets/{perps_market}")
-        expect(page.get_by_test_id("market-funding")).to_contain_text("Funding Rate / Countdown-8.1818%")
+        expect(page.get_by_test_id("market-funding")).to_contain_text(
+            "Funding Rate / Countdown-8.1818%"
+        )
         expect(page.get_by_test_id("index-price")).to_have_text("Index Price110.00")
 
     @pytest.mark.skip("Skipped due to issue #5421")
-    @pytest.mark.usefixtures("page","risk_accepted", "auth")
+    @pytest.mark.usefixtures("risk_accepted", "auth")
     def test_funding_payment_history(perps_market, page: Page, vega):
-        page.goto(f"/#/markets/{perps_market}")   
+        page.goto(f"/#/markets/{perps_market}")
         change_keys(page, vega, "market_maker")
         page.get_by_test_id("Funding history").click()
         element = page.get_by_test_id("tab-funding-history")
@@ -92,30 +94,36 @@ class TestPerpetuals:
         else:
             print("Bounding box not found for the element")
 
-@pytest.mark.usefixtures("page","risk_accepted", "auth")
+
+@pytest.mark.usefixtures("risk_accepted", "auth")
 def test_perps_market_termination_proposed(page: Page, vega: VegaService):
     perpetual_market = setup_perps_market(vega)
-    page.goto(f"/#/markets/{perpetual_market}") 
+    page.goto(f"/#/markets/{perpetual_market}")
     vega.update_market_state(
         proposal_key=MM_WALLET.name,
         market_id=perpetual_market,
         market_state=MarketStateUpdateType.Terminate,
         price=100,
-        vote_closing_time = datetime.now() + timedelta(seconds=15),
-        vote_enactment_time = datetime.now() + timedelta(seconds=60),
-        approve_proposal = True,
-        forward_time_to_enactment = False,
+        vote_closing_time=datetime.now() + timedelta(seconds=15),
+        vote_enactment_time=datetime.now() + timedelta(seconds=60),
+        approve_proposal=True,
+        forward_time_to_enactment=False,
     )
     vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
-    banner_text = page.get_by_test_id(f"termination-warning-banner-{perpetual_market}").text_content()
+    banner_text = page.get_by_test_id(
+        f"termination-warning-banner-{perpetual_market}"
+    ).text_content()
     pattern = re.compile(
-    r"Trading on Market BTC:DAI_Perpetual may stop on \d{2} [A-Za-z]+\. There is open proposal to close this market\.Proposed final price is 100\.00 BTC\.View proposal"
+        r"Trading on Market BTC:DAI_Perpetual may stop on \d{2} [A-Za-z]+\. There is open proposal to close this market\.Proposed final price is 100\.00 BTC\.View proposal"
     )
-    assert pattern.search(banner_text), f"Text did not match pattern. Text was: {banner_text}"
+    assert pattern.search(
+        banner_text
+    ), f"Text did not match pattern. Text was: {banner_text}"
 
-@pytest.mark.usefixtures("page","risk_accepted", "auth" )
+
+@pytest.mark.usefixtures("risk_accepted", "auth")
 def test_perps_market_terminated(page: Page, vega: VegaService):
     perpetual_market = setup_perps_market(vega)
     vega.update_market_state(
@@ -123,8 +131,8 @@ def test_perps_market_terminated(page: Page, vega: VegaService):
         market_id=perpetual_market,
         market_state=MarketStateUpdateType.Terminate,
         price=100,
-        approve_proposal = True,
-        forward_time_to_enactment = True,
+        approve_proposal=True,
+        forward_time_to_enactment=True,
     )
     vega.forward("10s")
     vega.wait_fn(1)
@@ -133,11 +141,19 @@ def test_perps_market_terminated(page: Page, vega: VegaService):
     page.goto(f"/#/markets/{perpetual_market}") 
     # TODO cahnge back to have text once bug #5465 is fixed
     expect(page.get_by_test_id("market-price")).to_have_text("Mark Price100.00")
-    expect(page.get_by_test_id("market-change")).to_contain_text("Change (24h)")
-    expect(page.get_by_test_id("market-volume")).to_contain_text("Volume (24h)")
-    expect(page.get_by_test_id("market-trading-mode")).to_have_text("Trading modeNo trading")
+    expect(page.get_by_test_id("market-change")).to_have_text("Change (24h)-")
+    expect(page.get_by_test_id("market-volume")).to_have_text("Volume (24h)-")
+    expect(page.get_by_test_id("market-trading-mode")).to_have_text(
+        "Trading modeNo trading"
+    )
     expect(page.get_by_test_id("market-state")).to_have_text("StatusClosed")
-    expect(page.get_by_test_id("liquidity-supplied")).to_have_text("Liquidity supplied 0.00 (0.00%)")
-    expect(page.get_by_test_id("market-funding")).to_contain_text("Funding Rate / Countdown")
+    expect(page.get_by_test_id("liquidity-supplied")).to_have_text(
+        "Liquidity supplied 0.00 (0.00%)"
+    )
+    expect(page.get_by_test_id("market-funding")).to_contain_text(
+        "Funding Rate / Countdown"
+    )
     expect(page.get_by_test_id("index-price")).to_contain_text("Index Price")
-    expect(page.get_by_test_id("deal-ticket-error-message-summary")).to_have_text("This market is closed and not accepting orders")
+    expect(page.get_by_test_id("deal-ticket-error-message-summary")).to_have_text(
+        "This market is closed and not accepting orders"
+    )

--- a/apps/trading/e2e/tests/pnl/test_pnl.py
+++ b/apps/trading/e2e/tests/pnl/test_pnl.py
@@ -4,13 +4,15 @@ from vega_sim.service import VegaService
 from actions.vega import submit_order
 from actions.utils import change_keys
 
+
 def check_pnl_color_value(element, expected_color, expected_value):
     color = element.evaluate("element => getComputedStyle(element).color")
     value = element.inner_text()
     assert color == expected_color, f"Unexpected color: {color}"
     assert value == expected_value, f"Unexpected value: {value}"
 
-@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth", "risk_accepted")
+
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_pnl(continuous_market, vega: VegaService, page: Page):
     page.set_viewport_size({"width": 1748, "height": 977})
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 104.50000)
@@ -59,9 +61,13 @@ def test_pnl(continuous_market, vega: VegaService, page: Page):
 
     key_1_unrealised_pnl = key_1.query_selector('xpath=./div[@col-id="unrealisedPNL"]')
     key_1_realised_pnl = key_1.query_selector('xpath=./div[@col-id="realisedPNL"]')
-    key_mm_unrealised_pnl = key_mm.query_selector('xpath=./div[@col-id="unrealisedPNL"]')
+    key_mm_unrealised_pnl = key_mm.query_selector(
+        'xpath=./div[@col-id="unrealisedPNL"]'
+    )
     key_mm_realised_pnl = key_mm.query_selector('xpath=./div[@col-id="realisedPNL"]')
-    key_mm2_unrealised_pnl = key_mm2.query_selector('xpath=./div[@col-id="unrealisedPNL"]')
+    key_mm2_unrealised_pnl = key_mm2.query_selector(
+        'xpath=./div[@col-id="unrealisedPNL"]'
+    )
     key_mm2_realised_pnl = key_mm2.query_selector('xpath=./div[@col-id="realisedPNL"]')
     check_pnl_color_value(key_1_realised_pnl, "rgb(0, 0, 0)", "0.00")
     check_pnl_color_value(key_1_unrealised_pnl, "rgb(236, 0, 60)", "-4.00")

--- a/apps/trading/e2e/tests/portfolio/test_ledger_entries.py
+++ b/apps/trading/e2e/tests/portfolio/test_ledger_entries.py
@@ -2,30 +2,31 @@ import os
 import pytest
 from playwright.sync_api import Page, expect
 
-from actions.utils import wait_for_toast_confirmation
-
-@pytest.mark.usefixtures("page", "auth", "risk_accepted", "continuous_market")
+#TODO migrate to jest
+@pytest.mark.usefixtures("auth", "risk_accepted", "continuous_market")
 def test_ledger_entries_downloads(page: Page):
     page.goto("/#/portfolio")
     page.get_by_test_id("Ledger entries").click()
     expect(page.get_by_test_id("ledger-download-button")).to_be_enabled()
     # 7007-LEEN-001
     page.get_by_test_id("ledger-download-button").click()
-    #7007-LEEN-009
+    # 7007-LEEN-009
     expect(page.get_by_test_id("toast-content")).to_contain_text(("Your file is ready"))
     # Get the user's Downloads directory
     downloads_directory = os.path.expanduser("~") + "/Downloads/"
     # Start waiting for the download
     with page.expect_download() as download_info:
-    # Perform the action that initiates download
+        # Perform the action that initiates download
         page.get_by_role("link", name="Get file here").click()
-
 
     download = download_info.value
     # Wait for the download process to complete and save the downloaded file in the Downloads directory
     download.save_as(os.path.join(downloads_directory, download.suggested_filename))
 
     # Verify the download by asserting that the file exists
-    downloaded_file_path = os.path.join(downloads_directory, download.suggested_filename)
-    assert os.path.exists(downloaded_file_path), f"Download failed! File not found at: {downloaded_file_path}"
-
+    downloaded_file_path = os.path.join(
+        downloads_directory, download.suggested_filename
+    )
+    assert os.path.exists(
+        downloaded_file_path
+    ), f"Download failed! File not found at: {downloaded_file_path}"

--- a/apps/trading/e2e/tests/positions/test_collateral.py
+++ b/apps/trading/e2e/tests/positions/test_collateral.py
@@ -8,44 +8,60 @@ TOOLTIP_LABEL = "margin-health-tooltip-label"
 TOOLTIP_VALUE = "margin-health-tooltip-value"
 COL_ID_USED = ".ag-center-cols-container [col-id='used'] .ag-cell-value"
 
+
 @pytest.fixture(scope="module")
 def vega(request):
     with init_vega(request) as vega:
         yield vega
 
+
 @pytest.fixture(scope="module")
 def continuous_market(vega: VegaService):
     return setup_continuous_market(vega)
+
 
 @pytest.mark.usefixtures("auth", "risk_accepted")
 def test_usage_breakdown(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("Collateral").click()
     page.locator(".ag-floating-top-container .ag-row [col-id='used']").click()
-    usage_breakdown = page.get_by_test_id('usage-breakdown')
+    usage_breakdown = page.get_by_test_id("usage-breakdown")
 
     # Verify headers
-    headers = ['Market', 'Account type', 'Balance', 'Margin health']
-    ag_headers = usage_breakdown.locator('.ag-header-cell-text').element_handles()
+    headers = ["Market", "Account type", "Balance", "Margin health"]
+    ag_headers = usage_breakdown.locator(".ag-header-cell-text").element_handles()
     for i, header_element in enumerate(ag_headers):
         header_text = header_element.text_content()
         assert header_text == headers[i]
 
     # Other expectations
-    expect(usage_breakdown.locator('[class="mb-2 text-sm"]')).to_have_text("You have 1,000,000.00 tDAI in total.")
+    expect(usage_breakdown.locator('[class="mb-2 text-sm"]')).to_have_text(
+        "You have 1,000,000.00 tDAI in total."
+    )
     expect(usage_breakdown.locator(COL_ID_USED).first).to_have_text("8.50269 (0%)")
-    expect(usage_breakdown.locator(COL_ID_USED).nth(1)).to_have_text("999,991.49731 (99%)")
+    expect(usage_breakdown.locator(COL_ID_USED).nth(1)).to_have_text(
+        "999,991.49731 (99%)"
+    )
 
     # Maintenance Level
-    expect(usage_breakdown.locator(".ag-center-cols-container [col-id='market.id'] .ag-cell-value").first).to_have_text("2.85556 above maintenance level")
+    expect(
+        usage_breakdown.locator(
+            ".ag-center-cols-container [col-id='market.id'] .ag-cell-value"
+        ).first
+    ).to_have_text("2.85556 above maintenance level")
 
     # Margin health tooltip
     usage_breakdown.get_by_test_id("margin-health-chart-track").hover()
-    tooltip_data = [("maintenance level", "5.64713"), ("search level", "6.21184"), ("initial level", "8.47069"), ("balance", "8.50269"), ("release level", "9.60012")]
+    tooltip_data = [
+        ("maintenance level", "5.64713"),
+        ("search level", "6.21184"),
+        ("initial level", "8.47069"),
+        ("balance", "8.50269"),
+        ("release level", "9.60012"),
+    ]
 
     for index, (label, value) in enumerate(tooltip_data):
         expect(page.get_by_test_id(TOOLTIP_LABEL).nth(index)).to_have_text(label)
         expect(page.get_by_test_id(TOOLTIP_VALUE).nth(index)).to_have_text(value)
 
-
-    page.get_by_test_id('dialog-close').click()
+    page.get_by_test_id("dialog-close").click()

--- a/apps/trading/e2e/tests/positions/test_positions.py
+++ b/apps/trading/e2e/tests/positions/test_positions.py
@@ -5,6 +5,7 @@ from fixtures.market import (
     setup_continuous_market,
 )
 
+
 @pytest.mark.usefixtures("auth", "risk_accepted")
 def test_closed_market_position(vega: VegaService, page: Page):
     market_id = setup_continuous_market(vega)
@@ -26,4 +27,3 @@ def test_closed_market_position(vega: VegaService, page: Page):
     expect(market.get_by_test_id("stack-cell-primary")).to_have_text("BTC:DAI_2023")
     page.get_by_test_id("open-transfer").click()
     expect(page.locator(".ag-overlay-panel")).to_have_text("No positions")
-   

--- a/apps/trading/e2e/tests/settings/test_settings.py
+++ b/apps/trading/e2e/tests/settings/test_settings.py
@@ -9,10 +9,9 @@ def vega():
         yield vega
 
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_share_usage_data(page: Page):
     page.goto("/")
-   # page.get_by_test_id("icon-cross").click()
     page.get_by_test_id("Settings").click()
     telemetry_switch = page.locator("#switch-settings-telemetry-switch")
     expect(telemetry_switch).to_have_attribute("data-state", "unchecked")
@@ -41,7 +40,7 @@ ICON_TO_TOAST = {
 }
 
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_toast_positions(page: Page):
     page.goto("/")
     page.get_by_test_id("Settings").click()
@@ -52,7 +51,7 @@ def test_toast_positions(page: Page):
         expect(page.locator(f"[{toast_selector}]")).to_be_visible()
 
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_dark_mode(page: Page):
     page.goto("/")
     page.get_by_test_id("Settings").click()

--- a/apps/trading/e2e/tests/successor_market/test_succession_line.py
+++ b/apps/trading/e2e/tests/successor_market/test_succession_line.py
@@ -5,7 +5,7 @@ from fixtures.market import setup_continuous_market, setup_simple_successor_mark
 
 
 @pytest.fixture
-@pytest.mark.usefixtures("vega")
+@pytest.mark.usefixtures()
 def successor_market(vega: VegaService):
     parent_market_id = setup_continuous_market(vega)
     tdai_id = vega.find_asset_id(symbol="tDAI")
@@ -23,8 +23,7 @@ def successor_market(vega: VegaService):
     return successor_market_id
 
 
-
-@pytest.mark.usefixtures("page", "risk_accepted")
+@pytest.mark.usefixtures("risk_accepted")
 def test_succession_line(page: Page, successor_market):
     page.goto(f"/#/markets/{successor_market}")
     page.get_by_test_id("Info").click()

--- a/apps/trading/e2e/tests/trade_history/test_trade_history.py
+++ b/apps/trading/e2e/tests/trade_history/test_trade_history.py
@@ -45,8 +45,10 @@ def verify_data_grid(page: Page, data_test_id, expected_pattern):
                 raise AssertionError(f"Pattern does not match: {expected} != {actual}")
 
 
-@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
-def test_limit_order_new_trade_top_of_list(continuous_market, vega: VegaService, page: Page):
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_limit_order_new_trade_top_of_list(
+    continuous_market, vega: VegaService, page: Page
+):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 110)
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
@@ -67,7 +69,7 @@ def test_limit_order_new_trade_top_of_list(continuous_market, vega: VegaService,
     verify_data_grid(page, "Trades", expected_trade)
 
 
-@pytest.mark.usefixtures("page", "continuous_market", "auth", "risk_accepted")
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_price_copied_to_deal_ticket(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("Trades").click()

--- a/apps/trading/e2e/tests/trade_match/test_trade_match.py
+++ b/apps/trading/e2e/tests/trade_match/test_trade_match.py
@@ -4,10 +4,9 @@ from vega_sim.service import VegaService
 
 from actions.vega import submit_multiple_orders
 
+
 @pytest.mark.skip("tbd")
-@pytest.mark.usefixtures(
-    "page", "vega", "opening_auction_market", "auth", "risk_accepted"
-)
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_trade_match_table(opening_auction_market: str, vega: VegaService, page: Page):
     row_locator = ".ag-center-cols-container .ag-row"
     page.goto(f"/#/markets/{opening_auction_market}")

--- a/apps/trading/e2e/tests/trading_chart/test_trading_chart.py
+++ b/apps/trading/e2e/tests/trading_chart/test_trading_chart.py
@@ -12,7 +12,7 @@
 # InfoItem = namedtuple('InfoItem', ['name', 'infoText'])
 
 # @pytest.mark.skip("temporary skip")
-# @pytest.mark.parametrize("vega", [120], indirect=True)
+# @pytest.mark.parametrize(, [120], indirect=True)
 # @pytest.mark.usefixtures("continuous_market","risk_accepted", "auth")
 # def test_trading_chart(continuous_market, vega: VegaService, page: Page):
 #     page.goto(f"/#/markets/{continuous_market}")

--- a/apps/trading/e2e/tests/transfer/test_transfer_key_to_key.py
+++ b/apps/trading/e2e/tests/transfer/test_transfer_key_to_key.py
@@ -2,7 +2,13 @@ import pytest
 import re
 from playwright.sync_api import Page, expect
 from vega_sim.service import VegaService
-from actions.utils import wait_for_toast_confirmation, create_and_faucet_wallet, WalletConfig, next_epoch, change_keys
+from actions.utils import (
+    wait_for_toast_confirmation,
+    create_and_faucet_wallet,
+    WalletConfig,
+    next_epoch,
+    change_keys,
+)
 import vega_sim.proto.vega as vega_protos
 
 LIQ = WalletConfig("liq", "liq")
@@ -10,7 +16,8 @@ PARTY_A = WalletConfig("party_a", "party_a")
 PARTY_B = WalletConfig("party_b", "party_b")
 PARTY_C = WalletConfig("party_c", "party_c")
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_transfer_submit(continuous_market, vega: VegaService, page: Page):
     # 1003-TRAN-001
     # 1003-TRAN-006
@@ -19,38 +26,50 @@ def test_transfer_submit(continuous_market, vega: VegaService, page: Page):
     # 1003-TRAN-009
     # 1003-TRAN-010
     # 1003-TRAN-023
-    page.goto('/#/portfolio')
+    page.goto("/#/portfolio")
 
-    expect(page.get_by_test_id('transfer-form')).to_be_visible
-    page.get_by_test_id('select-asset').click()
-    expect(page.get_by_test_id('rich-select-option')).to_have_count(1)
+    expect(page.get_by_test_id("transfer-form")).to_be_visible
+    page.get_by_test_id("select-asset").click()
+    expect(page.get_by_test_id("rich-select-option")).to_have_count(1)
 
-    page.get_by_test_id('rich-select-option').click()
+    page.get_by_test_id("rich-select-option").click()
     page.select_option('[data-testid=transfer-form] [name="toVegaKey"]', index=2)
     page.select_option('[data-testid=transfer-form] [name="fromAccount"]', index=1)
 
     expected_asset_text = re.compile(r"tDAI tDAI999991.49731 tDAI.{6}….{4}")
-    actual_asset_text = page.get_by_test_id('select-asset').text_content().strip()
+    actual_asset_text = page.get_by_test_id("select-asset").text_content().strip()
 
-    assert expected_asset_text.search(actual_asset_text), f"Expected pattern not found in {actual_asset_text}"
+    assert expected_asset_text.search(
+        actual_asset_text
+    ), f"Expected pattern not found in {actual_asset_text}"
 
-    page.locator('[data-testid=transfer-form] input[name="amount"]').fill('1')
-    expect(page.locator('[data-testid=transfer-form] input[name="amount"]')).not_to_be_empty()
+    page.locator('[data-testid=transfer-form] input[name="amount"]').fill("1")
+    expect(
+        page.locator('[data-testid=transfer-form] input[name="amount"]')
+    ).not_to_be_empty()
 
     page.locator('[data-testid=transfer-form] [type="submit"]').click()
     wait_for_toast_confirmation(page)
     vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
-    expected_confirmation_text = re.compile(r"Transfer completeYour transaction has been confirmedView in block explorerTransferTo .{6}….{6}1\.00 tDAI")
-    actual_confirmation_text = page.get_by_test_id('toast-content').text_content()
-    assert expected_confirmation_text.search(actual_confirmation_text), f"Expected pattern not found in {actual_confirmation_text}"
+    expected_confirmation_text = re.compile(
+        r"Transfer completeYour transaction has been confirmedView in block explorerTransferTo .{6}….{6}1\.00 tDAI"
+    )
+    actual_confirmation_text = page.get_by_test_id("toast-content").text_content()
+    assert expected_confirmation_text.search(
+        actual_confirmation_text
+    ), f"Expected pattern not found in {actual_confirmation_text}"
 
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
-def test_transfer_vesting_below_minimum(continuous_market, vega: VegaService, page: Page):
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_transfer_vesting_below_minimum(
+    continuous_market, vega: VegaService, page: Page
+):
     vega.update_network_parameter(
-    "market_maker", parameter="transfer.minTransferQuantumMultiple", new_value="100000"
+        "market_maker",
+        parameter="transfer.minTransferQuantumMultiple",
+        new_value="100000",
     )
     vega.wait_for_total_catchup()
 
@@ -94,28 +113,34 @@ def test_transfer_vesting_below_minimum(continuous_market, vega: VegaService, pa
     vega.wait_for_total_catchup()
     next_epoch(vega=vega)
     next_epoch(vega=vega)
-    page.goto('/#/portfolio')
-    expect(page.get_by_test_id('transfer-form')).to_be_visible
+    page.goto("/#/portfolio")
+    expect(page.get_by_test_id("transfer-form")).to_be_visible
 
     change_keys(page, vega, "party_b")
-    page.get_by_test_id('select-asset').click()
-    page.get_by_test_id('rich-select-option').click()
+    page.get_by_test_id("select-asset").click()
+    page.get_by_test_id("rich-select-option").click()
 
-    option_value = page.locator('[data-testid="transfer-form"] [name="fromAccount"] option[value^="ACCOUNT_TYPE_VESTED_REWARDS"]').first.get_attribute("value")
+    option_value = page.locator(
+        '[data-testid="transfer-form"] [name="fromAccount"] option[value^="ACCOUNT_TYPE_VESTED_REWARDS"]'
+    ).first.get_attribute("value")
 
-    page.select_option('[data-testid="transfer-form"] [name="fromAccount"]', option_value)
+    page.select_option(
+        '[data-testid="transfer-form"] [name="fromAccount"]', option_value
+    )
 
-    page.locator('[data-testid=transfer-form] input[name="amount"]').fill('0.000001')
+    page.locator('[data-testid=transfer-form] input[name="amount"]').fill("0.000001")
     page.locator('[data-testid=transfer-form] [type="submit"]').click()
-    expect(page.get_by_test_id('input-error-text')).to_be_visible
-    expect(page.get_by_test_id('input-error-text')).to_have_text("Amount below minimum requirements for partial transfer. Use max to bypass")
+    expect(page.get_by_test_id("input-error-text")).to_be_visible
+    expect(page.get_by_test_id("input-error-text")).to_have_text(
+        "Amount below minimum requirements for partial transfer. Use max to bypass"
+    )
     vega.one_off_transfer(
         from_key_name=PARTY_B.name,
         to_key_name=PARTY_B.name,
-        from_account_type= vega_protos.vega.AccountType.ACCOUNT_TYPE_VESTED_REWARDS,
-        to_account_type= vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL,
-        asset= asset_id,
-        amount= 24.999999,
+        from_account_type=vega_protos.vega.AccountType.ACCOUNT_TYPE_VESTED_REWARDS,
+        to_account_type=vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL,
+        asset=asset_id,
+        amount=24.999999,
     )
     vega.forward("10s")
     vega.wait_fn(10)
@@ -127,6 +152,10 @@ def test_transfer_vesting_below_minimum(continuous_market, vega: VegaService, pa
     vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
-    expected_confirmation_text = re.compile(r"Transfer completeYour transaction has been confirmedView in block explorerTransferTo .{6}….{6}0\.00001 tDAI")
-    actual_confirmation_text = page.get_by_test_id('toast-content').text_content()
-    assert expected_confirmation_text.search(actual_confirmation_text), f"Expected pattern not found in {actual_confirmation_text}"
+    expected_confirmation_text = re.compile(
+        r"Transfer completeYour transaction has been confirmedView in block explorerTransferTo .{6}….{6}0\.00001 tDAI"
+    )
+    actual_confirmation_text = page.get_by_test_id("toast-content").text_content()
+    assert expected_confirmation_text.search(
+        actual_confirmation_text
+    ), f"Expected pattern not found in {actual_confirmation_text}"

--- a/apps/trading/e2e/tests/wallet/test_wallet.py
+++ b/apps/trading/e2e/tests/wallet/test_wallet.py
@@ -15,6 +15,7 @@ tif = "order-tif"
 expire = "expire"
 api_request_match = r"http://localhost:\d+/api/v2/requests"
 
+
 @pytest.fixture(scope="module")
 def vega(request):
     with init_vega(request) as vega:
@@ -25,50 +26,59 @@ def vega(request):
 def continuous_market(vega):
     return setup_continuous_market(vega)
 
+
 def handle_route_connection_lost(route: Route, request):
-        if request.method == "POST" and re.match(api_request_match, request.url):
-            route.fulfill(
-                status=200,
-                headers={"Content-Type": "application/json"},
-                body='{"jsonrpc": "2.0", "id": "1"}'
-            )
-        else:
-            route.continue_()
+    if request.method == "POST" and re.match(api_request_match, request.url):
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body='{"jsonrpc": "2.0", "id": "1"}',
+        )
+    else:
+        route.continue_()
+
 
 def handle_route_connection_rejected(route: Route, request):
-        if request.method == "POST" and re.match(api_request_match, request.url):
-            custom_response = {
-                "jsonrpc": "2.0",
-                "error": {
-                    "code": 3001,
-                    "data": "the user rejected the wallet connection",
-                    "message": "User error"
-                },
-                "id": "0"
-            }
-            route.fulfill(
-                status=400,
-                headers={"Content-Type": "application/json"},
-                body=json.dumps(custom_response)
-            )
-        else:
-            route.continue_()
+    if request.method == "POST" and re.match(api_request_match, request.url):
+        custom_response = {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": 3001,
+                "data": "the user rejected the wallet connection",
+                "message": "User error",
+            },
+            "id": "0",
+        }
+        route.fulfill(
+            status=400,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(custom_response),
+        )
+    else:
+        route.continue_()
 
-def assert_connection_approve(route: Route, request, page:Page):
-        if request.method == "POST" and re.match(api_request_match, request.url):
-            expect(page.get_by_test_id("toast-content")).to_have_text("Please go to your Vega wallet application and approve or reject the transaction.")
-        else:
-            route.continue_()
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
+def assert_connection_approve(route: Route, request, page: Page):
+    if request.method == "POST" and re.match(api_request_match, request.url):
+        expect(page.get_by_test_id("toast-content")).to_have_text(
+            "Please go to your Vega wallet application and approve or reject the transaction."
+        )
+    else:
+        route.continue_()
+
+
+@pytest.mark.usefixtures("auth", "risk_accepted")
 def test_wallet_connection_error(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.route("**/*", handle_route_connection_lost)
     page.get_by_test_id("connect-vega-wallet").click()
     page.get_by_test_id("connector-jsonRpc").click()
-    expect(page.get_by_test_id("wallet-dialog-title")).to_have_text("Something went wrong")
+    expect(page.get_by_test_id("wallet-dialog-title")).to_have_text(
+        "Something went wrong"
+    )
 
-@pytest.mark.usefixtures("page", "risk_accepted")
+
+@pytest.mark.usefixtures("risk_accepted")
 def test_wallet_connection_rejected(continuous_market, page: Page):
     # 0002-WCON-002
     # 0002-WCON-005
@@ -78,11 +88,13 @@ def test_wallet_connection_rejected(continuous_market, page: Page):
     page.route("**/*", handle_route_connection_rejected)
     page.get_by_test_id("connect-vega-wallet").click()
     page.get_by_test_id("connector-jsonRpc").click()
-    expect(page.get_by_test_id("dialog-content").nth(1)).to_have_text("User errorthe user rejected the wallet connectionTry againAbout the Vega wallet  | Supported browsers ")
+    expect(page.get_by_test_id("dialog-content").nth(1)).to_have_text(
+        "User errorthe user rejected the wallet connectionTry againAbout the Vega wallet  | Supported browsers "
+    )
 
 
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
-def test_wallet_connection_error_transaction(continuous_market, vega: VegaService, page: Page):
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_wallet_connection_error_transaction(continuous_market, page: Page):
     # 0003-WTXN-009
     # 0003-WTXN-011
     # 0002-WCON-016
@@ -92,20 +104,26 @@ def test_wallet_connection_error_transaction(continuous_market, vega: VegaServic
     page.get_by_test_id(order_price).fill("120")
     page.route("**/*", handle_route_connection_lost)
     page.get_by_test_id(place_order).click()
-    expect(page.get_by_test_id("toast-content")).to_have_text("Wallet disconnectedThe connection to your Vega Wallet has been lost.Connect vega wallet")
-    
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
-def test_wallet_transaction_rejected(continuous_market, vega: VegaService, page: Page):
+    expect(page.get_by_test_id("toast-content")).to_have_text(
+        "Wallet disconnectedThe connection to your Vega Wallet has been lost.Connect vega wallet"
+    )
+
+
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_wallet_transaction_rejected(continuous_market, page: Page):
     # 0003-WTXN-007
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id(order_size).fill("10")
     page.get_by_test_id(order_price).fill("120")
     page.route("**/*", handle_route_connection_rejected)
     page.get_by_test_id(place_order).click()
-    expect(page.get_by_test_id("toast-content")).to_have_text("Error occurredthe user rejected the wallet connection")
-    
-@pytest.mark.usefixtures("page", "auth", "risk_accepted")
-def test_wallet_connection_approve(continuous_market, vega: VegaService, page: Page):
+    expect(page.get_by_test_id("toast-content")).to_have_text(
+        "Error occurredthe user rejected the wallet connection"
+    )
+
+
+@pytest.mark.usefixtures("auth", "risk_accepted")
+def test_wallet_connection_approve(continuous_market, page: Page):
     # 0002-WCON-005
     # 0002-WCON-007
     # 0002-WCON-009


### PR DESCRIPTION
Applied black formatting across tests and removed any duplicated fixture usage.