### PR TITLE
fix(trading): keep leaderboard rank when filtering

### DIFF
--- a/apps/trading/components/competitions/competitions-leaderboard.tsx
+++ b/apps/trading/components/competitions/competitions-leaderboard.tsx
@@ -33,9 +33,9 @@ export const CompetitionsLeaderboard = ({
         { name: 'status', displayName: t('Status') },
         { name: 'volume', displayName: t('Volume') },
       ]}
-      data={data.map((td, i) => {
+      data={data.map((td) => {
         // leaderboard place or medal
-        let rank: number | React.ReactNode = i + 1;
+        let rank: number | React.ReactNode = td.rank;
         if (rank === 1) rank = <Rank variant="gold" />;
         if (rank === 2) rank = <Rank variant="silver" />;
         if (rank === 3) rank = <Rank variant="bronze" />;

--- a/apps/trading/lib/hooks/use-teams.tsx
+++ b/apps/trading/lib/hooks/use-teams.tsx
@@ -36,7 +36,9 @@ export const useTeams = (aggregationEpochs = DEFAULT_AGGREGATION_EPOCHS) => {
       ...stats.find((s) => s.teamId === t.teamId),
     }));
 
-    return orderBy(data, (d) => Number(d.totalQuantumRewards || 0), 'desc');
+    return orderBy(data, (d) => Number(d.totalQuantumRewards || 0), 'desc').map(
+      (d, i) => ({ ...d, rank: i + 1 })
+    );
   }, [teams, stats]);
 
   return {


### PR DESCRIPTION
# Related issues 🔗

Closes #5729 

# Description ℹ️

* keeps rank when filtering

# Demo 📺

https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/a0d091e6-0f08-4181-bc4d-4169b55cc103

# Technical 👨‍🔧

N/A
