### PR TITLE
fix(trading): use same epochs for all games/stats

### DIFF
--- a/apps/trading/lib/hooks/constants.ts
+++ b/apps/trading/lib/hooks/constants.ts
@@ -1,0 +1,8 @@
+import { ENV, Networks } from '@vegaprotocol/environment';
+
+const TEAMS_STATS_EPOCHS_MAINNET = 30;
+const TEAMS_STATS_EPOCHS_TESTNET = 192;
+export const TEAMS_STATS_EPOCHS =
+  ENV.VEGA_ENV === Networks.MAINNET
+    ? TEAMS_STATS_EPOCHS_MAINNET
+    : TEAMS_STATS_EPOCHS_TESTNET;

--- a/apps/trading/lib/hooks/use-games.ts
+++ b/apps/trading/lib/hooks/use-games.ts
@@ -7,8 +7,7 @@ import orderBy from 'lodash/orderBy';
 import { removePaginationWrapper } from '@vegaprotocol/utils';
 import { useEpochInfoQuery } from './__generated__/Epoch';
 import { type ApolloError } from '@apollo/client';
-
-const TAKE_EPOCHS = 30; // TODO: should this be DEFAULT_AGGREGATION_EPOCHS?
+import { TEAMS_STATS_EPOCHS } from './constants';
 
 const findTeam = (entities: GameFieldsFragment['entities'], teamId: string) => {
   const team = entities.find(
@@ -45,7 +44,7 @@ export const useGames = (teamId?: string, epochFrom?: number): GamesData => {
 
   let from = epochFrom;
   if (!from && epochData) {
-    from = Number(epochData.epoch.id) - TAKE_EPOCHS;
+    from = Number(epochData.epoch.id) - TEAMS_STATS_EPOCHS;
     if (from < 1) from = 1; // make sure it's not negative
   }
 

--- a/apps/trading/lib/hooks/use-team.ts
+++ b/apps/trading/lib/hooks/use-team.ts
@@ -5,7 +5,7 @@ import {
   type TeamRefereeFieldsFragment,
   type TeamMemberStatsFieldsFragment,
 } from './__generated__/Team';
-import { DEFAULT_AGGREGATION_EPOCHS } from './use-teams';
+import { TEAMS_STATS_EPOCHS } from './constants';
 
 export type Team = TeamFieldsFragment;
 export type TeamStats = TeamStatsFieldsFragment;
@@ -22,7 +22,7 @@ export const useTeam = (teamId?: string, partyId?: string) => {
     variables: {
       teamId: teamId || '',
       partyId,
-      aggregationEpochs: DEFAULT_AGGREGATION_EPOCHS,
+      aggregationEpochs: TEAMS_STATS_EPOCHS,
     },
     skip: !teamId,
     fetchPolicy: 'cache-and-network',

--- a/apps/trading/lib/hooks/use-teams.tsx
+++ b/apps/trading/lib/hooks/use-teams.tsx
@@ -4,9 +4,7 @@ import { useTeamsQuery } from './__generated__/Teams';
 import { useTeamsStatisticsQuery } from './__generated__/TeamsStatistics';
 import compact from 'lodash/compact';
 import { type TeamStatsFieldsFragment } from './__generated__/Team';
-
-// 192
-export const DEFAULT_AGGREGATION_EPOCHS = 192;
+import { TEAMS_STATS_EPOCHS } from './constants';
 
 const EMPTY_STATS: Partial<TeamStatsFieldsFragment> = {
   totalQuantumVolume: '0',
@@ -16,7 +14,7 @@ const EMPTY_STATS: Partial<TeamStatsFieldsFragment> = {
   quantumRewards: [],
 };
 
-export const useTeams = (aggregationEpochs = DEFAULT_AGGREGATION_EPOCHS) => {
+export const useTeams = (aggregationEpochs = TEAMS_STATS_EPOCHS) => {
   const {
     data: teamsData,
     loading: teamsLoading,


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

We were not using a consistent epoch number for stats aggregation for teams/competitiosn
