### PR TITLE
fix(deal-ticket): stray curly in stop order deal ticket

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
@@ -649,7 +649,6 @@ const formatTrigger = (
             Number(triggerTrailingPercentOffset) || 0
           ).toFixed(1),
         })
-  }
   }`;
 
 const SubmitButton = ({


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Removes a curly brace from being rendered in the stop order deal ticket button
