### PR TITLE
fix(trading): vega wallet dialog typo full featured link translation

### DIFF
--- a/libs/i18n/src/locales/en/wallet.json
+++ b/libs/i18n/src/locales/en/wallet.json
@@ -53,7 +53,7 @@
   "Use the Desktop App/CLI": "Use the Desktop App/CLI",
   "User rejected": "User rejected",
   "Vega browser extension not installed": "Vega browser extension not installed",
-  "Vega Wallet <0>full featured<0>": "Vega Wallet <0>full featured<0>",
+  "Vega Wallet <0>full featured</0>": "Vega Wallet <0>full featured</0>",
   "Verifying chain": "Verifying chain",
   "View as party": "View as party",
   "VIEW AS VEGA USER": "VIEW AS VEGA USER",

--- a/libs/wallet/src/connect-dialog/connect-dialog.tsx
+++ b/libs/wallet/src/connect-dialog/connect-dialog.tsx
@@ -268,7 +268,7 @@ const ConnectorList = ({
             onClick={() => onSelect('injected')}
             title={
               <Trans
-                defaults="Vega Wallet <0>full featured<0>"
+                defaults="Vega Wallet <0>full featured</0>"
                 components={[<span className="text-xs">full featured</span>]}
               />
             }
@@ -281,7 +281,7 @@ const ConnectorList = ({
           <div>
             <h1 className="mb-1 text-lg">
               <Trans
-                defaults="Vega Wallet <0>full featured<0>"
+                defaults="Vega Wallet <0>full featured</0>"
                 components={[<span className="text-xs">full featured</span>]}
               />
             </h1>


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

Translation typo `<0> </0>`

# Demo 📺

Fixes 
<img width="875" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/2de1b3aa-e1b2-4c2a-ab1a-3e09f85ee28b">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
