### PR TITLE
fix(trading): market id use text-xs in key details

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -246,7 +246,7 @@ export const KeyDetailsInfoPanel = ({
   return (
     <>
       <KeyValueTable>
-        <KeyValueTableRow noBorder>
+        <KeyValueTableRow noBorder className="text-xs">
           <div>{t('Market ID')}</div>
           <CopyWithTooltip text={market.id}>
             <button


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

Fixes text-xs on market id in key details

# Demo 📺
Fixes this: 
![Screenshot 2024-01-29 at 13 21 37](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/418c7b88-83fc-46b8-a02b-c1abcb0e534d)

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
