### PR TITLE
fix(governance): handle an expected error

### DIFF
--- a/apps/governance/src/lib/party.test.ts
+++ b/apps/governance/src/lib/party.test.ts
@@ -1,0 +1,112 @@
+import type { ApolloError } from '@apollo/client';
+import {
+  PARTY_NOT_FOUND,
+  filterAcceptableGraphqlErrors,
+  isPartyNotFoundError,
+} from './party';
+import type { GraphQLError } from 'graphql';
+
+/**
+ *
+ * @param message
+ * @returns GraphQLError
+ */
+function createMockApolloErrors(message: string): GraphQLError {
+  return {
+    message,
+    extensions: {
+      code: message.toUpperCase().replace(/ /g, '_'),
+    },
+    locations: [],
+    originalError: new Error(message),
+    path: [],
+    nodes: [],
+    positions: [1],
+    name: message,
+    source: {
+      body: message,
+      name: message,
+      locationOffset: {
+        line: 1,
+        column: 1,
+      },
+    },
+  };
+}
+
+describe('filterAcceptableGraphqlErrors', () => {
+  it('should return undefined if the error is a party not found error', () => {
+    const error: Partial<ApolloError> = {
+      graphQLErrors: [createMockApolloErrors('failed to get party for ID')],
+    };
+
+    const result = filterAcceptableGraphqlErrors(error as ApolloError);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the error if it is not a party not found error', () => {
+    const error: Partial<ApolloError> = {
+      graphQLErrors: [createMockApolloErrors('Some other error')],
+    };
+
+    const result = filterAcceptableGraphqlErrors(error as ApolloError);
+
+    expect(result).toEqual(error);
+  });
+
+  it('should return the error if there are multiple errors', () => {
+    const error: Partial<ApolloError> = {
+      graphQLErrors: [
+        createMockApolloErrors('failed to get party for ID'),
+        createMockApolloErrors('Some other error'),
+      ],
+    };
+
+    const result = filterAcceptableGraphqlErrors(error as ApolloError);
+
+    expect(result).toEqual(error);
+  });
+
+  it('should return the error if there are no errors', () => {
+    const error: Partial<ApolloError> = {
+      graphQLErrors: [],
+    };
+
+    const result = filterAcceptableGraphqlErrors(error as ApolloError);
+
+    expect(result).toEqual(error);
+  });
+
+  it('should return undefined if the error is undefined', () => {
+    const result = filterAcceptableGraphqlErrors(undefined);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('isPartyNotFoundError', () => {
+  it('should return true if the error message includes PARTY_NOT_FOUND', () => {
+    const error = { message: 'failed to get party for ID' };
+
+    const result = isPartyNotFoundError(error);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false if the error message does not include PARTY_NOT_FOUND', () => {
+    const error = { message: 'Some other error' };
+
+    const result = isPartyNotFoundError(error);
+
+    expect(result).toBe(false);
+  });
+
+  // Will trip if the error message changes, which should not be a problem, but there
+  // might be logic that depends on it
+  it('expects party not found error to remain consistent', () => {
+    const error = 'failed to get party for ID';
+
+    expect(PARTY_NOT_FOUND).toStrictEqual(error);
+  });
+});

--- a/apps/governance/src/lib/party.ts
+++ b/apps/governance/src/lib/party.ts
@@ -1,3 +1,5 @@
+import type { ApolloError } from '@apollo/client';
+
 export const PARTY_NOT_FOUND = 'failed to get party for ID';
 
 export const isPartyNotFoundError = (error: { message: string }) => {
@@ -6,3 +8,23 @@ export const isPartyNotFoundError = (error: { message: string }) => {
   }
   return false;
 };
+
+/**
+ * If a party has no accounts or data, then this GraphQL query believes it does not exist
+ * Not having any rewards is a valid state, so in some cases we can filter this error out.
+ *
+ * @param error ApolloError | undefined
+ * @returns ApolloError | undefined
+ */
+export function filterAcceptableGraphqlErrors(
+  error?: ApolloError
+): ApolloError | undefined {
+  // Currently the only error we expect is when a party has no accounts
+  if (error && error.graphQLErrors.length === 1) {
+    if (isPartyNotFoundError(error.graphQLErrors[0])) {
+      return;
+    }
+  }
+
+  return error;
+}

--- a/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.tsx
+++ b/apps/governance/src/routes/proposals/components/vote-details/vote-buttons.tsx
@@ -18,6 +18,7 @@ import { ProposalMinRequirements, ProposalUserAction } from '../shared';
 import { VoteTransactionDialog } from './vote-transaction-dialog';
 import { useVoteButtonsQuery } from './__generated__/Stake';
 import type { DialogProps, VegaTxState } from '@vegaprotocol/proposals';
+import { filterAcceptableGraphqlErrors } from '../../../../lib/party';
 
 interface VoteButtonsContainerProps {
   voteState: VoteState | null;
@@ -42,8 +43,10 @@ export const VoteButtonsContainer = (props: VoteButtonsContainerProps) => {
     skip: !pubKey,
   });
 
+  const filteredErrors = filterAcceptableGraphqlErrors(error);
+
   return (
-    <AsyncRenderer loading={loading} error={error} data={data}>
+    <AsyncRenderer loading={loading} error={filteredErrors} data={data}>
       <VoteButtons
         {...props}
         currentStakeAvailable={toBigNum(

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards.tsx
@@ -10,7 +10,7 @@ import { EpochIndividualRewardsTable } from './epoch-individual-rewards-table';
 import { generateEpochIndividualRewardsList } from './generate-epoch-individual-rewards-list';
 import { calculateEpochOffset } from '../../../lib/epoch-pagination';
 import { useNetworkParam } from '@vegaprotocol/network-parameters';
-import { type ApolloError } from '@apollo/client';
+import { filterAcceptableGraphqlErrors } from '../../../lib/party';
 
 const EPOCHS_PAGE_SIZE = 10;
 
@@ -101,7 +101,7 @@ export const EpochIndividualRewards = ({
   }, [epochId, refetchData]);
 
   // Workarounds for the error handling of AsyncRenderer
-  const filteredErrors = filterExpectedErrors(error);
+  const filteredErrors = filterAcceptableGraphqlErrors(error);
   const filteredData = data || [];
 
   return (
@@ -144,23 +144,3 @@ export const EpochIndividualRewards = ({
     />
   );
 };
-
-/**
- * If a party has no accounts or data, then this GraphQL query believes it does not exist
- * Not having any rewards is a valid state, so we filter this error out.
- *
- * @param error ApolloError | undefined
- * @returns ApolloError | undefined
- */
-export function filterExpectedErrors(
-  error?: ApolloError
-): ApolloError | undefined {
-  // Currently the only error we expect is when a party has no accounts
-  if (error && error.graphQLErrors.length === 1) {
-    if (error.graphQLErrors[0].message === 'failed to get party for ID') {
-      return;
-    }
-  }
-
-  return error;
-}


### PR DESCRIPTION
# Related issues 🔗

Closes #5634

Also closes a similar issue with Voting - if a user had no accoutns and went to a single proposal, they would see an error rather than a suggestion to connect a wallet.

# Description ℹ️
If a party has never deposited or traded, they have no accounts and the `parties` API will return an error that the party
does not exit. This was handled poorly, and rendered a 'party does not exist' error instead of simply 'the key you are
looking at does not have any rewards'. This PR filters out the Party Does Not Exist error so that the view renders more
usefully for the user.

# Demo 📺

<img width="1346" alt="Screenshot 2024-01-23 at 14 33 20" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/ee3bf8d2-b319-4bd1-8dda-d9f661df9e1b">
