### PR TITLE
fix(trading): mobile friendly referral and fees views

### DIFF
--- a/apps/trading/client-pages/referrals/apply-code-form.tsx
+++ b/apps/trading/client-pages/referrals/apply-code-form.tsx
@@ -296,7 +296,7 @@ export const ApplyCodeForm = ({ onSuccess }: { onSuccess?: () => void }) => {
     <>
       <div
         data-testid="referral-apply-code-form"
-        className="bg-vega-clight-800 dark:bg-vega-cdark-800 mx-auto w-2/3 max-w-md rounded-lg p-8"
+        className="bg-vega-clight-800 dark:bg-vega-cdark-800 mx-auto md:w-2/3 max-w-md rounded-lg p-8"
       >
         <h3 className="calt mb-4 text-center text-2xl">
           {t('Apply a referral code')}

--- a/apps/trading/client-pages/referrals/constants.ts
+++ b/apps/trading/client-pages/referrals/constants.ts
@@ -3,7 +3,7 @@ export const GRADIENT =
   'bg-gradient-to-b from-vega-clight-800 dark:from-vega-cdark-800 to-transparent';
 
 export const SKY_BACKGROUND =
-  'bg-[url(/sky-light.png)] dark:bg-[url(/sky-dark.png)] bg-[40%_0px] bg-[length:1440px] bg-no-repeat bg-local';
+  'bg-[url(/sky-light.png)] dark:bg-[url(/sky-dark.png)] bg-[37%_0px] bg-[length:1440px] bg-no-repeat bg-local';
 
 // TODO: Update the links to use the correct referral related pages
 export const REFERRAL_DOCS_LINK =

--- a/apps/trading/client-pages/referrals/create-code-form.tsx
+++ b/apps/trading/client-pages/referrals/create-code-form.tsx
@@ -49,7 +49,7 @@ export const CreateCodeForm = () => {
   return (
     <div
       data-testid="referral-create-code-form"
-      className="w-2/3 max-w-md mx-auto bg-vega-clight-800 dark:bg-vega-cdark-800 p-8 rounded-lg"
+      className="md:w-2/3 max-w-md mx-auto bg-vega-clight-800 dark:bg-vega-cdark-800 p-8 rounded-lg"
     >
       <h3 className="mb-4 text-2xl text-center calt">
         {t('Create a referral code')}

--- a/apps/trading/client-pages/referrals/how-it-works-table.tsx
+++ b/apps/trading/client-pages/referrals/how-it-works-table.tsx
@@ -1,5 +1,5 @@
 import { useT } from '../../lib/use-t';
-import { Table } from './table';
+import { Table } from '../../components/table';
 
 export const HowItWorksTable = () => {
   const t = useT();

--- a/apps/trading/client-pages/referrals/landing-banner.tsx
+++ b/apps/trading/client-pages/referrals/landing-banner.tsx
@@ -5,16 +5,16 @@ import { useT } from '../../lib/use-t';
 export const LandingBanner = () => {
   const t = useT();
   return (
-    <div className={classNames('relative mb-20')}>
+    <div className={classNames('relative mb-10 lg:mb-20')}>
       <div className="">
         <div
           aria-hidden
-          className="absolute top-20 right-[120px] md:right-[240px] max-sm:hidden"
+          className="absolute top-20 right-[220px] md:right-[240px] max-sm:hidden"
         >
           <AnimatedDudeWithWire />
         </div>
-        <div className="pt-20 sm:w-[50%]">
-          <h1 className="text-6xl font-alpha calt mb-10">
+        <div className="pt-10 lg:pt-20 sm:w-[50%]">
+          <h1 className="text-3xl _text-[6vw] lg:!text-6xl leading-[1em] font-alpha calt mb-10">
             {t('Vega community referrals')}
           </h1>
           <p className="text-lg mb-1">
@@ -22,7 +22,7 @@ export const LandingBanner = () => {
               'Referral programs can be proposed and created via community governance.'
             )}
           </p>
-          <p className="text-lg mb-10">
+          <p className="text-lg mb-1">
             {t(
               'Once live, users can generate referral codes to share with their friends and earn commission on their trades, while referred traders can access fee discounts based on the running volume of the group.'
             )}

--- a/apps/trading/client-pages/referrals/layout.tsx
+++ b/apps/trading/client-pages/referrals/layout.tsx
@@ -13,7 +13,7 @@ export const Layout = ({
     <div
       className={classNames(
         'max-w-[1440px]',
-        'mx-auto px-16 md:px-32 pb-32',
+        'mx-auto px-8 lg:px-32 pb-32',
         'relative z-0',
         className
       )}

--- a/apps/trading/client-pages/referrals/layout.tsx
+++ b/apps/trading/client-pages/referrals/layout.tsx
@@ -13,7 +13,7 @@ export const Layout = ({
     <div
       className={classNames(
         'max-w-[1440px]',
-        'mx-auto px-8 lg:px-32 pb-32',
+        'mx-auto px-4 lg:px-32 pb-32',
         'relative z-0',
         className
       )}

--- a/apps/trading/client-pages/referrals/referral-statistics.tsx
+++ b/apps/trading/client-pages/referrals/referral-statistics.tsx
@@ -14,7 +14,7 @@ import {
   useUpdateReferees,
 } from './hooks/use-referral';
 import classNames from 'classnames';
-import { Table } from './table';
+import { Table } from '../../components/table';
 import {
   addDecimalsFormatNumber,
   getDateFormat,

--- a/apps/trading/client-pages/referrals/referrals.tsx
+++ b/apps/trading/client-pages/referrals/referrals.tsx
@@ -72,7 +72,7 @@ export const Referrals = () => {
       {showNav && <Nav />}
       <div
         className={classNames({
-          'py-16': showNav,
+          'py-8 lg:py-16': showNav,
           'h-[300px] relative': loading || error,
         })}
       >

--- a/apps/trading/client-pages/referrals/table.tsx
+++ b/apps/trading/client-pages/referrals/table.tsx
@@ -66,7 +66,7 @@ export const Table = forwardRef<
         ref={ref}
         className={classNames(
           'w-full',
-          'border-separate border rounded-md border-spacing-0',
+          'border-separate border rounded-md border-spacing-0 overflow-hidden',
           BORDER_COLOR,
           GRADIENT,
           className

--- a/apps/trading/client-pages/referrals/tiers.tsx
+++ b/apps/trading/client-pages/referrals/tiers.tsx
@@ -3,11 +3,12 @@ import {
   getDateTimeFormat,
 } from '@vegaprotocol/utils';
 import { useReferralProgram } from './hooks/use-referral-program';
-import { Table } from './table';
+import { Table } from '../../components/table';
 import classNames from 'classnames';
 import { BORDER_COLOR, GRADIENT } from './constants';
-import { Tag } from './tag';
-import type { ComponentProps, ReactNode } from 'react';
+import { Tag } from '../../components/helpers/tag';
+import { getTierColor, getTierGradient } from '../../components/helpers/tiers';
+import type { ReactNode } from 'react';
 import { ExternalLink, truncateMiddle } from '@vegaprotocol/ui-toolkit';
 import {
   DApp,
@@ -18,25 +19,6 @@ import {
 } from '@vegaprotocol/environment';
 import { useT, ns } from '../../lib/use-t';
 import { Trans } from 'react-i18next';
-
-// rainbow-ish order
-const TIER_COLORS: Array<ComponentProps<typeof Tag>['color']> = [
-  'pink',
-  'orange',
-  'yellow',
-  'green',
-  'blue',
-  'purple',
-];
-
-const getTierColor = (tier: number) => {
-  const tiers = Object.keys(TIER_COLORS).length;
-  let index = Math.abs(tier - 1);
-  if (tier >= tiers) {
-    index = index % tiers;
-  }
-  return TIER_COLORS[index];
-};
 
 const Loading = ({ variant }: { variant: 'large' | 'inline' }) => (
   <div
@@ -53,10 +35,12 @@ const StakingTier = ({
   tier,
   referralRewardMultiplier,
   minimumStakedTokens,
+  max,
 }: {
   tier: number;
   referralRewardMultiplier: string;
   minimumStakedTokens: string;
+  max?: number;
 }) => {
   const t = useT();
   const minimum = addDecimalsFormatNumber(minimumStakedTokens, 18);
@@ -97,7 +81,7 @@ const StakingTier = ({
         )}
       >
         <div>
-          <Tag color={getTierColor(tier)}>
+          <Tag color={getTierColor(tier, max)}>
             {t('Multiplier')} {referralRewardMultiplier}x
           </Tag>
           <p className="mt-1 text-sm text-vega-clight-100 dark:text-vega-cdark-100">
@@ -159,7 +143,9 @@ export const TiersContainer = () => {
 
   return (
     <>
-      <h2 className="text-3xl mt-10">{t('Current program details')}</h2>
+      <h2 className="text-3xl mt-10 font-alpha calt">
+        {t('Current program details')}
+      </h2>
       {details?.id && (
         <p>
           <Trans
@@ -272,6 +258,7 @@ const StakingTiers = ({
       <StakingTier
         key={i}
         tier={tier}
+        max={data.length}
         referralRewardMultiplier={referralRewardMultiplier}
         minimumStakedTokens={minimumStakedTokens}
       />
@@ -333,22 +320,7 @@ const TiersTable = ({
       className="bg-white dark:bg-vega-cdark-900"
       data={data.map((d) => ({
         ...d,
-        className: classNames({
-          'from-vega-yellow-400 dark:from-vega-yellow-600 to-20%  bg-highlight':
-            'yellow' === getTierColor(d.tier),
-          'from-vega-green-400 dark:from-vega-green-600 to-20%  bg-highlight':
-            'green' === getTierColor(d.tier),
-          'from-vega-blue-400 dark:from-vega-blue-600 to-20%  bg-highlight':
-            'blue' === getTierColor(d.tier),
-          'from-vega-purple-400 dark:from-vega-purple-600 to-20%  bg-highlight':
-            'purple' === getTierColor(d.tier),
-          'from-vega-pink-400 dark:from-vega-pink-600 to-20%  bg-highlight':
-            'pink' === getTierColor(d.tier),
-          'from-vega-orange-400 dark:from-vega-orange-600 to-20%  bg-highlight':
-            'orange' === getTierColor(d.tier),
-          'from-vega-clight-200 dark:from-vega-cdark-200 to-20%  bg-highlight':
-            'none' === getTierColor(d.tier),
-        }),
+        className: classNames(getTierGradient(d.tier, data.length)),
       }))}
     />
   );

--- a/apps/trading/client-pages/referrals/tiers.tsx
+++ b/apps/trading/client-pages/referrals/tiers.tsx
@@ -198,7 +198,18 @@ export const TiersContainer = () => {
       </div>
 
       {/* Container */}
-      <div className="bg-vega-clight-800 dark:bg-vega-cdark-800 text-black dark:text-white rounded-lg p-6 mt-1 mb-20">
+      <div
+        className={classNames(
+          'md:bg-vega-clight-800',
+          'md:dark:bg-vega-cdark-800',
+          'md:text-black',
+          'md:dark:text-white',
+          'md:rounded-lg',
+          'md:p-6',
+          'mt-1',
+          'mb-20'
+        )}
+      >
         {/* Benefit tiers */}
         <div className="flex flex-col mb-5">
           <h3 className="text-2xl calt">{t('Benefit tiers')}</h3>

--- a/apps/trading/client-pages/referrals/tile.tsx
+++ b/apps/trading/client-pages/referrals/tile.tsx
@@ -19,9 +19,11 @@ export const Tile = ({
   return (
     <div
       className={classNames(
-        'rounded-lg overflow-hidden relative',
-        'bg-vega-clight-800 dark:bg-vega-cdark-800 text-black dark:text-white',
-        'p-6',
+        'text-black dark:text-white',
+        'overflow-hidden relative',
+        'p-3 md:p-6',
+        'rounded-lg',
+        'bg-vega-clight-800 dark:bg-vega-cdark-800',
         className
       )}
     >
@@ -55,7 +57,10 @@ export const StatTile = ({
       >
         {title}
       </h3>
-      <div data-testid={`${testId}-value`} className="text-5xl text-left">
+      <div
+        data-testid={`${testId}-value`}
+        className="text-2xl lg:text-5xl text-left"
+      >
         {children}
       </div>
       {description && (
@@ -119,7 +124,7 @@ export const CodeTile = ({
         >
           <div
             className={classNames(
-              'relative bg-rainbow bg-clip-text text-transparent text-5xl overflow-hidden',
+              'relative bg-rainbow bg-clip-text text-transparent text-2xl lg:text-5xl overflow-hidden',
               FADE_OUT_STYLE
             )}
           >

--- a/apps/trading/components/card/card.tsx
+++ b/apps/trading/components/card/card.tsx
@@ -9,6 +9,7 @@ export const Card = ({
   loading = false,
   highlight = false,
   testId,
+  noBackgroundOnMobile = false,
 }: {
   children: ReactNode;
   title: string;
@@ -16,20 +17,33 @@ export const Card = ({
   loading?: boolean;
   highlight?: boolean;
   testId?: string;
+  noBackgroundOnMobile?: boolean;
 }) => {
   return (
     <div
       data-testid={testId}
       className={classNames(
-        'bg-vega-clight-800 dark:bg-vega-cdark-800 col-span-full p-0.5 lg:col-auto',
-        'rounded-lg',
+        'col-span-full lg:col-auto',
+        {
+          'rounded-lg bg-vega-clight-800 dark:bg-vega-cdark-800 p-0.5':
+            !noBackgroundOnMobile,
+          'mt-3 md:mt-0 md:rounded-lg md:bg-vega-clight-800 md:dark:bg-vega-cdark-800 md:p-0.5':
+            noBackgroundOnMobile,
+        },
         {
           'bg-rainbow': highlight,
         },
         className
       )}
     >
-      <div className="bg-vega-clight-800 dark:bg-vega-cdark-800 h-full w-full rounded p-4">
+      <div
+        className={classNames('h-full w-full', {
+          'bg-vega-clight-800 dark:bg-vega-cdark-800 rounded p-4':
+            !noBackgroundOnMobile,
+          'md:bg-vega-clight-800 md:dark:bg-vega-cdark-800 md:rounded md:p-4':
+            noBackgroundOnMobile,
+        })}
+      >
         <h2 className="mb-3">{title}</h2>
         {loading ? <CardLoader /> : children}
       </div>

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -486,7 +486,7 @@ const VolumeTiers = ({
       <SimpleTable
         className="bg-white dark:bg-vega-cdark-900"
         columns={[
-          { name: 'tier', displayName: t('Tier'), testId: 'tier-value' },
+          { name: 'tier', displayName: t('Tier'), testId: 'col-tier-value' },
           {
             name: 'discount',
             displayName: t('Discount'),
@@ -515,7 +515,7 @@ const VolumeTiers = ({
           const indicator = isUserTier ? <YourTier /> : null;
           const tierIndicator = (
             <div className="flex justify-between">
-              <span>{i + 1}</span>
+              <span data-testid={`tier-value-${i}`}>{i + 1}</span>
               <span className="md:hidden">{indicator}</span>
             </div>
           );
@@ -574,7 +574,7 @@ const ReferralTiers = ({
       <SimpleTable
         className="bg-white dark:bg-vega-cdark-900"
         columns={[
-          { name: 'tier', displayName: t('Tier'), testId: 'tier-value' },
+          { name: 'tier', displayName: t('Tier'), testId: 'col-tier-value' },
           {
             name: 'discount',
             displayName: t('Discount'),
@@ -626,7 +626,7 @@ const ReferralTiers = ({
 
           const tierIndicator = (
             <div className="flex justify-between">
-              <span>{i + 1}</span>
+              <span data-testid={`tier-value-${i}`}>{i + 1}</span>
               <span className="md:hidden">{indicator}</span>
             </div>
           );

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -512,7 +512,9 @@ const VolumeTiers = ({
         ]}
         data={Array.from(tiers).map((tier, i) => {
           const isUserTier = tierIndex === i;
-          const indicator = isUserTier ? <YourTier /> : null;
+          const indicator = isUserTier ? (
+            <YourTier testId={`your-volume-tier-${i}`} />
+          ) : null;
           const tierIndicator = (
             <div className="flex justify-between">
               <span data-testid={`tier-value-${i}`}>{i + 1}</span>
@@ -616,7 +618,7 @@ const ReferralTiers = ({
           const requiredVolume = Number(tier.minimumRunningNotionalTakerVolume);
 
           const indicator = isUserTier ? (
-            <YourTier testId={`your-tier-${i}`} />
+            <YourTier testId={`your-referral-tier-${i}`} />
           ) : referralVolumeInWindow >= requiredVolume &&
             epochsInSet < tier.minimumEpochs ? (
             <span className="text-muted text-xs">

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -13,7 +13,7 @@ import { MarketFees } from './market-fees';
 import { useVolumeStats } from './use-volume-stats';
 import { useReferralStats } from './use-referral-stats';
 import { formatPercentage, getAdjustedFee } from './utils';
-import { Table, Td, Th, THead, Tr } from './table';
+import { Table as SimpleTable } from '../../components/table';
 import BigNumber from 'bignumber.js';
 import { Links } from '../../lib/links';
 import { Link } from 'react-router-dom';
@@ -24,6 +24,8 @@ import {
   truncateMiddle,
 } from '@vegaprotocol/ui-toolkit';
 import { useT } from '../../lib/use-t';
+import classNames from 'classnames';
+import { getTierGradient } from '../helpers/tiers';
 
 export const FeesContainer = () => {
   const t = useT();
@@ -166,6 +168,7 @@ export const FeesContainer = () => {
         className="lg:col-span-full xl:col-span-2"
         loading={loading}
         data-testid="volume-discount-card"
+        noBackgroundOnMobile={true}
       >
         <VolumeTiers
           tiers={volumeTiers}
@@ -179,12 +182,14 @@ export const FeesContainer = () => {
         className="lg:col-span-full xl:col-span-2"
         loading={loading}
         data-testid="referral-discount-card"
+        noBackgroundOnMobile={true}
       >
         <ReferralTiers
           tiers={referralTiers}
           tierIndex={referralTierIndex}
           epochsInSet={epochsInSet}
           referralVolumeInWindow={referralVolumeInWindow}
+          referralDiscountWindowLength={referralDiscountWindowLength}
         />
       </Card>
       <Card
@@ -192,6 +197,7 @@ export const FeesContainer = () => {
         className="lg:col-span-full"
         loading={marketsLoading}
         data-testid="fees-by-market-card"
+        noBackgroundOnMobile={true}
       >
         <MarketFees
           markets={markets}
@@ -477,7 +483,54 @@ const VolumeTiers = ({
 
   return (
     <div>
-      <Table>
+      <SimpleTable
+        className="bg-white dark:bg-vega-cdark-900"
+        columns={[
+          { name: 'tier', displayName: t('Tier') },
+          { name: 'discount', displayName: t('Discount') },
+          { name: 'minTradingVolume', displayName: t('Min. trading volume') },
+          {
+            name: 'myVolume',
+            displayName: t('myVolume', 'My volume (last {{count}} epochs)', {
+              count: windowLength,
+            }),
+          },
+          {
+            name: 'indicator',
+            className: 'max-md:hidden',
+          },
+        ]}
+        data={Array.from(tiers).map((tier, i) => {
+          const isUserTier = tierIndex === i;
+          const indicator = isUserTier ? <YourTier /> : null;
+          const tierIndicator = (
+            <div className="flex justify-between">
+              <span>{i + 1}</span>
+              <span className="md:hidden">{indicator}</span>
+            </div>
+          );
+          return {
+            tier: tierIndicator,
+            discount: (
+              <>{formatPercentage(Number(tier.volumeDiscountFactor))}%</>
+            ),
+            minTradingVolume: (
+              <>{formatNumber(tier.minimumRunningNotionalTakerVolume)}</>
+            ),
+            myVolume: isUserTier ? (
+              formatNumber(lastEpochVolume)
+            ) : (
+              <span className="md:hidden">-</span>
+            ),
+            indicator: indicator,
+            className: classNames(
+              getTierGradient(i + 1, tiers.length),
+              'text-xs'
+            ),
+          };
+        })}
+      />
+      {/* <Table>
         <THead>
           <Tr>
             <Th data-testid="tier-header">{t('Tier')}</Th>
@@ -514,7 +567,7 @@ const VolumeTiers = ({
             );
           })}
         </tbody>
-      </Table>
+      </Table> */}
     </div>
   );
 };
@@ -524,6 +577,7 @@ const ReferralTiers = ({
   tierIndex,
   epochsInSet,
   referralVolumeInWindow,
+  referralDiscountWindowLength,
 }: {
   tiers: Array<{
     referralDiscountFactor: string;
@@ -533,6 +587,7 @@ const ReferralTiers = ({
   tierIndex: number;
   epochsInSet: number;
   referralVolumeInWindow: number;
+  referralDiscountWindowLength: number;
 }) => {
   const t = useT();
 
@@ -544,7 +599,75 @@ const ReferralTiers = ({
 
   return (
     <div>
-      <Table>
+      <SimpleTable
+        className="bg-white dark:bg-vega-cdark-900"
+        columns={[
+          { name: 'tier', displayName: t('Tier') },
+          {
+            name: 'discount',
+            displayName: t('Discount'),
+            tooltip: t(
+              "The proportion of the referee's taker fees to be discounted"
+            ),
+          },
+          {
+            name: 'volume',
+            displayName: t(
+              'minTradingVolume',
+              'Min. trading volume (last {{count}} epochs)',
+              {
+                count: referralDiscountWindowLength,
+              }
+            ),
+            tooltip: t(
+              'The minimum running notional for the given benefit tier'
+            ),
+          },
+          {
+            name: 'epochs',
+            displayName: t('Min. epochs'),
+            tooltip: t(
+              'The minimum number of epochs the party needs to be in the referral set to be eligible for the benefit'
+            ),
+          },
+          { name: 'indicator', className: 'max-md:hidden' },
+        ]}
+        data={Array.from(tiers).map((tier, i) => {
+          const isUserTier = tierIndex === i;
+          const requiredVolume = Number(tier.minimumRunningNotionalTakerVolume);
+
+          const indicator = isUserTier ? (
+            <YourTier testId={`your-tier-${i}`} />
+          ) : referralVolumeInWindow >= requiredVolume &&
+            epochsInSet < tier.minimumEpochs ? (
+            <span className="text-muted text-xs">
+              Unlocks in {tier.minimumEpochs - epochsInSet} epochs
+            </span>
+          ) : null;
+
+          const tierIndicator = (
+            <div className="flex justify-between">
+              <span>{i + 1}</span>
+              <span className="md:hidden">{indicator}</span>
+            </div>
+          );
+
+          return {
+            tier: tierIndicator,
+            discount: (
+              <>{formatPercentage(Number(tier.referralDiscountFactor))}%</>
+            ),
+            volume: formatNumber(tier.minimumRunningNotionalTakerVolume),
+            epochs: tier.minimumEpochs,
+            indicator,
+            className: classNames(
+              getTierGradient(i + 1, tiers.length),
+              'text-xs'
+            ),
+          };
+        })}
+      />
+      {/* <Table>
         <THead>
           <Tr>
             <Th data-testid="tier-header">{t('Tier')}</Th>
@@ -597,7 +720,7 @@ const ReferralTiers = ({
             );
           })}
         </tbody>
-      </Table>
+      </Table> */}
     </div>
   );
 };
@@ -611,7 +734,7 @@ const YourTier = ({ testId }: YourTierProps) => {
 
   return (
     <span
-      className="bg-rainbow whitespace-nowrap rounded-xl px-4 py-1.5 text-white"
+      className="bg-rainbow whitespace-nowrap rounded-xl px-4 py-1.5 text-white text-xs"
       data-testid={testId}
     >
       {t('Your tier')}

--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -486,18 +486,28 @@ const VolumeTiers = ({
       <SimpleTable
         className="bg-white dark:bg-vega-cdark-900"
         columns={[
-          { name: 'tier', displayName: t('Tier') },
-          { name: 'discount', displayName: t('Discount') },
-          { name: 'minTradingVolume', displayName: t('Min. trading volume') },
+          { name: 'tier', displayName: t('Tier'), testId: 'tier-value' },
+          {
+            name: 'discount',
+            displayName: t('Discount'),
+            testId: 'discount-value',
+          },
+          {
+            name: 'minTradingVolume',
+            displayName: t('Min. trading volume'),
+            testId: 'min-volume-value',
+          },
           {
             name: 'myVolume',
             displayName: t('myVolume', 'My volume (last {{count}} epochs)', {
               count: windowLength,
             }),
+            testId: 'my-volume-value',
           },
           {
             name: 'indicator',
             className: 'max-md:hidden',
+            testId: 'your-tier',
           },
         ]}
         data={Array.from(tiers).map((tier, i) => {
@@ -530,44 +540,6 @@ const VolumeTiers = ({
           };
         })}
       />
-      {/* <Table>
-        <THead>
-          <Tr>
-            <Th data-testid="tier-header">{t('Tier')}</Th>
-            <Th data-testid="discount-header">{t('Discount')}</Th>
-            <Th data-testid="min-volume-header">{t('Min. trading volume')}</Th>
-            <Th data-testid="my-volume-header">
-              {t('myVolume', 'My volume (last {{count}} epochs)', {
-                count: windowLength,
-              })}
-            </Th>
-            <Th data-testid="actions-header" />
-          </Tr>
-        </THead>
-        <tbody>
-          {Array.from(tiers).map((tier, i) => {
-            const isUserTier = tierIndex === i;
-
-            return (
-              <Tr key={i} data-testid={`tier-row-${i}`}>
-                <Td data-testid={`tier-value-${i}`}>{i + 1}</Td>
-                <Td data-testid={`discount-value-${i}`}>
-                  {formatPercentage(Number(tier.volumeDiscountFactor))}%
-                </Td>
-                <Td data-testid={`min-volume-value-${i}`}>
-                  {formatNumber(tier.minimumRunningNotionalTakerVolume)}
-                </Td>
-                <Td data-testid={`my-volume-value-${i}`}>
-                  {isUserTier ? formatNumber(lastEpochVolume) : ''}
-                </Td>
-                <Td data-testid={`your-tier-${i}`}>
-                  {isUserTier ? <YourTier /> : null}
-                </Td>
-              </Tr>
-            );
-          })}
-        </tbody>
-      </Table> */}
     </div>
   );
 };
@@ -602,13 +574,14 @@ const ReferralTiers = ({
       <SimpleTable
         className="bg-white dark:bg-vega-cdark-900"
         columns={[
-          { name: 'tier', displayName: t('Tier') },
+          { name: 'tier', displayName: t('Tier'), testId: 'tier-value' },
           {
             name: 'discount',
             displayName: t('Discount'),
             tooltip: t(
               "The proportion of the referee's taker fees to be discounted"
             ),
+            testId: 'discount-value',
           },
           {
             name: 'volume',
@@ -622,6 +595,7 @@ const ReferralTiers = ({
             tooltip: t(
               'The minimum running notional for the given benefit tier'
             ),
+            testId: 'min-volume-value',
           },
           {
             name: 'epochs',
@@ -629,8 +603,13 @@ const ReferralTiers = ({
             tooltip: t(
               'The minimum number of epochs the party needs to be in the referral set to be eligible for the benefit'
             ),
+            testId: 'required-epochs-value',
           },
-          { name: 'indicator', className: 'max-md:hidden' },
+          {
+            name: 'indicator',
+            className: 'max-md:hidden',
+            testId: 'user-tier-or-unlocks',
+          },
         ]}
         data={Array.from(tiers).map((tier, i) => {
           const isUserTier = tierIndex === i;
@@ -667,60 +646,6 @@ const ReferralTiers = ({
           };
         })}
       />
-      {/* <Table>
-        <THead>
-          <Tr>
-            <Th data-testid="tier-header">{t('Tier')}</Th>
-            <Th data-testid="discount-header">{t('Discount')}</Th>
-            <Th data-testid="min-volume-header">{t('Min. trading volume')}</Th>
-            <Th data-testid="required-epochs-header">{t('Required epochs')}</Th>
-            <Th data-testid="extra-header" />
-          </Tr>
-        </THead>
-        <tbody>
-          {Array.from(tiers).map((tier, i) => {
-            const isUserTier = tierIndex === i;
-
-            const requiredVolume = Number(
-              tier.minimumRunningNotionalTakerVolume
-            );
-            let unlocksIn = null;
-
-            if (
-              referralVolumeInWindow >= requiredVolume &&
-              epochsInSet < tier.minimumEpochs
-            ) {
-              unlocksIn = (
-                <span className="text-muted">
-                  Unlocks in {tier.minimumEpochs - epochsInSet} epochs
-                </span>
-              );
-            }
-
-            return (
-              <Tr key={i} data-testid={`tier-row-${i}`}>
-                <Td data-testid={`tier-value-${i}`}>{i + 1}</Td>
-                <Td data-testid={`discount-value-${i}`}>
-                  {formatPercentage(Number(tier.referralDiscountFactor))}%
-                </Td>
-                <Td data-testid={`min-volume-value-${i}`}>
-                  {formatNumber(tier.minimumRunningNotionalTakerVolume)}
-                </Td>
-                <Td data-testid={`required-epochs-value-${i}`}>
-                  {tier.minimumEpochs}
-                </Td>
-                <Td data-testid={`user-tier-or-unlocks-${i}`}>
-                  {isUserTier ? (
-                    <YourTier testId={`your-tier-${i}`} />
-                  ) : (
-                    unlocksIn
-                  )}
-                </Td>
-              </Tr>
-            );
-          })}
-        </tbody>
-      </Table> */}
     </div>
   );
 };

--- a/apps/trading/components/fees-container/market-fees.tsx
+++ b/apps/trading/components/fees-container/market-fees.tsx
@@ -19,6 +19,7 @@ const useFeesTableColumnDefs = (): ColDef[] => {
           field: 'code',
           cellRenderer: 'MarketCodeCell',
           pinned: 'left',
+          width: 150,
         },
         {
           field: 'liquidityFee',
@@ -49,6 +50,7 @@ const useFeesTableColumnDefs = (): ColDef[] => {
 
 const feesTableDefaultColDef = {
   flex: 1,
+  minWidth: 62,
   resizable: true,
   sortable: true,
   suppressMovable: true,

--- a/apps/trading/components/fees-container/market-fees.tsx
+++ b/apps/trading/components/fees-container/market-fees.tsx
@@ -8,35 +8,41 @@ import { useNavigateWithMeta } from '../../lib/hooks/use-market-click-handler';
 import { Links } from '../../lib/links';
 import { useT } from '../../lib/use-t';
 import { useMemo } from 'react';
+import { type ColDef } from 'ag-grid-community/dist/lib/entities/colDef';
 
-const useFeesTableColumnDefs = () => {
+const useFeesTableColumnDefs = (): ColDef[] => {
   const t = useT();
   return useMemo(
-    () => [
-      { field: 'code', cellRenderer: 'MarketCodeCell' },
-      {
-        field: 'feeAfterDiscount',
-        headerName: t('Total fee after discount'),
-        valueFormatter: ({ value }: { value: number }) => value + '%',
-      },
-      {
-        field: 'infraFee',
-        valueFormatter: ({ value }: { value: number }) => value + '%',
-      },
-      {
-        field: 'makerFee',
-        valueFormatter: ({ value }: { value: number }) => value + '%',
-      },
-      {
-        field: 'liquidityFee',
-        valueFormatter: ({ value }: { value: number }) => value + '%',
-      },
-      {
-        field: 'totalFee',
-        headerName: t('Total fee before discount'),
-        valueFormatter: ({ value }: { value: number }) => value + '%',
-      },
-    ],
+    () =>
+      [
+        {
+          field: 'code',
+          cellRenderer: 'MarketCodeCell',
+          pinned: 'left',
+        },
+        {
+          field: 'liquidityFee',
+          valueFormatter: ({ value }: { value: number }) => value + '%',
+        },
+        {
+          field: 'feeAfterDiscount',
+          headerName: t('Total fee after discount'),
+          valueFormatter: ({ value }: { value: number }) => value + '%',
+        },
+        {
+          field: 'totalFee',
+          headerName: t('Total fee before discount'),
+          valueFormatter: ({ value }: { value: number }) => value + '%',
+        },
+        {
+          field: 'infraFee',
+          valueFormatter: ({ value }: { value: number }) => value + '%',
+        },
+        {
+          field: 'makerFee',
+          valueFormatter: ({ value }: { value: number }) => value + '%',
+        },
+      ] as ColDef[],
     [t]
   );
 };
@@ -45,6 +51,8 @@ const feesTableDefaultColDef = {
   flex: 1,
   resizable: true,
   sortable: true,
+  suppressMovable: true,
+  pinned: false,
 };
 
 const components = {
@@ -61,6 +69,8 @@ export const MarketFees = ({
   volumeDiscount: number;
 }) => {
   const navigateWithMeta = useNavigateWithMeta();
+
+  const colDef = useFeesTableColumnDefs();
 
   const rows = compact(markets || []).map((m) => {
     const infraFee = new BigNumber(m.fees.factors.infrastructureFee);
@@ -88,9 +98,9 @@ export const MarketFees = ({
   });
 
   return (
-    <div className="border rounded-sm border-default">
+    <div className="border rounded-lg md:rounded-sm overflow-hidden border-default">
       <AgGrid
-        columnDefs={useFeesTableColumnDefs()}
+        columnDefs={colDef}
         rowData={rows}
         getRowId={({ data }) => data.id}
         defaultColDef={feesTableDefaultColDef}

--- a/apps/trading/components/helpers/tag.tsx
+++ b/apps/trading/components/helpers/tag.tsx
@@ -2,7 +2,15 @@ import type { HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
 type TagProps = {
-  color?: 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'orange' | 'none';
+  color?:
+    | 'yellow'
+    | 'green'
+    | 'blue'
+    | 'purple'
+    | 'pink'
+    | 'orange'
+    | 'red'
+    | 'none';
 };
 export const Tag = ({
   color = 'none',

--- a/apps/trading/components/helpers/tiers.tsx
+++ b/apps/trading/components/helpers/tiers.tsx
@@ -1,0 +1,48 @@
+import type { ComponentProps } from 'react';
+import type { Tag } from './tag';
+import classNames from 'classnames';
+
+// rainbow-ish order
+export const TIER_COLORS: Array<ComponentProps<typeof Tag>['color']> = [
+  'none', // worst tier if 8 tiers, otherwise relative to the best tier
+  'red',
+  'pink',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple', // best tier
+];
+
+export const getTierColor = (tier: number, max = TIER_COLORS.length) => {
+  const available =
+    max < TIER_COLORS.length
+      ? TIER_COLORS.slice(TIER_COLORS.length - max)
+      : TIER_COLORS;
+  const tiers = Object.keys(available).length;
+  let index = Math.abs(tier - 1);
+  if (tier >= tiers) {
+    index = index % tiers;
+  }
+  return available[index];
+};
+
+export const getTierGradient = (tier: number, max = TIER_COLORS.length) =>
+  classNames({
+    'from-vega-yellow-400 dark:from-vega-yellow-600 to-20%  bg-highlight':
+      'yellow' === getTierColor(tier, max),
+    'from-vega-green-400 dark:from-vega-green-600 to-20%  bg-highlight':
+      'green' === getTierColor(tier, max),
+    'from-vega-blue-400 dark:from-vega-blue-600 to-20%  bg-highlight':
+      'blue' === getTierColor(tier, max),
+    'from-vega-purple-400 dark:from-vega-purple-600 to-20%  bg-highlight':
+      'purple' === getTierColor(tier, max),
+    'from-vega-pink-400 dark:from-vega-pink-600 to-20%  bg-highlight':
+      'pink' === getTierColor(tier, max),
+    'from-vega-orange-400 dark:from-vega-orange-600 to-20%  bg-highlight':
+      'orange' === getTierColor(tier, max),
+    'from-vega-red-400 dark:from-vega-red-600 to-20%  bg-highlight':
+      'red' === getTierColor(tier, max),
+    'from-vega-clight-600 dark:from-vega-cdark-600 to-20%  bg-highlight':
+      'none' === getTierColor(tier, max),
+  });

--- a/apps/trading/components/rewards-container/rewards-container.tsx
+++ b/apps/trading/components/rewards-container/rewards-container.tsx
@@ -231,6 +231,7 @@ export const RewardsContainer = () => {
         title={t('Rewards history')}
         className="lg:col-span-full"
         loading={rewardsLoading}
+        noBackgroundOnMobile={true}
       >
         <RewardsHistoryContainer
           epoch={Number(epochData?.epoch.id)}

--- a/apps/trading/components/rewards-container/rewards-history.spec.tsx
+++ b/apps/trading/components/rewards-container/rewards-history.spec.tsx
@@ -99,16 +99,25 @@ describe('RewardsHistoryTable', () => {
   it('renders table with accounts summed up by asset', () => {
     render(<RewardHistoryTable {...props} />);
 
-    const container = within(
+    const containerLeft = within(
+      document.querySelector('.ag-pinned-left-cols-container') as HTMLElement
+    );
+    const pinnedRows = containerLeft.getAllByRole('row');
+
+    const containerCenter = within(
       document.querySelector('.ag-center-cols-container') as HTMLElement
     );
-    const rows = container.getAllByRole('row');
+    const rows = containerCenter.getAllByRole('row');
     expect(rows).toHaveLength(
       Object.keys(groupBy(rewardSummaries, 'node.assetId')).length
     );
 
     let row = within(rows[0]);
-    let cells = row.getAllByRole('gridcell');
+    let pinnedRow = within(pinnedRows[0]);
+    let cells = [
+      ...pinnedRow.getAllByRole('gridcell'),
+      ...row.getAllByRole('gridcell'),
+    ];
 
     let assetCell = getCell(cells, 'asset.symbol');
     expect(assetCell.getByTestId('stack-cell-primary')).toHaveTextContent(
@@ -140,7 +149,11 @@ describe('RewardsHistoryTable', () => {
 
     // Second row
     row = within(rows[1]);
-    cells = row.getAllByRole('gridcell');
+    pinnedRow = within(pinnedRows[1]);
+    cells = [
+      ...pinnedRow.getAllByRole('gridcell'),
+      ...row.getAllByRole('gridcell'),
+    ];
 
     assetCell = getCell(cells, 'asset.symbol');
     expect(assetCell.getByTestId('stack-cell-primary')).toHaveTextContent(

--- a/apps/trading/components/rewards-container/rewards-history.tsx
+++ b/apps/trading/components/rewards-container/rewards-history.tsx
@@ -93,6 +93,7 @@ export const RewardsHistoryContainer = ({
 
 const defaultColDef = {
   flex: 1,
+  minWidth: 62,
   resizable: true,
   sortable: true,
 };
@@ -196,6 +197,7 @@ export const RewardHistoryTable = ({
         },
         sort: 'desc',
         pinned: 'left',
+        width: 150,
       },
       {
         field: 'infrastructureFees',

--- a/apps/trading/components/rewards-container/rewards-history.tsx
+++ b/apps/trading/components/rewards-container/rewards-history.tsx
@@ -195,6 +195,7 @@ export const RewardHistoryTable = ({
           return <StackedCell primary={value} secondary={data.asset.name} />;
         },
         sort: 'desc',
+        pinned: 'left',
       },
       {
         field: 'infrastructureFees',
@@ -257,7 +258,7 @@ export const RewardHistoryTable = ({
 
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between gap-2">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <h4 className="text-muted flex items-center gap-2 text-sm">
           <label htmlFor="fromEpoch">{t('From epoch')}</label>
           <EpochInput
@@ -329,15 +330,17 @@ export const RewardHistoryTable = ({
           </TradingButton>
         </div>
       </div>
-      <AgGrid
-        columnDefs={columnDefs}
-        defaultColDef={defaultColDef}
-        rowData={rowData}
-        rowHeight={45}
-        domLayout="autoHeight"
-        // Show loading message without wiping out the current rows
-        overlayNoRowsTemplate={loading ? t('Loading...') : t('No rows')}
-      />
+      <div className="border rounded-lg md:rounded-sm overflow-hidden border-default">
+        <AgGrid
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          rowData={rowData}
+          rowHeight={45}
+          domLayout="autoHeight"
+          // Show loading message without wiping out the current rows
+          overlayNoRowsTemplate={loading ? t('Loading...') : t('No rows')}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/trading/components/table/index.ts
+++ b/apps/trading/components/table/index.ts
@@ -1,0 +1,1 @@
+export * from './table';

--- a/apps/trading/components/table/table.tsx
+++ b/apps/trading/components/table/table.tsx
@@ -1,7 +1,10 @@
 import { Tooltip, VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 import classNames from 'classnames';
 import { forwardRef, type ReactNode, type HTMLAttributes } from 'react';
-import { BORDER_COLOR, GRADIENT } from './constants';
+
+export const BORDER_COLOR = 'border-vega-clight-500 dark:border-vega-cdark-500';
+export const GRADIENT =
+  'bg-gradient-to-b from-vega-clight-800 dark:from-vega-cdark-800 to-transparent';
 
 type TableColumnDefinition = {
   displayName?: ReactNode;
@@ -42,7 +45,7 @@ export const Table = forwardRef<
               key={name}
               col-id={name}
               className={classNames(
-                'px-5 py-3 text-sm  text-vega-clight-100 dark:text-vega-cdark-100 font-normal',
+                'px-5 py-3 text-xs  text-vega-clight-100 dark:text-vega-cdark-100 font-normal',
                 INNER_BORDER_STYLE
               )}
             >
@@ -85,7 +88,7 @@ export const Table = forwardRef<
               {columns.map(({ name, displayName, className }, j) => (
                 <td
                   className={classNames(
-                    'px-5 py-3 text-base',
+                    'px-5 py-3',
                     {
                       'max-md:flex max-md:flex-col max-md:justify-between':
                         !noCollapse,

--- a/apps/trading/components/table/table.tsx
+++ b/apps/trading/components/table/table.tsx
@@ -11,6 +11,7 @@ type TableColumnDefinition = {
   name: string;
   tooltip?: string;
   className?: string;
+  testId?: string;
 };
 
 type TableProps = {
@@ -85,7 +86,7 @@ export const Table = forwardRef<
                 'max-md:flex flex-col w-full': !noCollapse,
               })}
             >
-              {columns.map(({ name, displayName, className }, j) => (
+              {columns.map(({ name, displayName, className, testId }, j) => (
                 <td
                   className={classNames(
                     'px-5 py-3',
@@ -113,7 +114,7 @@ export const Table = forwardRef<
                       {displayName}
                     </span>
                   )}
-                  <span>{d[name]}</span>
+                  <span data-testid={`${testId || name}-${i}`}>{d[name]}</span>
                 </td>
               ))}
             </tr>

--- a/apps/trading/e2e/tests/fees/test_fees.py
+++ b/apps/trading/e2e/tests/fees/test_fees.py
@@ -52,6 +52,7 @@ REQUIRED_EPOCHS_VALUE_1 = "required-epochs-value-1"
 FILLS = "Fills"
 TAB_FILLS = "tab-fills"
 FEE_BREAKDOWN_TOOLTIP = "fee-breakdown-tooltip"
+PINNED_ROW_LOCATOR = ".ag-pinned-left-cols-container .ag-row"
 ROW_LOCATOR = ".ag-center-cols-container .ag-row"
 # Col-Ids:
 COL_INSTRUMENT_CODE = '[col-id="market.tradableInstrument.instrument.code"]'
@@ -461,8 +462,9 @@ def test_fees_page_discount_program_fees_by_market(
         vega_instance, tier, discount_program, market_ids
     )
     page.goto("/#/fees")
+    pinned = page.locator(PINNED_ROW_LOCATOR)
     row = page.locator(ROW_LOCATOR)
-    expect(row.locator(COL_CODE)).to_have_text("BTC:DAI_2023Futr")
+    expect(pinned.locator(COL_CODE)).to_have_text("BTC:DAI_2023Futr")
     expect(row.locator(COL_FEE_AFTER_DISCOUNT)).to_have_text(fees_after_discount)
     expect(row.locator(COL_INFRA_FEE)).to_have_text("0.05%")
     expect(row.locator(COL_MAKER_FEE)).to_have_text("10%")

--- a/apps/trading/e2e/tests/fees/test_fees.py
+++ b/apps/trading/e2e/tests/fees/test_fees.py
@@ -27,8 +27,6 @@ MIN_VOLUME_VALUE_0 = "min-volume-value-0"
 MIN_VOLUME_VALUE_1 = "min-volume-value-1"
 MY_VOLUME_VALUE_0 = "my-volume-value-0"
 MY_VOLUME_VALUE_1 = "my-volume-value-1"
-YOUR_TIER_0 = "your-tier-0"
-YOUR_TIER_1 = "your-tier-1"
 ORDER_SIZE = "order-size"
 ORDER_PRICE = "order-price"
 DISCOUNT_PILL = "discount-pill"
@@ -406,10 +404,10 @@ def test_fees_page_referral_discount_program_referral_benefits(
 @pytest.mark.parametrize(
     "tier, discount_program, my_volume_test_id, my_volume_value, your_tier",
     [
-        (1, "volume", "my-volume-value-0", "103", "your-tier-0"),
-        (2, "volume", "my-volume-value-1", "206", "your-tier-1"),
-        (1, "referral", "my-volume-value-0", "103", "your-tier-0"),
-        (2, "referral", "my-volume-value-1", "206", "your-tier-1"),
+        (1, "volume", "my-volume-value-0", "103", "your-volume-tier-0"),
+        (2, "volume", "my-volume-value-1", "206", "your-volume-tier-1"),
+        (1, "referral", "my-volume-value-0", "103", "your-referral-tier-0"),
+        (2, "referral", "my-volume-value-1", "206", "your-referral-tier-1"),
     ],
 )
 @pytest.mark.usefixtures("risk_accepted", "auth", "market_ids")

--- a/apps/trading/e2e/tests/fees/test_fees.py
+++ b/apps/trading/e2e/tests/fees/test_fees.py
@@ -439,8 +439,8 @@ def test_fees_page_discount_program_discount(
         expect(page.get_by_test_id(REQUIRED_EPOCHS_VALUE_0)).to_have_text("1")
         expect(page.get_by_test_id(REQUIRED_EPOCHS_VALUE_1)).to_have_text("2")
 
-    expect(page.get_by_test_id(your_tier)).to_be_visible()
-    expect(page.get_by_test_id(your_tier)).to_have_text("Your tier")
+    expect(page.get_by_test_id(your_tier).nth(1)).to_be_visible()
+    expect(page.get_by_test_id(your_tier).nth(1)).to_have_text("Your tier")
 
 
 @pytest.mark.parametrize(

--- a/apps/trading/e2e/tests/market/test_market_selector.py
+++ b/apps/trading/e2e/tests/market/test_market_selector.py
@@ -16,7 +16,7 @@ def test_market_selector(continuous_market, page: Page):
     btc_market = page.locator('[data-testid="market-selector-list"] a')
     expect(btc_market.locator("h3")).to_have_text("BTC:DAI_2023Futr")
     expect(btc_market.locator('[data-testid="market-selector-volume"]')).to_have_text(
-        "1"
+        "0.00"
     )
     expect(btc_market.locator('[data-testid="market-selector-price"]')).to_have_text(
         "107.50 tDAI"
@@ -57,7 +57,7 @@ def test_market_selector_filter(continuous_market, page: Page):
     page.get_by_test_id("search-term").fill("btc")
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
     expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
-        "BTC:DAI_2023107.50 tDAI1"
+        "BTC:DAI_2023107.50 tDAI0.00"
     )
 
     page.get_by_test_id("search-term").clear()
@@ -82,5 +82,5 @@ def test_market_selector_filter(continuous_market, page: Page):
     page.get_by_role("menuitemcheckbox").nth(0).get_by_text("tDAI").click()
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
     expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
-        "BTC:DAI_2023107.50 tDAI1"
+        "BTC:DAI_2023107.50 tDAI0.00"
     )

--- a/apps/trading/e2e/tests/market/test_market_selector.py
+++ b/apps/trading/e2e/tests/market/test_market_selector.py
@@ -9,7 +9,6 @@ def test_market_selector(continuous_market, page: Page):
     page.get_by_test_id("header-title").click()
     # 6001-MARK-066
     expect(page.get_by_test_id("market-selector")).to_be_visible()
-
     # 6001-MARK-021
     # 6001-MARK-022
     # 6001-MARK-024
@@ -17,7 +16,7 @@ def test_market_selector(continuous_market, page: Page):
     btc_market = page.locator('[data-testid="market-selector-list"] a')
     expect(btc_market.locator("h3")).to_have_text("BTC:DAI_2023Futr")
     expect(btc_market.locator('[data-testid="market-selector-volume"]')).to_have_text(
-        "0.00"
+        "1"
     )
     expect(btc_market.locator('[data-testid="market-selector-price"]')).to_have_text(
         "107.50 tDAI"
@@ -43,7 +42,6 @@ def test_market_selector_filter(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("header-title").click()
     # 6001-MARK-027
-
     page.get_by_test_id("product-Spot").click()
     expect(page.get_by_test_id("market-selector-list")).to_contain_text(
         "Spot markets coming soon."
@@ -59,7 +57,7 @@ def test_market_selector_filter(continuous_market, page: Page):
     page.get_by_test_id("search-term").fill("btc")
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
     expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
-        "BTC:DAI_2023107.50 tDAI0.00"
+        "BTC:DAI_2023107.50 tDAI1"
     )
 
     page.get_by_test_id("search-term").clear()
@@ -84,5 +82,5 @@ def test_market_selector_filter(continuous_market, page: Page):
     page.get_by_role("menuitemcheckbox").nth(0).get_by_text("tDAI").click()
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
     expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
-        "BTC:DAI_2023107.50 tDAI0.00"
+        "BTC:DAI_2023107.50 tDAI1"
     )

--- a/libs/datagrid/src/lib/cells/stacked-cell.tsx
+++ b/libs/datagrid/src/lib/cells/stacked-cell.tsx
@@ -8,9 +8,17 @@ export const StackedCell = ({
   secondary: ReactNode;
 }) => {
   return (
-    <div className="leading-4 text-ellipsis whitespace-nowrap overflow-hidden">
-      <div data-testid="stack-cell-primary">{primary}</div>
-      <div data-testid="stack-cell-secondary" className="text-muted">
+    <div className="leading-4">
+      <div
+        className="text-ellipsis whitespace-nowrap overflow-hidden"
+        data-testid="stack-cell-primary"
+      >
+        {primary}
+      </div>
+      <div
+        data-testid="stack-cell-secondary"
+        className="text-ellipsis whitespace-nowrap overflow-hidden text-muted"
+      >
         {secondary}
       </div>
     </div>


### PR DESCRIPTION
# Related issues 🔗

Closes #5428 
Closes #5427 

# Description ℹ️

* removes unnecessary backgrounds on mobile
* collapses the tier tables on mobile
* pins code / asset to the left
* introduces more compact view on mobile

# Demo 📺

![Screenshot 2023-12-20 at 22 26 24](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/6786d576-d53a-4c52-8b2d-e0ecaa99dbaf)
![Screenshot 2023-12-20 at 22 26 48](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/cd17bbea-8c9d-4ee5-92fc-94853c071113)
![Screenshot 2023-12-19 at 15 27 17](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/c8cce3b1-af78-4c7b-bcd6-f9bb43239d50)
...

# Technical 👨‍🔧

N/A
