### PR TITLE
fix(trading): use `No trading` instead of `Trading terminated`

### DIFF
--- a/apps/trading/client-pages/markets/closed.spec.tsx
+++ b/apps/trading/client-pages/markets/closed.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 // import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -314,7 +313,7 @@ describe('Closed', () => {
     );
   });
 
-  it.skip('display market actions', async () => {
+  it('display market actions', async () => {
     // Use market with a successor Id as the actions dropdown will optionally
     // show a link to the successor market
     const marketsWithSuccessorAndParent = [

--- a/apps/trading/e2e/tests/market/test_closed_markets.py
+++ b/apps/trading/e2e/tests/market/test_closed_markets.py
@@ -131,7 +131,7 @@ def test_terminated_market_no_settlement_date(page: Page, vega: VegaServiceNull)
     row_selector = page.locator(
         '[data-testid="tab-closed-markets"] .ag-center-cols-container .ag-row'
     ).first
-    expect(row_selector.locator('[col-id="state"]')).to_have_text("Trading Terminated")
+    expect(row_selector.locator('[col-id="state"]')).to_have_text("No trading")
     expect(row_selector.locator('[col-id="settlementDate"]')).to_have_text("Unknown")
 
     # TODO Create test for terminated market with settlement date in future

--- a/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
+++ b/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
@@ -174,9 +174,9 @@ def test_market_lifecycle(proposed_market, vega: VegaServiceNull, page: Page):
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
-    # market state should be changed to "Trading Terminated" because of the invalid oracle
+    # market state should be changed to "No trading" because of the invalid oracle
     expect(trading_mode).to_have_text("No trading")
-    expect(market_state).to_have_text("Trading Terminated")
+    expect(market_state).to_have_text("No trading")
 
     # settle market
     vega.submit_termination_and_settlement_data(

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -329,8 +329,9 @@ export const DealTicket = ({
 
     const marketTradingModeError = validateMarketTradingMode(
       marketTradingMode,
-      t('Trading terminated')
+      t('No trading')
     );
+
     if (marketTradingModeError !== true) {
       return {
         message: marketTradingModeError,

--- a/libs/i18n/src/locales/en/deal-ticket.json
+++ b/libs/i18n/src/locales/en/deal-ticket.json
@@ -116,7 +116,7 @@
   "Total fees": "Total fees",
   "Total margin available": "Total margin available",
   "TOTAL_MARGIN_AVAILABLE": "Total margin available = general {{assetSymbol}} balance ({{generalAccountBalance}} {{assetSymbol}}) + margin balance ({{marginAccountBalance}} {{assetSymbol}}) - maintenance level ({{marginMaintenance}} {{assetSymbol}}).",
-  "Trading terminated": "Trading terminated",
+  "No trading": "No trading",
   "Trailing percent offset cannot be higher than 99.9": "Trailing percent offset cannot be higher than 99.9",
   "Trailing percent offset cannot be lower than {{trailingPercentOffsetStep}}": "Trailing percent offset cannot be lower than {{trailingPercentOffsetStep}}",
   "Trailing percentage offset": "Trailing percentage offset",


### PR DESCRIPTION
# Related issues 🔗

Closes #5574 

# Description ℹ️

Use `No trading` instead of `Trading terminated` on market trading mode validation.
`Trading terminated` is a market state, however state validation does not bring as much value in this scenario. 

# Demo 📺

Fix:
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/876e7b3e-294a-4960-9ae4-0d8b24456ebb)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
