### PR TITLE
fix(governance): dont show all reward types in gov rewards table

### DIFF
--- a/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.spec.ts
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.spec.ts
@@ -241,6 +241,16 @@ describe('generateEpochAssetRewardsList', () => {
               amount: '5',
             },
           },
+          {
+            // This should not be included in the result
+            node: {
+              epoch: 2,
+              assetId: '3',
+              decimals: 18,
+              rewardType: AccountType.ACCOUNT_TYPE_REWARD_RETURN_VOLATILITY,
+              amount: '5',
+            },
+          },
         ],
       },
       epoch: {

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.ts
@@ -83,12 +83,16 @@ export const generateEpochTotalRewardsList = ({
         (Number(rewardItem?.amount) || 0) + Number(reward.amount)
       ).toString();
 
-      if (Object.keys(RowAccountTypes).includes(reward.rewardType)) {
-        rewards?.set(reward.rewardType, {
-          rewardType: reward.rewardType,
-          amount,
-        });
+      // only RowAccountTypes are relevant for this table, others should
+      // be discarded
+      if (!Object.keys(RowAccountTypes).includes(reward.rewardType)) {
+        return acc;
       }
+
+      rewards?.set(reward.rewardType, {
+        rewardType: reward.rewardType,
+        amount,
+      });
 
       epoch.assetRewards.set(reward.assetId, {
         assetId: reward.assetId,

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/generate-epoch-total-rewards-list.ts
@@ -83,10 +83,12 @@ export const generateEpochTotalRewardsList = ({
         (Number(rewardItem?.amount) || 0) + Number(reward.amount)
       ).toString();
 
-      rewards?.set(reward.rewardType, {
-        rewardType: reward.rewardType,
-        amount,
-      });
+      if (Object.keys(RowAccountTypes).includes(reward.rewardType)) {
+        rewards?.set(reward.rewardType, {
+          rewardType: reward.rewardType,
+          amount,
+        });
+      }
 
       epoch.assetRewards.set(reward.assetId, {
         assetId: reward.assetId,


### PR DESCRIPTION
# Related issues 🔗

Closes #5677 

# Description ℹ️

Fixes an issue where new reward types were being rendered in the table, breaking the grid layout. This change checks that the reward type is included in the RowAccountType object before setting the reward data.