### PR TITLE
fix(trading): add depth chart on mobile view

### DIFF
--- a/apps/trading/client-pages/market/trade-panels.tsx
+++ b/apps/trading/client-pages/market/trade-panels.tsx
@@ -75,6 +75,7 @@ export const TradePanels = ({ market, pinnedAsset }: TradePanelsProps) => {
           {[
             'chart',
             'orderbook',
+            'depth',
             'trades',
             'liquidity',
             'fundingPayments',


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Depth chart was not added to the mobile view.