### PR TITLE
fix(explorer): pass through tendermint error responses from usefetch

### DIFF
--- a/apps/explorer/src/app/routes/blocks/id/block.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.tsx
@@ -54,7 +54,7 @@ const Block = () => {
               </Button>
             </Link>
           </div>
-          {blockData && (
+          {blockData && 'result' in blockData && (
             <>
               <TableWithTbody className="mb-8">
                 <TableRow modifier="bordered">

--- a/apps/governance/src/routes/proposals/protocol-upgrade/protocol-upgrade-proposal-container.tsx
+++ b/apps/governance/src/routes/proposals/protocol-upgrade/protocol-upgrade-proposal-container.tsx
@@ -95,7 +95,7 @@ export const ProtocolUpgradeProposalContainer = () => {
           time={
             pending && time ? (
               convertToCountdownString(time, '0:00:00:00')
-            ) : blockInfo?.result ? (
+            ) : blockInfo && 'result' in blockInfo && blockInfo?.result ? (
               <span title={blockInfo.result.block.header.time}>
                 {formatDateWithLocalTimezone(
                   new Date(blockInfo.result.block.header.time)

--- a/libs/proposals/src/lib/protocol-upgrade-proposals/use-block-rising.ts
+++ b/libs/proposals/src/lib/protocol-upgrade-proposals/use-block-rising.ts
@@ -68,10 +68,13 @@ export const useBlockRising = (skip = false) => {
         }
       );
 
-      const heights = compact([
-        ...results.map((r) => r?.blockHeight),
-        blockInfo?.result.block.header.height,
-      ]);
+      const heights = compact([...results.map((r) => r?.blockHeight)]);
+
+      // Handles TendermintErrorResponses
+      if (blockInfo && 'result' in blockInfo) {
+        heights.push(blockInfo.result.block.header.height);
+      }
+
       const current = max(heights);
       if (current && Number(current) > prev) {
         setBlock(Number(current));

--- a/libs/react-helpers/src/hooks/use-fetch.ts
+++ b/libs/react-helpers/src/hooks/use-fetch.ts
@@ -76,16 +76,26 @@ export const useFetch = <T>(
             ...options,
             body: body ? body : options?.body,
           });
-          if (!response.ok) {
+
+          data = (await response.json()) as T;
+
+          if (!response.ok && !data) {
             throw new Error(response.statusText);
           }
 
-          data = (await response.json()) as T;
           // @ts-ignore - 'error' in data
-          if (data && 'error' in data) {
+          if (data && data.error) {
+            // Explicit check for TendermintErrorResponse style error
+            // @ts-ignore - 'error' in data
+            if (data.error.data) {
+              // @ts-ignore - 'error' in data
+
+              throw new Error(data.error.data);
+            }
             // @ts-ignore - data.error
             throw new Error(data.error);
           }
+
           if (cancelRequest.current) return;
 
           dispatch({ type: ActionType.FETCHED, payload: data });

--- a/libs/tendermint/src/lib/use-block-info.ts
+++ b/libs/tendermint/src/lib/use-block-info.ts
@@ -5,6 +5,8 @@ import type {
   TendermintErrorResponse,
 } from '../types';
 
+type TendermintResponse = TendermintBlockResponse | TendermintErrorResponse;
+
 export const useBlockInfo = (blockHeight?: number, canFetch = true) => {
   const { TENDERMINT_URL } = useEnvironment();
 
@@ -13,9 +15,11 @@ export const useBlockInfo = (blockHeight?: number, canFetch = true) => {
     TENDERMINT_URL && blockHeight && !isNaN(blockHeight) && canFetch
   );
 
-  const { state, refetch } = useFetch<
-    TendermintBlockResponse | TendermintErrorResponse
-  >(url, { cache: 'force-cache' }, canFetchData);
+  const { state, refetch } = useFetch<TendermintResponse>(
+    url,
+    { cache: 'force-cache' },
+    canFetchData
+  );
 
   return { state, refetch };
 };

--- a/libs/tendermint/src/lib/use-block-info.ts
+++ b/libs/tendermint/src/lib/use-block-info.ts
@@ -1,6 +1,9 @@
 import { useEnvironment } from '@vegaprotocol/environment';
 import { useFetch } from '@vegaprotocol/react-helpers';
-import { type TendermintBlockResponse } from '../types';
+import type {
+  TendermintBlockResponse,
+  TendermintErrorResponse,
+} from '../types';
 
 export const useBlockInfo = (blockHeight?: number, canFetch = true) => {
   const { TENDERMINT_URL } = useEnvironment();
@@ -10,11 +13,9 @@ export const useBlockInfo = (blockHeight?: number, canFetch = true) => {
     TENDERMINT_URL && blockHeight && !isNaN(blockHeight) && canFetch
   );
 
-  const { state, refetch } = useFetch<TendermintBlockResponse>(
-    url,
-    { cache: 'force-cache' },
-    canFetchData
-  );
+  const { state, refetch } = useFetch<
+    TendermintBlockResponse | TendermintErrorResponse
+  >(url, { cache: 'force-cache' }, canFetchData);
 
   return { state, refetch };
 };

--- a/libs/tendermint/src/types.ts
+++ b/libs/tendermint/src/types.ts
@@ -7,6 +7,16 @@ export type TendermintBlockResponse = {
   };
 };
 
+export type TendermintErrorResponse = {
+  jsonrpc: string;
+  id: number;
+  error: {
+    code: number;
+    message: string;
+    data: string;
+  };
+};
+
 type Id = {
   hash: string;
   parts: {
@@ -34,7 +44,7 @@ type Header = {
   proposer_address: string;
 };
 
-type Block = {
+export type Block = {
   header: Header;
   data: {
     txs: string[];


### PR DESCRIPTION
# Related issues 🔗

Closes #4692 

# Description ℹ️

The useFetch hook obscured tendermint errors, because Tendermint returns an error HTTP status code as well as a body containing an error. This PR passes through the error string.

It feels a little specific to Tendermint, but in reality the useFetch hook is primarily used to access Tendermint RPC endpoints, so it seemed acceptable.

The end result is that the error for future blocks is now rendered on the Block page of Explorer if a future block is accessed.

There are some `//@ts-ignore`s in here, which are from before the PR existed. It feels wrong, but if someone wants to improve on it let me know and we can work on it. The reason these are there is that we're accessing a property in a generic type `T`.

# Demo 📺

<img width="1160" alt="Screenshot 2023-12-15 at 12 15 51" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/bf9e6163-455b-4366-827a-130290c3c58c">
