### PR TITLE
fix(trading): game cards are not showing

### DIFF
--- a/apps/trading/lib/hooks/use-games.ts
+++ b/apps/trading/lib/hooks/use-games.ts
@@ -1,12 +1,23 @@
 import compact from 'lodash/compact';
 import { useActiveRewardsQuery } from '../../components/rewards-container/__generated__/Rewards';
 import { isActiveReward } from '../../components/rewards-container/active-rewards';
-import { EntityScope, type TransferNode } from '@vegaprotocol/types';
+import {
+  EntityScope,
+  IndividualScope,
+  type TransferNode,
+} from '@vegaprotocol/types';
 
 const isScopedToTeams = (node: TransferNode) =>
   node.transfer.kind.__typename === 'RecurringTransfer' &&
-  node.transfer.kind.dispatchStrategy?.entityScope ===
-    EntityScope.ENTITY_SCOPE_TEAMS;
+  // scoped to teams
+  (node.transfer.kind.dispatchStrategy?.entityScope ===
+    EntityScope.ENTITY_SCOPE_TEAMS ||
+    // or to individuals
+    (node.transfer.kind.dispatchStrategy?.entityScope ===
+      EntityScope.ENTITY_SCOPE_INDIVIDUALS &&
+      // but they have to be in a team
+      node.transfer.kind.dispatchStrategy.individualScope ===
+        IndividualScope.INDIVIDUAL_SCOPE_IN_TEAM));
 
 export const useGames = ({
   currentEpoch,


### PR DESCRIPTION
# Related issues 🔗

Closes #5708 

# Description ℹ️

This PR enables the game cards on the competition home page.

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/efffc5b8-706e-438b-8edb-ed2b6c65cd36)

# Technical 👨‍🔧

Games are not only the transfers scoped to teams but also scoped to individuals but in a team.
