### PR TITLE
fix(trading): lp data provider reload - updating book

### DIFF
--- a/apps/trading/components/liquidity-container/liquidity-container.tsx
+++ b/apps/trading/components/liquidity-container/liquidity-container.tsx
@@ -4,7 +4,6 @@ import {
   lpAggregatedDataProvider,
   type Filter,
   LiquidityTable,
-  liquidityProvisionsDataProvider,
 } from '@vegaprotocol/liquidity';
 import { getAsset, useMarket } from '@vegaprotocol/markets';
 import {
@@ -71,7 +70,7 @@ export const LiquidityContainer = ({
 
 const useReloadLiquidityData = (marketId: string | undefined) => {
   const { reload } = useDataProvider({
-    dataProvider: liquidityProvisionsDataProvider,
+    dataProvider: lpAggregatedDataProvider,
     variables: { marketId: marketId || '' },
     update: () => true,
     skip: !marketId,


### PR DESCRIPTION
# Related issues 🔗

Closes #5852

# Description ℹ️

Update LP data provider reloading - The live time on book was not updating.

# Demo 📺

N/A

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
