### PR TITLE
feat(governance): update market proposal header with copy and open buttons

### DIFF
--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.spec.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.spec.tsx
@@ -124,7 +124,7 @@ describe('Proposal header', () => {
       screen.queryByTestId('proposal-description')
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('proposal-details')).toHaveTextContent(
-      'Market change: MarketId'
+      'Update to market ID: MarketId'
     );
   });
 

--- a/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
+++ b/apps/governance/src/routes/proposals/components/proposal-detail-header/proposal-header.tsx
@@ -1,5 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { Lozenge, VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
+import {
+  CopyWithTooltip,
+  Lozenge,
+  Tooltip,
+  VegaIcon,
+  VegaIconNames,
+} from '@vegaprotocol/ui-toolkit';
 import { shorten } from '@vegaprotocol/utils';
 import { Heading, SubHeading } from '../../../../components/heading';
 import type { ReactNode } from 'react';
@@ -12,7 +18,12 @@ import {
   useNewTransferProposalDetails,
   useSuccessorMarketProposalDetails,
 } from '@vegaprotocol/proposals';
-import { useFeatureFlags } from '@vegaprotocol/environment';
+import {
+  CONSOLE_MARKET_PAGE,
+  DApp,
+  useFeatureFlags,
+  useLinks,
+} from '@vegaprotocol/environment';
 import Routes from '../../../routes';
 import { Link } from 'react-router-dom';
 import type { VoteState } from '../vote-details/use-user-vote';
@@ -31,6 +42,8 @@ export const ProposalHeader = ({
   const featureFlags = useFeatureFlags((state) => state.flags);
   const { t } = useTranslation();
   const change = proposal?.terms.change;
+
+  const consoleLink = useLinks(DApp.Console);
 
   let details: ReactNode;
   let proposalType = '';
@@ -106,8 +119,33 @@ export const ProposalHeader = ({
       fallbackTitle = t('UpdateMarketProposal');
       details = (
         <>
-          <span>{t('MarketChange')}:</span>{' '}
-          <span>{truncateMiddle(change.marketId)}</span>
+          <span>{t('UpdateToMarket')}:</span>{' '}
+          <span className="inline-flex items-start gap-2">
+            <span className="break-all">{change.marketId} </span>
+            <span className="inline-flex items-end gap-0">
+              <CopyWithTooltip
+                text={change.marketId}
+                description={t('copyToClipboard')}
+              >
+                <button className="inline-block px-1">
+                  <VegaIcon size={20} name={VegaIconNames.COPY} />
+                </button>
+              </CopyWithTooltip>
+              <Tooltip description={t('OpenInConsole')} align="center">
+                <button
+                  className="inline-block px-1"
+                  onClick={() => {
+                    const marketPageLink = consoleLink(
+                      CONSOLE_MARKET_PAGE.replace(':marketId', change.marketId)
+                    );
+                    window.open(marketPageLink, '_blank');
+                  }}
+                >
+                  <VegaIcon size={20} name={VegaIconNames.OPEN_EXTERNAL} />
+                </button>
+              </Tooltip>
+            </span>
+          </span>
         </>
       );
       break;

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -131,6 +131,7 @@ export const useEtherscanLink = () => {
 export const CONSOLE_TRANSFER = '#/portfolio/assets/transfer';
 export const CONSOLE_TRANSFER_ASSET =
   '#/portfolio/assets/transfer?assetId=:assetId';
+export const CONSOLE_MARKET_PAGE = '#/markets/:marketId';
 
 // Governance pages
 export const TOKEN_NEW_MARKET_PROPOSAL = '/proposals/propose/new-market';

--- a/libs/i18n/src/locales/en/governance.json
+++ b/libs/i18n/src/locales/en/governance.json
@@ -799,6 +799,8 @@
   "unsupportedVersion": "Looks like you're running an outdated version of GoWallet. You're running {{version}} but {{requiredVersion}} is required.",
   "UpdateAsset": "Update asset",
   "UpdateAssetProposal": "Update asset proposal",
+  "UpdateToMarket": "Update to market ID",
+  "OpenInConsole": "Open in Console",
   "UpdateMarket": "Update market",
   "UpdateMarketProposal": "Update market proposal",
   "UpdateMarketState": "Update market state",


### PR DESCRIPTION
# Related issues 🔗

Closes #5528 

# Description ℹ️

* changes "Market change" to "Update to market ID: .... "
* adds copy to clipboard button
* adds "Open in Console" button

# Demo 📺

https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/55a67af6-b95b-4ec5-ad1a-0b5c894e5d16


# Technical 👨‍🔧

N/A
