### PR TITLE
fix(trading): ensure fees queries always fetch on mount and poll

### DIFF
--- a/apps/trading/components/fees-container/fees-container.tsx
+++ b/apps/trading/components/fees-container/fees-container.tsx
@@ -38,7 +38,11 @@ export const FeesContainer = () => {
   const { data: markets, loading: marketsLoading } = useMarketList();
 
   const { data: programData, loading: programLoading } =
-    useDiscountProgramsQuery({ errorPolicy: 'ignore' });
+    useDiscountProgramsQuery({
+      errorPolicy: 'ignore',
+      fetchPolicy: 'cache-and-network',
+      pollInterval: 15000,
+    });
 
   const volumeDiscountWindowLength =
     programData?.currentVolumeDiscountProgram?.windowLength || 1;
@@ -49,6 +53,8 @@ export const FeesContainer = () => {
       partyId: pubKey || '',
     },
     skip: !pubKey,
+    fetchPolicy: 'cache-and-network',
+    pollInterval: 15000,
   });
 
   const previousEpoch = (Number(feesData?.epoch.id) || 0) - 1;

--- a/apps/trading/components/fees-container/use-referral-stats.ts
+++ b/apps/trading/components/fees-container/use-referral-stats.ts
@@ -1,4 +1,5 @@
 import type { DiscountProgramsQuery, FeesQuery } from './__generated__/Fees';
+
 export const useReferralStats = (
   previousEpoch?: number,
   referralStats?: NonNullable<


### PR DESCRIPTION
# Related issues 🔗

Closes #5373 

# Description ℹ️

- Changes fetchPolicy so that on mount the query will execute against the data node (and not just the cache).
- Adds a poll every 15s