### PR TITLE
feat(trading): show total value of the volume traded in last 24hrs

### DIFF
--- a/apps/trading/client-pages/market/market-header-stats.tsx
+++ b/apps/trading/client-pages/market/market-header-stats.tsx
@@ -19,6 +19,7 @@ import {
   useFundingRate,
   useMarketTradingMode,
   useExternalTwap,
+  getQuoteName,
 } from '@vegaprotocol/markets';
 import { MarketState as State } from '@vegaprotocol/types';
 import { HeaderStat } from '../../components/header';
@@ -41,6 +42,7 @@ export const MarketHeaderStats = ({ market }: MarketHeaderStatsProps) => {
   const { open: openAssetDetailsDialog } = useAssetDetailsDialogStore();
 
   const asset = getAsset(market);
+  const quoteUnit = getQuoteName(market);
 
   return (
     <>
@@ -60,6 +62,8 @@ export const MarketHeaderStats = ({ market }: MarketHeaderStatsProps) => {
         <Last24hVolume
           marketId={market.id}
           positionDecimalPlaces={market.positionDecimalPlaces}
+          marketDecimals={market.decimalPlaces}
+          quoteUnit={quoteUnit}
         />
       </HeaderStat>
       <HeaderStatMarketTradingMode

--- a/apps/trading/client-pages/markets/market-list-table.tsx
+++ b/apps/trading/client-pages/markets/market-list-table.tsx
@@ -5,7 +5,7 @@ import {
   useDataGridEvents,
 } from '@vegaprotocol/datagrid';
 import type { MarketMaybeWithData } from '@vegaprotocol/markets';
-import { useColumnDefs } from './use-column-defs';
+import { useMarketsColumnDefs } from './use-column-defs';
 import type { DataGridStore } from '../../stores/datagrid-store-slice';
 import { type StateCreator, create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -50,7 +50,7 @@ export const useMarketsStore = create<DataGridSlice>()(
 );
 
 export const MarketListTable = (props: Props) => {
-  const columnDefs = useColumnDefs();
+  const columnDefs = useMarketsColumnDefs();
   const gridStore = useMarketsStore((store) => store.gridStore);
   const updateGridStore = useMarketsStore((store) => store.updateGridStore);
 

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -7,21 +7,31 @@ import type {
 } from '@vegaprotocol/datagrid';
 import { COL_DEFS, SetFilter } from '@vegaprotocol/datagrid';
 import * as Schema from '@vegaprotocol/types';
-import { addDecimalsFormatNumber, toBigNum } from '@vegaprotocol/utils';
+import {
+  addDecimalsFormatNumber,
+  formatNumber,
+  toBigNum,
+} from '@vegaprotocol/utils';
 import { ButtonLink, Tooltip } from '@vegaprotocol/ui-toolkit';
 import { useAssetDetailsDialogStore } from '@vegaprotocol/assets';
 import type {
+  MarketFieldsFragment,
   MarketMaybeWithData,
   MarketMaybeWithDataAndCandles,
 } from '@vegaprotocol/markets';
 import { MarketActionsDropdown } from './market-table-actions';
-import { calcCandleVolume, getAsset } from '@vegaprotocol/markets';
+import {
+  calcCandleVolume,
+  calcCandleVolumePrice,
+  getAsset,
+  getQuoteName,
+} from '@vegaprotocol/markets';
 import { MarketCodeCell } from './market-code-cell';
 import { useT } from '../../lib/use-t';
 
 const { MarketTradingMode, AuctionTrigger } = Schema;
 
-export const useColumnDefs = () => {
+export const useMarketsColumnDefs = () => {
   const t = useT();
   const { open: openAssetDetailsDialog } = useAssetDetailsDialogStore();
   return useMemo<ColDef[]>(
@@ -158,11 +168,25 @@ export const useColumnDefs = () => {
         }: ValueFormatterParams<MarketMaybeWithDataAndCandles, 'candles'>) => {
           const candles = data?.candles;
           const vol = candles ? calcCandleVolume(candles) : '0';
+          const quoteName = getQuoteName(data as MarketFieldsFragment);
+          const volPrice =
+            candles &&
+            calcCandleVolumePrice(
+              candles,
+              data.decimalPlaces,
+              data.positionDecimalPlaces
+            );
+
           const volume =
             data && vol && vol !== '0'
               ? addDecimalsFormatNumber(vol, data.positionDecimalPlaces)
               : '0.00';
-          return volume;
+          const volumePrice =
+            volPrice && formatNumber(volPrice, data?.decimalPlaces);
+
+          return volumePrice
+            ? `${volume} (${volumePrice} ${quoteName})`
+            : volume;
         },
       },
       {

--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -155,6 +155,7 @@ export const MarketVolumeInfoPanel = ({ market }: MarketInfoProps) => {
           <Last24hVolume
             marketId={market.id}
             positionDecimalPlaces={market.positionDecimalPlaces}
+            marketDecimals={market.decimalPlaces}
           />
         ),
         openInterest: dash(data?.openInterest),

--- a/libs/markets/src/lib/market-utils.spec.tsx
+++ b/libs/markets/src/lib/market-utils.spec.tsx
@@ -1,6 +1,7 @@
 import * as Schema from '@vegaprotocol/types';
 import type { Market, MarketMaybeWithDataAndCandles } from './markets-provider';
 import {
+  calcCandleVolumePrice,
   calcTradedFactor,
   filterAndSortMarkets,
   sumFeesFactors,
@@ -143,5 +144,33 @@ describe('sumFeesFactors', () => {
         liquidityFee: '0.3',
       })
     ).toEqual(0.6);
+  });
+});
+
+describe('calcCandleVolumePrice', () => {
+  it('calculates the volume price', () => {
+    const candles = [
+      {
+        volume: '1000',
+        high: '100',
+        low: '10',
+        open: '15',
+        close: '90',
+        periodStart: '2022-05-18T13:08:27.693537312Z',
+      },
+      {
+        volume: '1000',
+        high: '100',
+        low: '10',
+        open: '15',
+        close: '90',
+        periodStart: '2022-05-18T14:08:27.693537312Z',
+      },
+    ];
+    const marketDecimals = 3;
+    const positionDecimalPlaces = 2;
+    expect(
+      calcCandleVolumePrice(candles, marketDecimals, positionDecimalPlaces)
+    ).toEqual('2');
   });
 });

--- a/libs/markets/src/lib/market-utils.ts
+++ b/libs/markets/src/lib/market-utils.ts
@@ -1,4 +1,8 @@
-import { formatNumberPercentage, toBigNum } from '@vegaprotocol/utils';
+import {
+  addDecimal,
+  formatNumberPercentage,
+  toBigNum,
+} from '@vegaprotocol/utils';
 import { MarketState, MarketTradingMode } from '@vegaprotocol/types';
 import BigNumber from 'bignumber.js';
 import orderBy from 'lodash/orderBy';
@@ -147,10 +151,51 @@ export const calcCandleHigh = (candles: Candle[]): string | undefined => {
     .toString();
 };
 
+/**
+ * The total number of contracts traded in the last 24 hours.
+ *
+ * @param candles
+ * @returns the volume of a given set of candles
+ */
 export const calcCandleVolume = (candles: Candle[]): string | undefined =>
   candles &&
   candles.reduce((acc, c) => new BigNumber(acc).plus(c.volume).toString(), '0');
 
+/**
+ * The total number of contracts traded in the last 24 hours. (Total value of contracts traded in the last 24 hours)
+ * The volume is calculated as the sum of the product of the volume and the high price of each candle.
+ * The result is formatted using positionDecimalPlaces to account for the position size.
+ * The result is formatted using marketDecimals to account for the market precision.
+ *
+ * @param candles
+ * @param marketDecimals
+ * @param positionDecimalPlaces
+ * @returns the volume (in quote price) of a given set of candles
+ */
+export const calcCandleVolumePrice = (
+  candles: Candle[],
+  marketDecimals: number = 1,
+  positionDecimalPlaces: number = 1
+): string | undefined =>
+  candles &&
+  candles.reduce(
+    (acc, c) =>
+      new BigNumber(acc)
+        .plus(
+          BigNumber(addDecimal(c.volume, positionDecimalPlaces)).times(
+            addDecimal(c.high, marketDecimals)
+          )
+        )
+        .toString(),
+    '0'
+  );
+
+/**
+ * Calculates the traded factor of a given market.
+ *
+ * @param m
+ * @returns
+ */
 export const calcTradedFactor = (m: MarketMaybeWithDataAndCandles) => {
   const volume = Number(calcCandleVolume(m.candles || []) || 0);
   const price = m.data?.markPrice ? Number(m.data.markPrice) : 0;


### PR DESCRIPTION
# Related issues 🔗

Closes #3982 

# Description ℹ️

Show total value of the volume traded in last 24hrs

# Demo 📺

<img width="1680" alt="Screenshot 2024-02-06 at 21 13 06" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/10f3b0a6-560d-44f5-9318-727df676ae2b">
<img width="1175" alt="Screenshot 2024-02-06 at 21 30 49" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/e0cf696a-5e4f-4e0e-86e3-d1be64c14371">
<img width="1677" alt="Screenshot 2024-02-06 at 21 50 56" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/54cbbf3d-24b6-46c6-a8e8-f5d2651d74cb">



# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
