### PR TITLE
chore(trading-view): minor tv chart tweaks

### DIFF
--- a/libs/trading-view/src/lib/trading-view.tsx
+++ b/libs/trading-view/src/lib/trading-view.tsx
@@ -86,8 +86,7 @@ export const TradingView = ({
 
         // Show volume study by default, second bool arg adds it as a overlay on top of the chart
         studies.forEach((study) => {
-          const asOverlay = study === 'Volume';
-          activeChart.createStudy(study, asOverlay);
+          activeChart.createStudy(study);
         });
 
         // Subscribe to interval changes so it can be persisted in chart settings
@@ -127,5 +126,7 @@ const getOverrides = (theme: 'dark' | 'light') => {
     // colors set here, trading view lets the user set a color
     'paneProperties.background': theme === 'dark' ? '#05060C' : '#fff',
     'paneProperties.backgroundType': 'solid',
+    // hide market name within TV chart as its already above
+    'paneProperties.legendProperties.showSeriesTitle': false,
   };
 };


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Minor tweaks to the trading view chart to align more with the default chart
- Sets volume as study (instead of overlay)
- Removes the market name from the symbol (so its not duplicated below the instrument code in the market header
