### PR TITLE
chore(trading): rollback current traded volume change

### DIFF
--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -333,11 +333,7 @@ export const CurrentVolume = ({
   return (
     <div className="flex flex-col gap-3 pt-4" data-testid="current-volume">
       <CardStat
-        value={
-          currentVolume.isZero()
-            ? `<${formatNumberRounded(requiredForNextTier)}`
-            : formatNumberRounded(currentVolume)
-        }
+        value={formatNumberRounded(currentVolume)}
         text={t('pastEpochs', 'Past {{count}} epochs', {
           count: windowLength,
         })}


### PR DESCRIPTION
# Related issues 🔗

Closes #5448

# Description ℹ️

Rollback change on fees page. 

# Demo 📺

Before:
<img width="1679" alt="Screenshot 2023-12-20 at 13 28 17" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/3b31621a-0161-44ad-90db-cd739d9530da">
After: 
<img width="1680" alt="Screenshot 2023-12-20 at 13 28 05" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/37599e0f-ded5-4991-8297-4efdb08ef837">



# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
