### PR TITLE
fix(trading): adjust full screen for mobile dialogs

### DIFF
--- a/libs/accounts/src/lib/breakdown-table.tsx
+++ b/libs/accounts/src/lib/breakdown-table.tsx
@@ -38,7 +38,7 @@ const BreakdownTable = forwardRef<AgGridReact, BreakdownTableProps>(
         {
           headerName: t('Market'),
           field: 'market.tradableInstrument.instrument.code',
-          width: 90,
+          maxWidth: 150,
           pinned: true,
           sort: 'desc',
           cellRenderer: ({

--- a/libs/ui-toolkit/src/components/dialog/dialog.tsx
+++ b/libs/ui-toolkit/src/components/dialog/dialog.tsx
@@ -38,14 +38,14 @@ export function Dialog({
   );
   const wrapperClasses = classNames(
     // Dimensions
-    'max-w-[90vw] p-4 md:p-8',
+    'w-screen sm:max-w-[90vw] p-4 md:p-8',
     // Need to apply background and text colors again as content is rendered in a portal
     'dark:bg-black bg-white dark:text-white',
     getIntentBorder(intent),
     {
-      'w-[520px]': size === 'small',
-      'w-[680px]': size === 'medium',
-      'w-[720px] lg:w-[940px]': size === 'large',
+      'sm:w-[520px]': size === 'small',
+      'sm:w-[680px]': size === 'medium',
+      'sm:w-[720px] lg:w-[940px]': size === 'large',
     }
   );
 


### PR DESCRIPTION
# Related issues 🔗

Closes #5665 

# Description ℹ️

* fix breakdown collateral popup by adjusting one column and 
* make dialogs take full screen width when on mobile

# Demo 📺
<img width="415" alt="Screenshot 2024-01-24 at 17 16 18" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/fc172599-9597-4c7a-97d5-459d5a76f3d7">

<img width="554" alt="Screenshot 2024-01-24 at 17 16 11" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/d12a5897-d594-420e-ac6a-8dfcf06ada0f">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
