### PR TITLE
fix(explorer): sizedelta in ammends displayed incorrectly'

### DIFF
--- a/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
@@ -175,6 +175,7 @@ describe('Amend order details', () => {
 
     const res = renderExistingAmend('123', 1, amend);
     expect(await res.findByText('New size')).toBeInTheDocument();
+    expect(await res.findByText('Size ±')).toBeInTheDocument();
   });
 
   it('Renders Reference if provided', async () => {

--- a/apps/explorer/src/app/components/order-details/amend-order-details.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.tsx
@@ -82,7 +82,7 @@ const AmendOrderDetails = ({ id, version, amend }: AmendOrderDetailsProps) => {
             {amend.sizeDelta && amend.sizeDelta !== '0' ? (
               <div className="mb-12 md:mb-0">
                 <h2 className="text-dark mb-4 text-2xl font-bold">
-                  {t('New size')}
+                  {t('Size ±')}
                 </h2>
                 <h5
                   className={`mb-0 text-lg font-medium capitalize text-gray-500 ${getSideDeltaColour(
@@ -93,6 +93,16 @@ const AmendOrderDetails = ({ id, version, amend }: AmendOrderDetailsProps) => {
                 </h5>
               </div>
             ) : null}
+            {o && (
+              <div className="">
+                <h2 className="text-dark mb-4 text-2xl font-bold">
+                  {t('New size')}
+                </h2>
+                <h5 className="mb-0 text-lg font-medium text-gray-500">
+                  {o ? o.size : null}
+                </h5>
+              </div>
+            )}
 
             {amend.price && amend.price !== '0' ? (
               <div className="">


### PR DESCRIPTION
- **fix(explorer): fix display of amends with sizedelta**

# Related issues 🔗

Closes #5774

# Description ℹ️

`sizeDelta` displayed as the new price, rather than a change to the price. This change changes the label, and displays the actual size more clearly.

# Demo 📺

<img width="623" alt="Screenshot 2024-02-19 at 11 48 54" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/6d9c2b7d-7cb3-4d75-a36c-8df6ed8a3559">

# To test
- You need an order 
- Then you need to amend the order using the sizeDelta field
- Example: https://explorer.fairground.wtf/txs/0x2ABAE5BCDF7F45BE24CD9599E77AEEED0D281B1F0548429D9041FDC1F15670A1 was size `7000`, then ammended using sizeDelta `-2000` to size `5000`