### PR TITLE
chore(trading): market-sim branch parralel fix

### DIFF
--- a/.github/workflows/console-test-run.yml
+++ b/.github/workflows/console-test-run.yml
@@ -205,7 +205,7 @@ jobs:
       # run tests
       #----------------------------------------------
       - name: Run tests
-        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 2 --dist loadfile --durations=90
+        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 1 --dist loadfile --durations=90
         working-directory: apps/trading/e2e
       #----------------------------------------------
       # upload traces

--- a/.github/workflows/console-test-run.yml
+++ b/.github/workflows/console-test-run.yml
@@ -205,7 +205,7 @@ jobs:
       # run tests
       #----------------------------------------------
       - name: Run tests
-        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 1 --dist loadfile --durations=90
+        run: CONSOLE_IMAGE_NAME=ci/trading:local poetry run pytest -v -s --numprocesses 2 --dist loadfile --durations=90
         working-directory: apps/trading/e2e
       #----------------------------------------------
       # upload traces

--- a/apps/trading/e2e/pyproject.toml
+++ b/apps/trading/e2e/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "trading market-sim e2e"}]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
 psutil = "^5.9.5"
-vega-sim = {git = "https://github.com/vegaprotocol/vega-market-sim.git/"}
+vega-sim = {git = "https://github.com/vegaprotocol/vega-market-sim.git/", branch = "feat/retry_transaction_submissions"}
 pytest-playwright = "^0.4.2"
 docker = "^6.1.3"
 pytest-xdist = "^3.3.1"

--- a/apps/trading/e2e/pyproject.toml
+++ b/apps/trading/e2e/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "trading market-sim e2e"}]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"
 psutil = "^5.9.5"
-vega-sim = {git = "https://github.com/vegaprotocol/vega-market-sim.git/", branch = "feat/retry_transaction_submissions"}
+vega-sim = {git = "https://github.com/vegaprotocol/vega-market-sim.git/"}
 pytest-playwright = "^0.4.2"
 docker = "^6.1.3"
 pytest-xdist = "^3.3.1"

--- a/apps/trading/e2e/tests/market/test_closed_markets.py
+++ b/apps/trading/e2e/tests/market/test_closed_markets.py
@@ -131,7 +131,7 @@ def test_terminated_market_no_settlement_date(page: Page, vega: VegaServiceNull)
     row_selector = page.locator(
         '[data-testid="tab-closed-markets"] .ag-center-cols-container .ag-row'
     ).first
-    expect(row_selector.locator('[col-id="state"]')).to_have_text("No trading")
+    expect(row_selector.locator('[col-id="state"]')).to_have_text("Trading Terminated")
     expect(row_selector.locator('[col-id="settlementDate"]')).to_have_text("Unknown")
 
     # TODO Create test for terminated market with settlement date in future

--- a/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
+++ b/apps/trading/e2e/tests/market_lifecycle/test_market_lifecycle.py
@@ -176,7 +176,7 @@ def test_market_lifecycle(proposed_market, vega: VegaServiceNull, page: Page):
 
     # market state should be changed to "No trading" because of the invalid oracle
     expect(trading_mode).to_have_text("No trading")
-    expect(market_state).to_have_text("No trading")
+    expect(market_state).to_have_text("Trading Terminated")
 
     # settle market
     vega.submit_termination_and_settlement_data(

--- a/apps/trading/e2e/tests/trade_history/test_trade_history.py
+++ b/apps/trading/e2e/tests/trade_history/test_trade_history.py
@@ -73,7 +73,6 @@ def test_limit_order_new_trade_top_of_list(
 def test_price_copied_to_deal_ticket(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("Trades").click()
-    page.locator("[col-id=price]").last.click()
+    page.locator("[col-id=price]").nth(1).click()
     # 6005-THIS-007
-    page.reload()
     expect(page.get_by_test_id("order-price")).to_have_value("107.50000")

--- a/apps/trading/e2e/tests/wallet/test_wallet.py
+++ b/apps/trading/e2e/tests/wallet/test_wallet.py
@@ -116,7 +116,7 @@ def test_wallet_transaction_rejected(continuous_market, page: Page):
     page.get_by_test_id(order_price).fill("120")
     page.route("**/*", handle_route_connection_rejected)
     page.get_by_test_id(place_order).click()
-    expect(page.get_by_test_id("toast-content")).to_have_text(
+    expect(page.get_by_test_id("toast-content").nth(0)).to_have_text(
         "Error occurredthe user rejected the wallet connection"
     )
 


### PR DESCRIPTION
Market-sim has been updated to include a retry on submit transaction.

This PR updates e2e to use 2 runners instead of 1