### PR TITLE
fix(governance): improve error message for configuration error

### DIFF
--- a/libs/i18n/src/locales/en/governance.json
+++ b/libs/i18n/src/locales/en/governance.json
@@ -383,7 +383,7 @@
   "MoreMarketsInfo": "To see Explorer data on existing markets visit",
   "MoreNetParamsInfo": "To see Explorer data on network params visit",
   "MoreProposalsInfo": "To see Explorer data on proposals visit",
-  "multisigContractIncorrect": "is incorrectly configured. Validator and delegator rewards will be penalised until this is resolved.",
+  "multisigContractIncorrect": "was incorrectly configured as at the end of the last epoch so rewards were penalised. Validator and delegator rewards will continue to be penalised until this is resolved.",
   "multisigContractLink": "Ethereum Multisig Contract",
   "multisigPenalty": "Multisig penalty",
   "myPendingStake": "My pending stake",


### PR DESCRIPTION
# Related issues 🔗

Closes #5588

# Description ℹ️

Makes the error message for an incorrectly configured multisig contract clearer. This is going to `main` as it relates to an error currently existing on the mainnet governance site. This change will be 🍒 cherry-picked in to `develop`.