### PR TITLE
chore(trading): fix price monitoring test

### DIFF
--- a/apps/trading/e2e/tests/market/test_monitoring_auction_price_volatility_market.py
+++ b/apps/trading/e2e/tests/market/test_monitoring_auction_price_volatility_market.py
@@ -64,7 +64,6 @@ def setup_market_monitoring_auction(vega: VegaServiceNull, simple_market):
     submit_order(vega, MM_WALLET.name, simple_market, "SIDE_SELL", 1, 1 + 0.1 / 2)
     submit_order(vega, MM_WALLET2.name, simple_market, "SIDE_SELL", 1, 1)
 
-    vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
@@ -75,7 +74,6 @@ def setup_market_monitoring_auction(vega: VegaServiceNull, simple_market):
     submit_order(vega, MM_WALLET2.name, simple_market, "SIDE_BUY", 100, 95)
     submit_order(vega, MM_WALLET2.name, simple_market, "SIDE_BUY", 1, 105)
 
-    vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
@@ -109,7 +107,6 @@ def test_market_monitoring_auction_price_volatility_limit_order(
     page.get_by_test_id("place-order").click()
 
     wait_for_toast_confirmation(page)
-    vega.forward("10s")
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
     page.get_by_test_id("All").click()


### PR DESCRIPTION
currently the test leaves the price monitoring auction with the forward 10s.

The tests still pass as they go into a liquidity auction that has the same error message (which it probably shouldn't but they are being removed in 74 vega).

Removing the forward time in this test means we are testing an actual price monitoring auction state.