### PR TITLE
feat(explorer): transfer status and games overview

### DIFF
--- a/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
@@ -64,7 +64,9 @@ export const ProposalSummary = ({
   return (
     <div className="w-auto max-w-lg border-2 border-solid border-vega-light-100 dark:border-vega-dark-200 p-5">
       {id && <ProposalStatusIcon id={id} />}
-      {rationale?.title && <h1 className="text-xl pb-1">{rationale.title}</h1>}
+      {rationale?.title && (
+        <h1 className="text-xl pb-1 break-all">{rationale.title}</h1>
+      )}
       {rationale?.description && (
         <div className="pt-2 text-sm leading-tight">
           <ReactMarkdown

--- a/apps/explorer/src/app/components/txs/details/transfer/Transfer.graphql
+++ b/apps/explorer/src/app/components/txs/details/transfer/Transfer.graphql
@@ -1,16 +1,18 @@
-query ExplorerTransferVote($id: ID!) {
+query ExplorerTransferStatus($id: ID!) {
   transfer(id: $id) {
-    reference
-    timestamp
-    status
-    reason
-    fromAccountType
-    from
-    to
-    toAccountType
-    asset {
-      id
+    transfer {
+      reference
+      timestamp
+      status
+      reason
+      fromAccountType
+      from
+      to
+      toAccountType
+      asset {
+        id
+      }
+      amount
     }
-    amount
   }
 }

--- a/apps/explorer/src/app/components/txs/details/transfer/Transfer.graphql
+++ b/apps/explorer/src/app/components/txs/details/transfer/Transfer.graphql
@@ -1,0 +1,16 @@
+query ExplorerTransferVote($id: ID!) {
+  transfer(id: $id) {
+    reference
+    timestamp
+    status
+    reason
+    fromAccountType
+    from
+    to
+    toAccountType
+    asset {
+      id
+    }
+    amount
+  }
+}

--- a/apps/explorer/src/app/components/txs/details/transfer/__generated__/Transfer.ts
+++ b/apps/explorer/src/app/components/txs/details/transfer/__generated__/Transfer.ts
@@ -1,0 +1,59 @@
+import * as Types from '@vegaprotocol/types';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type ExplorerTransferVoteQueryVariables = Types.Exact<{
+  id: Types.Scalars['ID'];
+}>;
+
+
+export type ExplorerTransferVoteQuery = { __typename?: 'Query', transfer?: { __typename?: 'Transfer', reference?: string | null, timestamp: any, status: Types.TransferStatus, reason?: string | null, fromAccountType: Types.AccountType, from: string, to: string, toAccountType: Types.AccountType, amount: string, asset?: { __typename?: 'Asset', id: string } | null } | null };
+
+
+export const ExplorerTransferVoteDocument = gql`
+    query ExplorerTransferVote($id: ID!) {
+  transfer(id: $id) {
+    reference
+    timestamp
+    status
+    reason
+    fromAccountType
+    from
+    to
+    toAccountType
+    asset {
+      id
+    }
+    amount
+  }
+}
+    `;
+
+/**
+ * __useExplorerTransferVoteQuery__
+ *
+ * To run a query within a React component, call `useExplorerTransferVoteQuery` and pass it any options that fit your needs.
+ * When your component renders, `useExplorerTransferVoteQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useExplorerTransferVoteQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useExplorerTransferVoteQuery(baseOptions: Apollo.QueryHookOptions<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>(ExplorerTransferVoteDocument, options);
+      }
+export function useExplorerTransferVoteLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>(ExplorerTransferVoteDocument, options);
+        }
+export type ExplorerTransferVoteQueryHookResult = ReturnType<typeof useExplorerTransferVoteQuery>;
+export type ExplorerTransferVoteLazyQueryHookResult = ReturnType<typeof useExplorerTransferVoteLazyQuery>;
+export type ExplorerTransferVoteQueryResult = Apollo.QueryResult<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>;

--- a/apps/explorer/src/app/components/txs/details/transfer/__generated__/Transfer.ts
+++ b/apps/explorer/src/app/components/txs/details/transfer/__generated__/Transfer.ts
@@ -3,57 +3,59 @@ import * as Types from '@vegaprotocol/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ExplorerTransferVoteQueryVariables = Types.Exact<{
+export type ExplorerTransferStatusQueryVariables = Types.Exact<{
   id: Types.Scalars['ID'];
 }>;
 
 
-export type ExplorerTransferVoteQuery = { __typename?: 'Query', transfer?: { __typename?: 'Transfer', reference?: string | null, timestamp: any, status: Types.TransferStatus, reason?: string | null, fromAccountType: Types.AccountType, from: string, to: string, toAccountType: Types.AccountType, amount: string, asset?: { __typename?: 'Asset', id: string } | null } | null };
+export type ExplorerTransferStatusQuery = { __typename?: 'Query', transfer?: { __typename?: 'TransferNode', transfer: { __typename?: 'Transfer', reference?: string | null, timestamp: any, status: Types.TransferStatus, reason?: string | null, fromAccountType: Types.AccountType, from: string, to: string, toAccountType: Types.AccountType, amount: string, asset?: { __typename?: 'Asset', id: string } | null } } | null };
 
 
-export const ExplorerTransferVoteDocument = gql`
-    query ExplorerTransferVote($id: ID!) {
+export const ExplorerTransferStatusDocument = gql`
+    query ExplorerTransferStatus($id: ID!) {
   transfer(id: $id) {
-    reference
-    timestamp
-    status
-    reason
-    fromAccountType
-    from
-    to
-    toAccountType
-    asset {
-      id
+    transfer {
+      reference
+      timestamp
+      status
+      reason
+      fromAccountType
+      from
+      to
+      toAccountType
+      asset {
+        id
+      }
+      amount
     }
-    amount
   }
 }
     `;
 
 /**
- * __useExplorerTransferVoteQuery__
+ * __useExplorerTransferStatusQuery__
  *
- * To run a query within a React component, call `useExplorerTransferVoteQuery` and pass it any options that fit your needs.
- * When your component renders, `useExplorerTransferVoteQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useExplorerTransferStatusQuery` and pass it any options that fit your needs.
+ * When your component renders, `useExplorerTransferStatusQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useExplorerTransferVoteQuery({
+ * const { data, loading, error } = useExplorerTransferStatusQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useExplorerTransferVoteQuery(baseOptions: Apollo.QueryHookOptions<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>) {
+export function useExplorerTransferStatusQuery(baseOptions: Apollo.QueryHookOptions<ExplorerTransferStatusQuery, ExplorerTransferStatusQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>(ExplorerTransferVoteDocument, options);
+        return Apollo.useQuery<ExplorerTransferStatusQuery, ExplorerTransferStatusQueryVariables>(ExplorerTransferStatusDocument, options);
       }
-export function useExplorerTransferVoteLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>) {
+export function useExplorerTransferStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ExplorerTransferStatusQuery, ExplorerTransferStatusQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>(ExplorerTransferVoteDocument, options);
+          return Apollo.useLazyQuery<ExplorerTransferStatusQuery, ExplorerTransferStatusQueryVariables>(ExplorerTransferStatusDocument, options);
         }
-export type ExplorerTransferVoteQueryHookResult = ReturnType<typeof useExplorerTransferVoteQuery>;
-export type ExplorerTransferVoteLazyQueryHookResult = ReturnType<typeof useExplorerTransferVoteLazyQuery>;
-export type ExplorerTransferVoteQueryResult = Apollo.QueryResult<ExplorerTransferVoteQuery, ExplorerTransferVoteQueryVariables>;
+export type ExplorerTransferStatusQueryHookResult = ReturnType<typeof useExplorerTransferStatusQuery>;
+export type ExplorerTransferStatusLazyQueryHookResult = ReturnType<typeof useExplorerTransferStatusLazyQuery>;
+export type ExplorerTransferStatusQueryResult = Apollo.QueryResult<ExplorerTransferStatusQuery, ExplorerTransferStatusQueryVariables>;

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
@@ -111,7 +111,7 @@ export function TransferParticipants({
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 16 9"
-                className="fill-vega-light-100 dark:fill-black"
+                className="fill-white dark:fill-black"
               >
                 <path d="M0,0L8,9l8,-9Z" />
               </svg>
@@ -120,7 +120,7 @@ export function TransferParticipants({
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 16 9"
-                className="fill-vega-light-100 dark:fill-vega-dark-200"
+                className="fill-vega-light-200 dark:fill-vega-dark-200"
               >
                 <path d="M0,0L8,9l8,-9Z" />
               </svg>

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -41,46 +41,57 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
     return null;
   }
 
+  // Destructure to make things a bit more readable
+  const {
+    assetForMetric,
+    entityScope,
+    individualScope,
+    teamScope,
+    distributionStrategy,
+    lockPeriod,
+    markets,
+    stakingRequirement,
+    windowLength,
+    notionalTimeWeightedAveragePositionRequirement,
+    rankTable,
+    nTopPerformers,
+  } = recurring.dispatchStrategy;
+
   return (
     <div className={wrapperClasses}>
-      <h2 className={headerClasses}>{t('Reward metrics')}</h2>
+      <h2 className={headerClasses}>{getRewardTitle(entityScope)}</h2>
       <ul className="relative block rounded-lg py-6 text-left p-6">
-        {recurring.dispatchStrategy.assetForMetric ? (
+        {assetForMetric ? (
           <li>
             <strong>{t('Asset')}</strong>:{' '}
-            <AssetLink assetId={recurring.dispatchStrategy.assetForMetric} />
+            <AssetLink assetId={assetForMetric} />
           </li>
         ) : null}
         <li>
           <strong>{t('Metric')}</strong>: {metricLabels[metric]}
         </li>
-        {recurring.dispatchStrategy.entityScope &&
-        entityScopeIcons[recurring.dispatchStrategy.entityScope] ? (
+        {entityScope && entityScopeIcons[entityScope] ? (
           <li>
             <strong>{t('Scope')}</strong>:{' '}
-            <VegaIcon
-              name={entityScopeIcons[recurring.dispatchStrategy.entityScope]}
-            />
+            <VegaIcon name={entityScopeIcons[entityScope]} />
+            {individualScope ? individualScopeLabels[individualScope] : null}
           </li>
         ) : null}
 
-        {recurring.dispatchStrategy.individualScope}
-        {recurring.dispatchStrategy.teamScope}
+        {teamScope}
+        {distributionStrategy}
 
-        {recurring.dispatchStrategy.lockPeriod &&
-        recurring.dispatchStrategy.lockPeriod !== '0' ? (
+        {lockPeriod && lockPeriod !== '0' ? (
           <li>
-            <strong>{t('Lock')}</strong>:{' '}
-            {recurring.dispatchStrategy.lockPeriod}
+            <strong>{t('Lock')}</strong>: {lockPeriod}
           </li>
         ) : null}
 
-        {recurring.dispatchStrategy.markets &&
-        recurring.dispatchStrategy.markets.length > 0 ? (
+        {markets && markets.length > 0 ? (
           <li>
             <strong>{t('Markets in scope')}</strong>:
             <ul>
-              {recurring.dispatchStrategy.markets.map((m) => (
+              {markets.map((m) => (
                 <li key={m}>
                   <MarketLink id={m} />
                 </li>
@@ -89,32 +100,52 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
           </li>
         ) : null}
 
-        {recurring.dispatchStrategy.stakingRequirement &&
-        recurring.dispatchStrategy.stakingRequirement !== '0' ? (
+        {stakingRequirement && stakingRequirement !== '0' ? (
           <li>
-            <strong>{t('Staking requirement')}</strong>:{' '}
-            {recurring.dispatchStrategy.stakingRequirement}
+            <strong>{t('Staking requirement')}</strong>: {stakingRequirement}
           </li>
         ) : null}
 
-        {recurring.dispatchStrategy.windowLength &&
-        recurring.dispatchStrategy.windowLength !== '0' ? (
+        {windowLength && windowLength !== '0' ? (
           <li>
             <strong>{t('Window length')}</strong>:{' '}
             {recurring.dispatchStrategy.windowLength}
           </li>
         ) : null}
 
-        {recurring.dispatchStrategy.rankTable &&
-        recurring.dispatchStrategy.rankTable.length > 0 ? (
+        {notionalTimeWeightedAveragePositionRequirement &&
+        notionalTimeWeightedAveragePositionRequirement !== '' ? (
           <li>
-            <strong>{t('Ranks')}</strong>:{' '}
-            {recurring.dispatchStrategy.rankTable.toString()}
+            <strong>
+              {t('notionalTimeWeightedAveragePositionRequirement')}
+            </strong>
+            : {notionalTimeWeightedAveragePositionRequirement}
+          </li>
+        ) : null}
+
+        {nTopPerformers && (
+          <li>
+            <strong>{t('Top performers')}</strong>: {nTopPerformers}
+          </li>
+        )}
+
+        {rankTable && rankTable.length > 0 ? (
+          <li>
+            <strong>{t('Ranks')}</strong>: {rankTable.toString()}
           </li>
         ) : null}
       </ul>
     </div>
   );
+}
+
+export function getRewardTitle(
+  scope?: components['schemas']['vegaEntityScope']
+) {
+  if (scope === 'ENTITY_SCOPE_TEAMS') {
+    return t('Game');
+  }
+  return t('Reward metrics');
 }
 
 interface TransferRecurringStrategyProps {
@@ -147,3 +178,14 @@ export function TransferRecurringStrategy({
     </>
   );
 }
+
+const individualScopeLabels: Record<
+  components['schemas']['vegaIndividualScope'],
+  string
+> = {
+  // Unspecified and All are not rendered
+  INDIVIDUAL_SCOPE_UNSPECIFIED: '',
+  INDIVIDUAL_SCOPE_ALL: '',
+  INDIVIDUAL_SCOPE_IN_TEAM: '(in team)',
+  INDIVIDUAL_SCOPE_NOT_IN_TEAM: '(not in team)',
+};

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -1,13 +1,20 @@
 import { t } from '@vegaprotocol/i18n';
 import { AssetLink, MarketLink } from '../../../../links';
-import { headerClasses, wrapperClasses } from '../transfer-details';
 import type { components } from '../../../../../../types/explorer';
 import type { Recurring } from '../transfer-details';
-import { DispatchMetricLabels } from '@vegaprotocol/types';
+import {
+  DispatchMetricLabels,
+  DistributionStrategy,
+} from '@vegaprotocol/types';
 import { VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 
 export type Metric = components['schemas']['vegaDispatchMetric'];
 export type Strategy = components['schemas']['vegaDispatchStrategy'];
+
+export const wrapperClasses =
+  'border border-vega-light-150 dark:border-vega-dark-200 rounded-md pv-2 mb-5 w-full sm:w-3/4 min-w-[200px] ';
+export const headerClasses =
+  'bg-solid bg-vega-light-150 dark:bg-vega-dark-150 border-vega-light-150 text-center text-xl py-2 font-alpha calt';
 
 const metricLabels: Record<Metric, string> = {
   DISPATCH_METRIC_UNSPECIFIED: 'Unknown metric',
@@ -21,6 +28,11 @@ const entityScopeIcons: Record<
 > = {
   ENTITY_SCOPE_INDIVIDUALS: VegaIconNames.MAN,
   ENTITY_SCOPE_TEAMS: VegaIconNames.TEAM,
+};
+
+const distributionStrategyLabel: Record<DistributionStrategy, string> = {
+  [DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA]: 'Pro Rata',
+  [DistributionStrategy.DISTRIBUTION_STRATEGY_RANK]: 'Ranked',
 };
 
 interface TransferRewardsProps {
@@ -79,7 +91,6 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
         ) : null}
 
         {teamScope}
-        {distributionStrategy}
 
         {lockPeriod && lockPeriod !== '0' ? (
           <li>
@@ -116,10 +127,8 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
         {notionalTimeWeightedAveragePositionRequirement &&
         notionalTimeWeightedAveragePositionRequirement !== '' ? (
           <li>
-            <strong>
-              {t('notionalTimeWeightedAveragePositionRequirement')}
-            </strong>
-            : {notionalTimeWeightedAveragePositionRequirement}
+            <strong>{t('Notional TWAP')}</strong>:{' '}
+            {notionalTimeWeightedAveragePositionRequirement}
           </li>
         ) : null}
 
@@ -128,13 +137,44 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
             <strong>{t('Top performers')}</strong>: {nTopPerformers}
           </li>
         )}
-
-        {rankTable && rankTable.length > 0 ? (
-          <li>
-            <strong>{t('Ranks')}</strong>: {rankTable.toString()}
-          </li>
-        ) : null}
+        {distributionStrategy &&
+          distributionStrategy !== 'DISTRIBUTION_STRATEGY_UNSPECIFIED' && (
+            <li>
+              <strong>{t('Distribution strategy')}</strong>:{' '}
+              {distributionStrategyLabel[distributionStrategy]}
+            </li>
+          )}
       </ul>
+      <div className="px-6 pt-1 pb-5">
+        {rankTable && rankTable.length > 0 ? (
+          <table className="border-collapse border border-slate-400 ">
+            <thead>
+              <tr>
+                <th className="border border-slate-300 bg-slate-300 px-3">
+                  <strong>{t('Start rank')}</strong>
+                </th>
+                <th className="border border-slate-300 bg-slate-300 px-3">
+                  <strong>{t('Share of reward pool')}</strong>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rankTable.map((row, i) => {
+                return (
+                  <tr>
+                    <td className="border border-slate-300 text-center">
+                      {row.startRank}
+                    </td>
+                    <td className="border border-slate-300 text-center">
+                      {row.shareRatio}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -11,10 +11,9 @@ import { VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 export type Metric = components['schemas']['vegaDispatchMetric'];
 export type Strategy = components['schemas']['vegaDispatchStrategy'];
 
-export const wrapperClasses =
-  'border border-vega-light-150 dark:border-vega-dark-200 rounded-md pv-2 mb-5 w-full sm:w-3/4 min-w-[200px] ';
+export const wrapperClasses = 'border pv-2 w-full flex-auto basis-full';
 export const headerClasses =
-  'bg-solid bg-vega-light-150 dark:bg-vega-dark-150 border-vega-light-150 text-center text-xl py-2 font-alpha calt';
+  'bg-solid bg-vega-light-150 dark:bg-vega-dark-150 text-center text-xl py-2 font-alpha calt';
 
 const metricLabels: Record<Metric, string> = {
   DISPATCH_METRIC_UNSPECIFIED: 'Unknown metric',

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -39,22 +39,17 @@ interface TransferRewardsProps {
 }
 
 /**
- * Renderer for a transfer. These can vary quite
- * widely, essentially every field can be null.
+ * Renders recurring transfers/game details in a way that is, perhaps, easy to understand
  *
  * @param transfer A recurring transfer object
  */
 export function TransferRewards({ recurring }: TransferRewardsProps) {
-  const metric =
-    recurring?.dispatchStrategy?.metric || 'DISPATCH_METRIC_UNSPECIFIED';
-
   if (!recurring || !recurring.dispatchStrategy) {
     return null;
   }
 
   // Destructure to make things a bit more readable
   const {
-    assetForMetric,
     entityScope,
     individualScope,
     teamScope,
@@ -81,20 +76,21 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
             {getScopeLabel(entityScope, teamScope)}
           </li>
         ) : null}
-        {metric && (
-          <li>
-            <strong>{t('Metric')}</strong>: {metricLabels[metric]}
-          </li>
-        )}
-
-        {assetForMetric ? (
-          <li>
-            <strong>{t('Asset')}</strong>:{' '}
-            <AssetLink assetId={assetForMetric} />
-          </li>
-        ) : null}
-
-        {lockPeriod ? (
+        {recurring.dispatchStrategy &&
+          recurring.dispatchStrategy.assetForMetric && (
+            <li>
+              <strong>{t('Asset for metric')}</strong>:{' '}
+              <AssetLink assetId={recurring.dispatchStrategy.assetForMetric} />
+            </li>
+          )}
+        {recurring.dispatchStrategy.metric &&
+          metricLabels[recurring.dispatchStrategy.metric] && (
+            <li>
+              <strong>{t('Metric')}</strong>:{' '}
+              {metricLabels[recurring.dispatchStrategy.metric]}
+            </li>
+          )}
+        {lockPeriod && (
           <li>
             <strong>{t('Reward lock')}</strong>:&nbsp;
             {recurring.dispatchStrategy.lockPeriod}{' '}
@@ -102,7 +98,7 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
               ? t('epoch')
               : t('epochs')}
           </li>
-        ) : null}
+        )}
 
         {markets && markets.length > 0 ? (
           <li>
@@ -172,7 +168,7 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
             <tbody>
               {rankTable.map((row, i) => {
                 return (
-                  <tr>
+                  <tr key={`rank-${i}`}>
                     <td className="border border-slate-300 text-center">
                       {row.startRank}
                     </td>
@@ -213,37 +209,6 @@ export function getRewardTitle(
     return t('Game');
   }
   return t('Reward metrics');
-}
-
-interface TransferRecurringStrategyProps {
-  strategy: Strategy;
-}
-
-/**
- * Simple renderer for a dispatch strategy in a recurring transfer
- *
- * @param strategy Dispatch strategy object
- */
-export function TransferRecurringStrategy({
-  strategy,
-}: TransferRecurringStrategyProps) {
-  if (!strategy) {
-    return null;
-  }
-
-  return (
-    <>
-      {strategy.assetForMetric ? (
-        <li>
-          <strong>{t('Asset for metric')}</strong>:{' '}
-          <AssetLink assetId={strategy.assetForMetric} />
-        </li>
-      ) : null}
-      <li>
-        <strong>{t('Metric')}</strong>: {strategy.metric}
-      </li>
-    </>
-  );
 }
 
 const individualScopeLabels: Record<

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -4,6 +4,7 @@ import { headerClasses, wrapperClasses } from '../transfer-details';
 import type { components } from '../../../../../../types/explorer';
 import type { Recurring } from '../transfer-details';
 import { DispatchMetricLabels } from '@vegaprotocol/types';
+import { VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
 
 export type Metric = components['schemas']['vegaDispatchMetric'];
 export type Strategy = components['schemas']['vegaDispatchStrategy'];
@@ -11,6 +12,15 @@ export type Strategy = components['schemas']['vegaDispatchStrategy'];
 const metricLabels: Record<Metric, string> = {
   DISPATCH_METRIC_UNSPECIFIED: 'Unknown metric',
   ...DispatchMetricLabels,
+};
+
+// Maps the two (non-null) values of entityScope to the icon that represents it
+const entityScopeIcons: Record<
+  string,
+  typeof VegaIconNames[keyof typeof VegaIconNames]
+> = {
+  ENTITY_SCOPE_INDIVIDUALS: VegaIconNames.MAN,
+  ENTITY_SCOPE_TEAMS: VegaIconNames.TEAM,
 };
 
 interface TransferRewardsProps {
@@ -34,7 +44,7 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
   return (
     <div className={wrapperClasses}>
       <h2 className={headerClasses}>{t('Reward metrics')}</h2>
-      <ul className="relative block rounded-lg py-6 text-center p-6">
+      <ul className="relative block rounded-lg py-6 text-left p-6">
         {recurring.dispatchStrategy.assetForMetric ? (
           <li>
             <strong>{t('Asset')}</strong>:{' '}
@@ -44,6 +54,27 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
         <li>
           <strong>{t('Metric')}</strong>: {metricLabels[metric]}
         </li>
+        {recurring.dispatchStrategy.entityScope &&
+        entityScopeIcons[recurring.dispatchStrategy.entityScope] ? (
+          <li>
+            <strong>{t('Scope')}</strong>:{' '}
+            <VegaIcon
+              name={entityScopeIcons[recurring.dispatchStrategy.entityScope]}
+            />
+          </li>
+        ) : null}
+
+        {recurring.dispatchStrategy.individualScope}
+        {recurring.dispatchStrategy.teamScope}
+
+        {recurring.dispatchStrategy.lockPeriod &&
+        recurring.dispatchStrategy.lockPeriod !== '0' ? (
+          <li>
+            <strong>{t('Lock')}</strong>:{' '}
+            {recurring.dispatchStrategy.lockPeriod}
+          </li>
+        ) : null}
+
         {recurring.dispatchStrategy.markets &&
         recurring.dispatchStrategy.markets.length > 0 ? (
           <li>
@@ -57,9 +88,30 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
             </ul>
           </li>
         ) : null}
-        <li>
-          <strong>{t('Factor')}</strong>: {recurring.factor}
-        </li>
+
+        {recurring.dispatchStrategy.stakingRequirement &&
+        recurring.dispatchStrategy.stakingRequirement !== '0' ? (
+          <li>
+            <strong>{t('Staking requirement')}</strong>:{' '}
+            {recurring.dispatchStrategy.stakingRequirement}
+          </li>
+        ) : null}
+
+        {recurring.dispatchStrategy.windowLength &&
+        recurring.dispatchStrategy.windowLength !== '0' ? (
+          <li>
+            <strong>{t('Window length')}</strong>:{' '}
+            {recurring.dispatchStrategy.windowLength}
+          </li>
+        ) : null}
+
+        {recurring.dispatchStrategy.rankTable &&
+        recurring.dispatchStrategy.rankTable.length > 0 ? (
+          <li>
+            <strong>{t('Ranks')}</strong>:{' '}
+            {recurring.dispatchStrategy.rankTable.toString()}
+          </li>
+        ) : null}
       </ul>
     </div>
   );

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -7,7 +7,7 @@ import {
   DistributionStrategy,
 } from '@vegaprotocol/types';
 import { VegaIcon, VegaIconNames } from '@vegaprotocol/ui-toolkit';
-
+import { formatNumber } from '@vegaprotocol/utils';
 export type Metric = components['schemas']['vegaDispatchMetric'];
 export type Strategy = components['schemas']['vegaDispatchStrategy'];
 
@@ -72,37 +72,44 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
     <div className={wrapperClasses}>
       <h2 className={headerClasses}>{getRewardTitle(entityScope)}</h2>
       <ul className="relative block rounded-lg py-6 text-left p-6">
+        {entityScope && entityScopeIcons[entityScope] ? (
+          <li>
+            <strong>{t('Scope')}</strong>:{' '}
+            <VegaIcon name={entityScopeIcons[entityScope]} />
+            &nbsp;
+            {individualScope ? individualScopeLabels[individualScope] : null}
+            {getScopeLabel(entityScope, teamScope)}
+          </li>
+        ) : null}
+        {metric && (
+          <li>
+            <strong>{t('Metric')}</strong>: {metricLabels[metric]}
+          </li>
+        )}
+
         {assetForMetric ? (
           <li>
             <strong>{t('Asset')}</strong>:{' '}
             <AssetLink assetId={assetForMetric} />
           </li>
         ) : null}
-        <li>
-          <strong>{t('Metric')}</strong>: {metricLabels[metric]}
-        </li>
-        {entityScope && entityScopeIcons[entityScope] ? (
-          <li>
-            <strong>{t('Scope')}</strong>:{' '}
-            <VegaIcon name={entityScopeIcons[entityScope]} />
-            {individualScope ? individualScopeLabels[individualScope] : null}
-          </li>
-        ) : null}
 
-        {teamScope}
-
-        {lockPeriod && lockPeriod !== '0' ? (
+        {lockPeriod ? (
           <li>
-            <strong>{t('Lock')}</strong>: {lockPeriod}
+            <strong>{t('Reward lock')}</strong>:&nbsp;
+            {recurring.dispatchStrategy.lockPeriod}{' '}
+            {recurring.dispatchStrategy.lockPeriod === '1'
+              ? t('epoch')
+              : t('epochs')}
           </li>
         ) : null}
 
         {markets && markets.length > 0 ? (
           <li>
             <strong>{t('Markets in scope')}</strong>:
-            <ul>
+            <ul className="inline-block ml-1">
               {markets.map((m) => (
-                <li key={m}>
+                <li key={m} className="inline-block mr-2">
                   <MarketLink id={m} />
                 </li>
               ))}
@@ -119,7 +126,10 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
         {windowLength && windowLength !== '0' ? (
           <li>
             <strong>{t('Window length')}</strong>:{' '}
-            {recurring.dispatchStrategy.windowLength}
+            {recurring.dispatchStrategy.windowLength}{' '}
+            {recurring.dispatchStrategy.windowLength === '1'
+              ? t('epoch')
+              : t('epochs')}
           </li>
         ) : null}
 
@@ -133,9 +143,11 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
 
         {nTopPerformers && (
           <li>
-            <strong>{t('Top performers')}</strong>: {nTopPerformers}
+            <strong>{t('Elligible team members:')}</strong> top{' '}
+            {`${formatNumber(Number(nTopPerformers) * 100, 0)}%`}
           </li>
         )}
+
         {distributionStrategy &&
           distributionStrategy !== 'DISTRIBUTION_STRATEGY_UNSPECIFIED' && (
             <li>
@@ -146,13 +158,13 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
       </ul>
       <div className="px-6 pt-1 pb-5">
         {rankTable && rankTable.length > 0 ? (
-          <table className="border-collapse border border-slate-400 ">
+          <table className="border-collapse border border-gray-400 ">
             <thead>
               <tr>
-                <th className="border border-slate-300 bg-slate-300 px-3">
+                <th className="border border-gray-300 bg-gray-300 px-3">
                   <strong>{t('Start rank')}</strong>
                 </th>
-                <th className="border border-slate-300 bg-slate-300 px-3">
+                <th className="border border-gray-300 bg-gray-300 px-3">
                   <strong>{t('Share of reward pool')}</strong>
                 </th>
               </tr>
@@ -178,6 +190,22 @@ export function TransferRewards({ recurring }: TransferRewardsProps) {
   );
 }
 
+export function getScopeLabel(
+  scope: components['schemas']['vegaEntityScope'] | undefined,
+  teamScope: readonly string[] | undefined
+): string {
+  if (scope === 'ENTITY_SCOPE_TEAMS') {
+    if (teamScope && teamScope.length !== 0) {
+      return ` ${teamScope.length} teams`;
+    } else {
+      return t('All teams');
+    }
+  } else if (scope === 'ENTITY_SCOPE_INDIVIDUALS') {
+    return t('Individuals');
+  } else {
+    return '';
+  }
+}
 export function getRewardTitle(
   scope?: components['schemas']['vegaEntityScope']
 ) {

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
@@ -25,7 +25,7 @@ export function TransferStatusView({ status, loading }: TransferStatusProps) {
 
   return (
     <div className={wrapperClasses}>
-      <h2 className={headerClasses}>{t('Transfer Status')}</h2>
+      <h2 className={headerClasses}>{t('Status')}</h2>
       <div className="relative block rounded-lg py-6 text-center p-6">
         {loading ? (
           <div className="leading-10 mt-12">

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
@@ -1,0 +1,40 @@
+import { t } from '@vegaprotocol/i18n';
+import { headerClasses, wrapperClasses } from '../transfer-details';
+import { Icon, Loader } from '@vegaprotocol/ui-toolkit';
+import type { ApolloError } from '@apollo/client';
+
+interface TransferStatusProps {
+  status: string;
+  error: ApolloError | undefined;
+  loading: boolean;
+}
+
+/**
+ * Renderer for a transfer. These can vary quite
+ * widely, essentially every field can be null.
+ *
+ * @param transfer A recurring transfer object
+ */
+export function TransferStatusView({ status, loading }: TransferStatusProps) {
+  if (!status) {
+    return null;
+  }
+
+  return (
+    <div className={wrapperClasses}>
+      <h2 className={headerClasses}>{t('Status')}</h2>
+      <div className="relative block rounded-lg py-6 text-center p-6">
+        {loading ? (
+          <Loader />
+        ) : (
+          <>
+            <p className="leading-10 my-2">
+              <Icon name="tick" className="text-green-500" />
+            </p>
+            <p className="leading-10 my-2">{status}</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
@@ -1,10 +1,13 @@
 import { t } from '@vegaprotocol/i18n';
 import { headerClasses, wrapperClasses } from '../transfer-details';
 import { Icon, Loader } from '@vegaprotocol/ui-toolkit';
+import type { IconName } from '@vegaprotocol/ui-toolkit';
 import type { ApolloError } from '@apollo/client';
+import { TransferStatus, TransferStatusMapping } from '@vegaprotocol/types';
+import { IconNames } from '@blueprintjs/icons';
 
 interface TransferStatusProps {
-  status: string;
+  status: TransferStatus | undefined;
   error: ApolloError | undefined;
   loading: boolean;
 }
@@ -22,19 +25,58 @@ export function TransferStatusView({ status, loading }: TransferStatusProps) {
 
   return (
     <div className={wrapperClasses}>
-      <h2 className={headerClasses}>{t('Status')}</h2>
+      <h2 className={headerClasses}>{t('Transfer Status')}</h2>
       <div className="relative block rounded-lg py-6 text-center p-6">
         {loading ? (
           <Loader />
         ) : (
           <>
             <p className="leading-10 my-2">
-              <Icon name="tick" className="text-green-500" />
+              <Icon
+                name={getIconForStatus(status)}
+                className={getColourForStatus(status)}
+              />
             </p>
-            <p className="leading-10 my-2">{status}</p>
+            <p className="leading-10 my-2">{TransferStatusMapping[status]}</p>
           </>
         )}
       </div>
     </div>
   );
+}
+
+/**
+ * Simple mapping from status to icon name
+ * @param status TransferStatus
+ * @returns IconName
+ */
+export function getIconForStatus(status: TransferStatus): IconName {
+  switch (status) {
+    case TransferStatus.STATUS_PENDING:
+      return IconNames.TIME;
+    case TransferStatus.STATUS_DONE:
+      return IconNames.TICK;
+    case TransferStatus.STATUS_REJECTED:
+      return IconNames.CROSS;
+    default:
+      return IconNames.TIME;
+  }
+}
+
+/**
+ * Simple mapping from status to colour
+ * @param status TransferStatus
+ * @returns string Tailwind classname
+ */
+export function getColourForStatus(status: TransferStatus): string {
+  switch (status) {
+    case TransferStatus.STATUS_PENDING:
+      return 'text-yellow-500';
+    case TransferStatus.STATUS_DONE:
+      return 'text-green-500';
+    case TransferStatus.STATUS_REJECTED:
+      return 'text-red-500';
+    default:
+      return 'text-yellow-500';
+  }
 }

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
@@ -20,7 +20,7 @@ interface TransferStatusProps {
  */
 export function TransferStatusView({ status, loading }: TransferStatusProps) {
   if (!status) {
-    return null;
+    status = TransferStatus.STATUS_PENDING;
   }
 
   return (
@@ -28,7 +28,9 @@ export function TransferStatusView({ status, loading }: TransferStatusProps) {
       <h2 className={headerClasses}>{t('Transfer Status')}</h2>
       <div className="relative block rounded-lg py-6 text-center p-6">
         {loading ? (
-          <Loader />
+          <div className="leading-10 mt-12">
+            <Loader size={'small'} />
+          </div>
         ) : (
           <>
             <p className="leading-10 my-2">

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
@@ -20,8 +20,6 @@ interface TransferDetailsProps {
   transfer: Transfer;
   from: string;
   id: string;
-  // If set, all blocks except the status one are hidden
-  statusOnly?: boolean;
 }
 
 /**
@@ -30,12 +28,7 @@ interface TransferDetailsProps {
  *
  * @param transfer A recurring transfer object
  */
-export function TransferDetails({
-  transfer,
-  from,
-  id,
-  statusOnly = false,
-}: TransferDetailsProps) {
+export function TransferDetails({ transfer, from, id }: TransferDetailsProps) {
   const recurring = transfer.recurring;
 
   // Currently all this is passed in to TransferStatus, but the extra details
@@ -50,17 +43,13 @@ export function TransferDetails({
 
   return (
     <div className="flex gap-5 flex-wrap">
-      {statusOnly ? null : (
-        <>
-          <TransferParticipants from={from} transfer={transfer} />
-          {recurring ? <TransferRepeat recurring={transfer.recurring} /> : null}
-          {recurring && recurring.dispatchStrategy ? (
-            <TransferRewards recurring={transfer.recurring} />
-          ) : null}
-        </>
-      )}
+      <TransferParticipants from={from} transfer={transfer} />
       {status ? (
         <TransferStatusView status={status} error={error} loading={loading} />
+      ) : null}
+      {recurring ? <TransferRepeat recurring={transfer.recurring} /> : null}
+      {recurring && recurring.dispatchStrategy ? (
+        <TransferRewards recurring={transfer.recurring} />
       ) : null}
     </div>
   );

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
@@ -2,6 +2,9 @@ import type { components } from '../../../../../types/explorer';
 import { TransferRepeat } from './blocks/transfer-repeat';
 import { TransferRewards } from './blocks/transfer-rewards';
 import { TransferParticipants } from './blocks/transfer-participants';
+import { useExplorerTransferVoteQuery } from './__generated__/Transfer';
+import { TransferStatusView } from './blocks/transfer-status';
+import { TransferStatus } from '@vegaprotocol/types';
 
 export type Recurring = components['schemas']['commandsv1RecurringTransfer'];
 export type Metric = components['schemas']['vegaDispatchMetric'];
@@ -16,6 +19,9 @@ export type Transfer = components['schemas']['commandsv1Transfer'];
 interface TransferDetailsProps {
   transfer: Transfer;
   from: string;
+  id: string;
+  // If set, all blocks except the status one are hidden
+  statusOnly?: boolean;
 }
 
 /**
@@ -24,15 +30,37 @@ interface TransferDetailsProps {
  *
  * @param transfer A recurring transfer object
  */
-export function TransferDetails({ transfer, from }: TransferDetailsProps) {
+export function TransferDetails({
+  transfer,
+  from,
+  id,
+  statusOnly = false,
+}: TransferDetailsProps) {
   const recurring = transfer.recurring;
+
+  // Currently all this is passed in to TransferStatus, but the extra details
+  // may be useful in the future.
+  const { data, error, loading } = useExplorerTransferVoteQuery({
+    variables: { id },
+  });
+
+  const status = error
+    ? TransferStatus.STATUS_REJECTED
+    : data?.transfer?.status;
 
   return (
     <div className="flex gap-5 flex-wrap">
-      <TransferParticipants from={from} transfer={transfer} />
-      {recurring ? <TransferRepeat recurring={transfer.recurring} /> : null}
-      {recurring && recurring.dispatchStrategy ? (
-        <TransferRewards recurring={transfer.recurring} />
+      {statusOnly ? null : (
+        <>
+          <TransferParticipants from={from} transfer={transfer} />
+          {recurring ? <TransferRepeat recurring={transfer.recurring} /> : null}
+          {recurring && recurring.dispatchStrategy ? (
+            <TransferRewards recurring={transfer.recurring} />
+          ) : null}
+        </>
+      )}
+      {status ? (
+        <TransferStatusView status={status} error={error} loading={loading} />
       ) : null}
     </div>
   );

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
@@ -10,7 +10,7 @@ export type Recurring = components['schemas']['commandsv1RecurringTransfer'];
 export type Metric = components['schemas']['vegaDispatchMetric'];
 
 export const wrapperClasses =
-  'border border-vega-light-150 dark:border-vega-dark-200 rounded-md pv-2 mb-5 w-full sm:w-1/4 min-w-[200px] ';
+  'border border-vega-light-150 dark:border-vega-dark-200 pv-2 w-full sm:w-1/3 basis-1/3';
 export const headerClasses =
   'bg-solid bg-vega-light-150 dark:bg-vega-dark-150 border-vega-light-150 text-center text-xl py-2 font-alpha calt';
 
@@ -42,12 +42,10 @@ export function TransferDetails({ transfer, from, id }: TransferDetailsProps) {
     : data?.transfer?.status;
 
   return (
-    <div className="flex gap-5 flex-wrap">
+    <div className="flex flex-wrap">
       <TransferParticipants from={from} transfer={transfer} />
-      {status ? (
-        <TransferStatusView status={status} error={error} loading={loading} />
-      ) : null}
       {recurring ? <TransferRepeat recurring={transfer.recurring} /> : null}
+      <TransferStatusView status={status} error={error} loading={loading} />
       {recurring && recurring.dispatchStrategy ? (
         <TransferRewards recurring={transfer.recurring} />
       ) : null}

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-details.tsx
@@ -2,7 +2,7 @@ import type { components } from '../../../../../types/explorer';
 import { TransferRepeat } from './blocks/transfer-repeat';
 import { TransferRewards } from './blocks/transfer-rewards';
 import { TransferParticipants } from './blocks/transfer-participants';
-import { useExplorerTransferVoteQuery } from './__generated__/Transfer';
+import { useExplorerTransferStatusQuery } from './__generated__/Transfer';
 import { TransferStatusView } from './blocks/transfer-status';
 import { TransferStatus } from '@vegaprotocol/types';
 
@@ -33,13 +33,13 @@ export function TransferDetails({ transfer, from, id }: TransferDetailsProps) {
 
   // Currently all this is passed in to TransferStatus, but the extra details
   // may be useful in the future.
-  const { data, error, loading } = useExplorerTransferVoteQuery({
+  const { data, error, loading } = useExplorerTransferStatusQuery({
     variables: { id },
   });
 
   const status = error
     ? TransferStatus.STATUS_REJECTED
-    : data?.transfer?.status;
+    : data?.transfer?.transfer.status;
 
   return (
     <div className="flex flex-wrap">

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-rewards.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-rewards.spec.tsx
@@ -1,0 +1,172 @@
+import {
+  getScopeLabel,
+  getRewardTitle,
+  TransferRewards,
+} from './blocks/transfer-rewards';
+import { render } from '@testing-library/react';
+import type { components } from '../../../../../types/explorer';
+import type { Recurring } from './transfer-details';
+import {
+  DispatchMetric,
+  DistributionStrategy,
+  EntityScope,
+  IndividualScope,
+} from '@vegaprotocol/types';
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+
+describe('getScopeLabel', () => {
+  it('should return the correct label for ENTITY_SCOPE_TEAMS with teamScope', () => {
+    const scope = 'ENTITY_SCOPE_TEAMS';
+    const teamScope = ['team1', 'team2', 'team3'];
+    const expectedLabel = ' 3 teams';
+
+    const result = getScopeLabel(scope, teamScope);
+
+    expect(result).toEqual(expectedLabel);
+  });
+
+  it('should return the correct label for ENTITY_SCOPE_TEAMS without teamScope', () => {
+    const scope = 'ENTITY_SCOPE_TEAMS';
+    const teamScope = undefined;
+    const expectedLabel = 'All teams';
+
+    const result = getScopeLabel(scope, teamScope);
+
+    expect(result).toEqual(expectedLabel);
+  });
+
+  it('should return the correct label for ENTITY_SCOPE_INDIVIDUALS', () => {
+    const scope = 'ENTITY_SCOPE_INDIVIDUALS';
+    const teamScope = undefined;
+    const expectedLabel = 'Individuals';
+
+    const result = getScopeLabel(scope, teamScope);
+
+    expect(result).toEqual(expectedLabel);
+  });
+
+  it('should return an empty string for unknown scope', () => {
+    const scope = 'UNKNOWN_SCOPE';
+    const teamScope = undefined;
+    const expectedLabel = '';
+
+    const result = getScopeLabel(
+      scope as unknown as components['schemas']['vegaEntityScope'],
+      teamScope
+    );
+
+    expect(result).toEqual(expectedLabel);
+  });
+});
+
+describe('getRewardTitle', () => {
+  it('should return the correct title for ENTITY_SCOPE_TEAMS', () => {
+    const scope = 'ENTITY_SCOPE_TEAMS';
+    const expectedTitle = 'Game';
+
+    const result = getRewardTitle(scope);
+
+    expect(result).toEqual(expectedTitle);
+  });
+
+  it('should return the correct title for other scopes', () => {
+    const scope = 'ENTITY_SCOPE_INDIVIDUALS';
+    const expectedTitle = 'Reward metrics';
+
+    const result = getRewardTitle(scope);
+
+    expect(result).toEqual(expectedTitle);
+  });
+});
+
+describe('TransferRewards', () => {
+  it('should render nothing if recurring dispatchStrategy is not provided', () => {
+    const { container } = render(
+      <TransferRewards recurring={null as unknown as Recurring} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render nothing if recurring.dispatchStrategy is not provided', () => {
+    const { container } = render(
+      <TransferRewards recurring={{} as unknown as Recurring} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render the reward details correctly', () => {
+    const recurring = {
+      dispatchStrategy: {
+        metric: DispatchMetric.DISPATCH_METRIC_AVERAGE_POSITION,
+        assetForMetric: '123',
+        entityScope: EntityScope.ENTITY_SCOPE_TEAMS,
+        individualScope: IndividualScope.INDIVIDUAL_SCOPE_IN_TEAM,
+        teamScope: [],
+        distributionStrategy:
+          DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA,
+        lockPeriod: 'lockPeriod',
+        markets: ['market1', 'market2'],
+        stakingRequirement: '1',
+        windowLength: 'windowLength',
+        notionalTimeWeightedAveragePositionRequirement:
+          'notionalTimeWeightedAveragePositionRequirement',
+        rankTable: [
+          { startRank: 1, shareRatio: 0.2 },
+          { startRank: 2, shareRatio: 0.3 },
+        ],
+        nTopPerformers: 'nTopPerformers',
+      },
+    };
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <MockedProvider>
+          <TransferRewards recurring={recurring} />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    expect(getByText('Game')).toBeInTheDocument();
+    expect(getByText('Scope')).toBeInTheDocument();
+    expect(getByText('Asset for metric')).toBeInTheDocument();
+    expect(getByText('Metric')).toBeInTheDocument();
+    expect(getByText('Reward lock')).toBeInTheDocument();
+    expect(getByText('Markets in scope')).toBeInTheDocument();
+    expect(getByText('Staking requirement')).toBeInTheDocument();
+    expect(getByText('Window length')).toBeInTheDocument();
+    expect(getByText('Notional TWAP')).toBeInTheDocument();
+    expect(getByText('Elligible team members:')).toBeInTheDocument();
+    expect(getByText('Distribution strategy')).toBeInTheDocument();
+    expect(getByText('Start rank')).toBeInTheDocument();
+    expect(getByText('Share of reward pool')).toBeInTheDocument();
+  });
+
+  it('should not render a rank table if recurring.dispatchStrategy.rankTable is not provided', () => {
+    const recurring = {
+      dispatchStrategy: {
+        entityScope: EntityScope.ENTITY_SCOPE_INDIVIDUALS,
+        individualScope: IndividualScope.INDIVIDUAL_SCOPE_ALL,
+        teamScope: ['team1', 'team2', 'team3'],
+        distributionStrategy:
+          DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA,
+        lockPeriod: 'lockPeriod',
+        markets: ['market1', 'market2'],
+        stakingRequirement: 'stakingRequirement',
+        windowLength: 'windowLength',
+        notionalTimeWeightedAveragePositionRequirement:
+          'notionalTimeWeightedAveragePositionRequirement',
+        nTopPerformers: 'nTopPerformers',
+      },
+    };
+
+    const { container } = render(
+      <MemoryRouter>
+        <MockedProvider>
+          <TransferRewards recurring={recurring} />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    expect(container.querySelector('table')).toBeNull();
+  });
+});

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -171,7 +171,6 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
       {transfer && (
         <div className="mt-8">
           <TransferDetails
-            statusOnly={false}
             transfer={transfer}
             from={from || ''}
             id={deterministicId}

--- a/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal.tsx
@@ -12,6 +12,8 @@ import { ProposalSignatureBundleNewAsset } from './proposal/signature-bundle-new
 import { ProposalSignatureBundleUpdateAsset } from './proposal/signature-bundle-update';
 import { MarketLink } from '../../links';
 import { formatNumber } from '@vegaprotocol/utils';
+import { TransferDetails } from './transfer/transfer-details';
+import { proposalToTransfer } from '../lib/proposal-to-transfer';
 
 export type Proposal = components['schemas']['v1ProposalSubmission'];
 export type ProposalTerms = components['schemas']['vegaProposalTerms'];
@@ -104,6 +106,12 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
     ? ProposalSignatureBundleNewAsset
     : ProposalSignatureBundleUpdateAsset;
 
+  let transfer, from;
+  if (proposal.terms?.newTransfer?.changes) {
+    transfer = proposalToTransfer(proposal.terms?.newTransfer.changes);
+    from = proposal.terms.newTransfer.changes.source;
+  }
+
   return (
     <>
       <TableWithTbody className="mb-8" allowWrap={true}>
@@ -149,13 +157,26 @@ export const TxProposal = ({ txData, pubKey, blockData }: TxProposalProps) => {
           </>
         ) : null}
       </TableWithTbody>
+
       <ProposalSummary
         id={deterministicId}
         rationale={proposal.rationale}
         terms={proposal?.terms}
       />
+
       {proposalRequiresSignatureBundle(proposal) && (
         <SignatureBundleComponent id={deterministicId} tx={tx} />
+      )}
+
+      {transfer && (
+        <div className="mt-8">
+          <TransferDetails
+            statusOnly={false}
+            transfer={transfer}
+            from={from || ''}
+            id={deterministicId}
+          />
+        </div>
       )}
     </>
   );

--- a/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
@@ -60,7 +60,7 @@ export const TxDetailsTransfer = ({
   }
 
   const from = txData.submitter;
-
+  const id = txSignatureToDeterministicId(txData.signature.value);
   return (
     <>
       <TableWithTbody className="mb-8" allowWrap={true}>
@@ -70,9 +70,7 @@ export const TxDetailsTransfer = ({
         </TableRow>
         <TableRow modifier="bordered" data-testid="id">
           <TableCell {...sharedHeaderProps}>{t('Transfer ID')}</TableCell>
-          <TableCell>
-            {txSignatureToDeterministicId(txData.signature.value)}
-          </TableCell>
+          <TableCell>{id}</TableCell>
         </TableRow>
         <TxDetailsShared
           txData={txData}
@@ -105,7 +103,7 @@ export const TxDetailsTransfer = ({
           </TableRow>
         ) : null}
       </TableWithTbody>
-      <TransferDetails from={from} transfer={transfer} />
+      <TransferDetails from={from} transfer={transfer} id={id} />
     </>
   );
 };

--- a/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
@@ -13,6 +13,7 @@ import {
   SPECIAL_CASE_NETWORK_ID,
 } from '../../links/party-link/party-link';
 import { txSignatureToDeterministicId } from '../lib/deterministic-ids';
+import Hash from '../../links/hash';
 
 type Transfer = components['schemas']['commandsv1Transfer'];
 
@@ -70,7 +71,9 @@ export const TxDetailsTransfer = ({
         </TableRow>
         <TableRow modifier="bordered" data-testid="id">
           <TableCell {...sharedHeaderProps}>{t('Transfer ID')}</TableCell>
-          <TableCell>{id}</TableCell>
+          <TableCell>
+            <Hash text={id} />
+          </TableCell>
         </TableRow>
         <TxDetailsShared
           txData={txData}

--- a/apps/explorer/src/app/components/txs/lib/proposal-to-transfer.ts
+++ b/apps/explorer/src/app/components/txs/lib/proposal-to-transfer.ts
@@ -1,0 +1,29 @@
+import type { components } from '../../../../types/explorer';
+
+type TransferProposal = components['schemas']['vegaNewTransferConfiguration'];
+type ActualTransfer = components['schemas']['commandsv1Transfer'];
+
+/**
+ * Converts a governance proposal for a transfer in to a transfer command that the
+ * TransferDetails component can then render. The types are very similar, but do not
+ * map precisely to each other due to some missing fields and some different field
+ * names.
+ *
+ * @param proposal Governance proposal for a transfer
+ * @returns transfer a Transfer object as if it had been submitted
+ */
+export function proposalToTransfer(proposal: TransferProposal): ActualTransfer {
+  return {
+    amount: proposal.amount,
+    asset: proposal.asset,
+    // On a transfer, 'from' is determined by the submitter, so there is no 'from' field
+    // fromAccountType does exist and is just named differently on the proposal
+    fromAccountType: proposal.sourceType,
+    oneOff: proposal.oneOff,
+    recurring: proposal.recurring,
+    // There is no reference applied on governance initiated transfers
+    reference: '',
+    to: proposal.destination,
+    toAccountType: proposal.destinationType,
+  };
+}

--- a/libs/types/src/__generated__/types.ts
+++ b/libs/types/src/__generated__/types.ts
@@ -14,6 +14,32 @@ export type Scalars = {
   Timestamp: any;
 };
 
+/** Margins for a hypothetical position not related to any existing party */
+export type AbstractMarginLevels = {
+  __typename?: 'AbstractMarginLevels';
+  /** Asset for the current margins */
+  asset: Asset;
+  /**
+   * If the margin of the party is greater than this level, then collateral will be released from the margin account into
+   * the general account of the party for the given asset.
+   */
+  collateralReleaseLevel: Scalars['String'];
+  /** This is the minimum margin required for a party to place a new order on the network, expressed as unsigned integer */
+  initialLevel: Scalars['String'];
+  /** Minimal margin for the position to be maintained in the network (unsigned integer) */
+  maintenanceLevel: Scalars['String'];
+  /** Margin factor, only relevant for isolated margin mode, else 0 */
+  marginFactor: Scalars['String'];
+  /** Margin mode of the party, cross margin or isolated margin */
+  marginMode: MarginMode;
+  /** Market in which the margin is required for this party */
+  market: Market;
+  /** When in isolated margin, the required order margin level, otherwise, 0 */
+  orderMarginLevel: Scalars['String'];
+  /** If the margin is between maintenance and search, the network will initiate a collateral search, expressed as unsigned integer */
+  searchLevel: Scalars['String'];
+};
+
 /** An account record */
 export type AccountBalance = {
   __typename?: 'AccountBalance';
@@ -359,6 +385,8 @@ export enum AuctionTrigger {
 
 export type BatchProposal = {
   __typename?: 'BatchProposal';
+  /** Terms of all the proposals in the batch */
+  batchTerms?: Maybe<BatchProposalTerms>;
   /** RFC3339Nano time and date when the proposal reached the network */
   datetime: Scalars['Timestamp'];
   /** Details of the rejection reason */
@@ -389,10 +417,10 @@ export type BatchProposal = {
   votes: ProposalVotes;
 };
 
-/** The rationale for the proposal */
+/** The terms for the batch proposal */
 export type BatchProposalTerms = {
   __typename?: 'BatchProposalTerms';
-  /** Actual changes being introduced by the proposal - actions the proposal triggers if passed and enacted. */
+  /** Actual changes being introduced by the batch proposal - actions the proposal triggers if passed and enacted. */
   changes: Array<Maybe<BatchProposalTermsChange>>;
   /**
    * RFC3339Nano time and date when voting closes for this proposal.
@@ -529,6 +557,22 @@ export type CompositePriceConfiguration = {
   decayPower: Scalars['Int'];
   /** Decay weight used in calculating time weight for a given trade */
   decayWeight: Scalars['String'];
+};
+
+export type CompositePriceSource = {
+  __typename?: 'CompositePriceSource';
+  /** The source of the price */
+  PriceSource: Scalars['String'];
+  /** The last time the price source was updated in RFC3339Nano */
+  lastUpdated: Scalars['Timestamp'];
+  /** The current value of the composite source price */
+  price: Scalars['String'];
+};
+
+export type CompositePriceState = {
+  __typename?: 'CompositePriceState';
+  /** Underlying state of the composite price */
+  priceSources?: Maybe<Array<CompositePriceSource>>;
 };
 
 export enum CompositePriceType {
@@ -2165,9 +2209,9 @@ export type MarginEdge = {
 export type MarginEstimate = {
   __typename?: 'MarginEstimate';
   /** Margin level estimate assuming no slippage */
-  bestCase: MarginLevels;
+  bestCase: AbstractMarginLevels;
   /** Margin level estimate assuming slippage cap is applied */
-  worstCase: MarginLevels;
+  worstCase: AbstractMarginLevels;
 };
 
 /** Margins for a given a party */
@@ -2439,6 +2483,8 @@ export type MarketData = {
   liquidityProviderSla?: Maybe<Array<LiquidityProviderSLA>>;
   /** The mark price (an unsigned integer) */
   markPrice: Scalars['String'];
+  /** State of the underlying internal composite price */
+  markPriceState?: Maybe<CompositePriceState>;
   /** The methodology used for the calculation of the mark price */
   markPriceType: CompositePriceType;
   /** Market of the associated mark price */
@@ -3053,6 +3099,8 @@ export type ObservableMarketData = {
   liquidityProviderSla?: Maybe<Array<ObservableLiquidityProviderSLA>>;
   /** The mark price (an unsigned integer) */
   markPrice: Scalars['String'];
+  /** State of the underlying internal composite price */
+  markPriceState?: Maybe<CompositePriceState>;
   /** The methodology used to calculated mark price */
   markPriceType: CompositePriceType;
   /** The market growth factor for the last market time window */
@@ -4021,6 +4069,8 @@ export type PerpetualData = {
   fundingRate?: Maybe<Scalars['String']>;
   /** Internal composite price used as input to the internal VWAP */
   internalCompositePrice: Scalars['String'];
+  /** The internal state of the underlying internal composite price */
+  internalCompositePriceState?: Maybe<CompositePriceState>;
   /** The methodology used to calculated internal composite price for perpetual markets */
   internalCompositePriceType: CompositePriceType;
   /** Time-weighted average price calculated from data points for this period from the internal data source. */
@@ -4031,6 +4081,8 @@ export type PerpetualData = {
   seqNum: Scalars['Int'];
   /** Time at which the funding period started */
   startTime: Scalars['Timestamp'];
+  /** The last value from the external oracle */
+  underlyingIndexPrice: Scalars['String'];
 };
 
 export type PerpetualProduct = {
@@ -4328,7 +4380,7 @@ export type ProposalDetail = {
   __typename?: 'ProposalDetail';
   /** Batch proposal ID that is provided by Vega once proposal reaches the network */
   batchId?: Maybe<Scalars['ID']>;
-  /** Terms of the proposal for a batch proposal */
+  /** Terms of all the proposals in the batch */
   batchTerms?: Maybe<BatchProposalTerms>;
   /** RFC3339Nano time and date when the proposal reached the Vega network */
   datetime: Scalars['Timestamp'];
@@ -4354,7 +4406,7 @@ export type ProposalDetail = {
   requiredParticipation: Scalars['String'];
   /** State of the proposal */
   state: ProposalState;
-  /** Terms of the proposal for proposal */
+  /** Terms of the proposal */
   terms?: Maybe<ProposalTerms>;
 };
 


### PR DESCRIPTION
- feat(explorer): extend transfers view
- chore(explorer): more fields for rewards
- feat(explorer): complete transfer status
- chore(explorer): progress on rank table
- chore(explorer): relayout transfers
- chore(explorer): update transfer status query to match latest preview
- test(explorer): add tests for games display

# Related issues 🔗

Closes #4306. Closes #5557. See notes below for testing.

# Description ℹ️

Updates the Transfer TX view to display extra information. Firstly, it uses a new API to show the transfer status 

Secondly it revamps the recurring reward transaction view to cover 'games', which is to say recurring transfers with a
dispatch strategy that targets teams. All possible fields for dispatchStrategy are rendered in a hopefully meaningful way,
although there's a limit to how muc explaining this panel can do. It might need some extra work when actual games are being
run, rather than test data.

# Demo 📺

# All transfers (one-off or recurring) have a new status block
<img width="932" alt="Screenshot 2024-02-08 at 12 33 40" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/a8ba9b30-9f15-4e35-86c5-f4c85cafc00c">

## Recurring transfers with 'game' stuff now have all the details rendered
<img width="1300" alt="Screenshot 2024-02-08 at 12 33 59" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/68be4595-dbea-4ef6-9fce-4024ad41e187">

# Technical 👨‍🔧
- Uses GraphQL queries not available in 0.73.x. This will cause GraphQL 422 errors on older networks.
- Fairground TX `98F545484000F49F91F55A92969AD3EA669355F18469379BC32AE9D11EC8218F` is an example game. Find others by filtering for transfers in the TX list
- For testing: the status of the transfer is different from the status of the transaction. A transfer can be accepted for 
future execution, but fail when it executes due to lacking funds.