### PR TITLE
fix(candles-chart): ignore candles from before market open date

### DIFF
--- a/libs/candles-chart/src/lib/Candles.graphql
+++ b/libs/candles-chart/src/lib/Candles.graphql
@@ -20,6 +20,9 @@ query Candles($marketId: ID!, $interval: Interval!, $since: String!) {
         code
       }
     }
+    marketTimestamps {
+      open
+    }
     candlesConnection(
       interval: $interval
       since: $since

--- a/libs/candles-chart/src/lib/__generated__/Candles.ts
+++ b/libs/candles-chart/src/lib/__generated__/Candles.ts
@@ -12,7 +12,7 @@ export type CandlesQueryVariables = Types.Exact<{
 }>;
 
 
-export type CandlesQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, positionDecimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', id: string, name: string, code: string } }, candlesConnection?: { __typename?: 'CandleDataConnection', edges?: Array<{ __typename?: 'CandleEdge', node: { __typename?: 'Candle', periodStart: any, lastUpdateInPeriod: any, high: string, low: string, open: string, close: string, volume: string } } | null> | null } | null } | null };
+export type CandlesQuery = { __typename?: 'Query', market?: { __typename?: 'Market', id: string, decimalPlaces: number, positionDecimalPlaces: number, tradableInstrument: { __typename?: 'TradableInstrument', instrument: { __typename?: 'Instrument', id: string, name: string, code: string } }, marketTimestamps: { __typename?: 'MarketTimestamps', open: any }, candlesConnection?: { __typename?: 'CandleDataConnection', edges?: Array<{ __typename?: 'CandleEdge', node: { __typename?: 'Candle', periodStart: any, lastUpdateInPeriod: any, high: string, low: string, open: string, close: string, volume: string } } | null> | null } | null } | null };
 
 export type CandlesEventsSubscriptionVariables = Types.Exact<{
   marketId: Types.Scalars['ID'];
@@ -45,6 +45,9 @@ export const CandlesDocument = gql`
         name
         code
       }
+    }
+    marketTimestamps {
+      open
     }
     candlesConnection(interval: $interval, since: $since, pagination: {last: 5000}) {
       edges {

--- a/libs/candles-chart/src/lib/candles.mock.ts
+++ b/libs/candles-chart/src/lib/candles.mock.ts
@@ -15,6 +15,10 @@ export const candlesQuery = (
       id: 'market-0',
       decimalPlaces: 5,
       positionDecimalPlaces: 0,
+      marketTimestamps: {
+        __typename: 'MarketTimestamps',
+        open: '2022-04-06T09:15:00Z',
+      },
       tradableInstrument: {
         instrument: {
           id: '',

--- a/libs/candles-chart/src/lib/data-source.spec.ts
+++ b/libs/candles-chart/src/lib/data-source.spec.ts
@@ -13,6 +13,9 @@ const returnDataMocks = (nodes: CandleFieldsFragment[]): CandlesQuery => {
       market: {
         decimalPlaces: 1,
         positionDecimalPlaces: 1,
+        marketTimestamps: {
+          open: '2022-05-10T11:00:00Z',
+        },
         candlesConnection: {
           edges: nodes.map((node) => ({ node })),
         },

--- a/libs/candles-chart/src/lib/data-source.ts
+++ b/libs/candles-chart/src/lib/data-source.ts
@@ -172,11 +172,19 @@ export class VegaDataSource implements DataSource {
         },
         fetchPolicy: 'no-cache',
       });
+
       if (data?.market?.candlesConnection?.edges) {
         const decimalPlaces = data.market.decimalPlaces;
         const positionDecimalPlaces = data.market.positionDecimalPlaces;
 
-        const openSince = new Date(data.market.marketTimestamps.open);
+        const openSince =
+          typeof data.market.marketTimestamps.open === 'string' &&
+          data.market.marketTimestamps.open.length > 0
+            ? new Date(data.market.marketTimestamps.open)
+            : // this should never happen, but just in case let's have it as
+              // Date(0) if the market data is incomplete for some reason
+              new Date(0);
+
         if (this.from < openSince) {
           // overwrite `from` if requested value is before the market's open date
           this.from = openSince;


### PR DESCRIPTION
# Related issues 🔗

Closes #5675

# Description ℹ️

* `VegaDataSource` ignores candles from before market open date
* it also ignores empty candles which may be returned by `candlesConnection` api

# Demo 📺

SEE BEFORE FIX in the 🎫 #5675
AFTER FIX:
<img width="1042" alt="Screenshot 2024-01-26 at 14 57 56" src="https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/c23428f0-db98-4102-8e17-f30f4d5efaec">


# Technical 👨‍🔧

N/A
