### PR TITLE
fix(trading): fix reward card asssets

### DIFF
--- a/apps/trading/components/rewards-container/active-rewards.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.tsx
@@ -24,6 +24,7 @@ import {
   type DispatchStrategy,
   IndividualScopeMapping,
   IndividualScopeDescriptionMapping,
+  type Asset,
 } from '@vegaprotocol/types';
 import { Card } from '../card/card';
 import { type ReactNode, useState } from 'react';
@@ -200,7 +201,8 @@ export const ActiveRewardCard = ({
         transferNode.transfer.asset?.decimals || 0,
         6
       )}
-      rewardAsset={transferNode.asset}
+      rewardAsset={transferNode.dispatchAsset}
+      transferAsset={transferNode.transfer.asset || undefined}
       endsIn={
         transferNode.transfer.kind.endEpoch != null
           ? transferNode.transfer.kind.endEpoch - currentEpoch
@@ -216,6 +218,8 @@ const RewardCard = ({
   colour,
   rewardAmount,
   rewardAsset,
+  transferAsset,
+  vegaAsset,
   dispatchStrategy,
   endsIn,
   dispatchMetricInfo,
@@ -224,12 +228,14 @@ const RewardCard = ({
   rewardAmount: string;
   /** The asset linked to the dispatch strategy via `dispatchMetricAssetId` property. */
   rewardAsset?: BasicAssetDetails;
+  /** The VEGA asset details, required to format the min staking amount. */
+  transferAsset?: Asset | undefined;
+  /** The VEGA asset details, required to format the min staking amount. */
+  vegaAsset?: BasicAssetDetails;
   /** The transfer's dispatch strategy. */
   dispatchStrategy: DispatchStrategy;
   /** The number of epochs until the transfer stops. */
   endsIn?: number;
-  /** The VEGA asset details, required to format the min staking amount. */
-  vegaAsset?: BasicAssetDetails;
   dispatchMetricInfo?: ReactNode;
 }) => {
   const t = useT();
@@ -269,7 +275,9 @@ const RewardCard = ({
                   {rewardAmount}
                 </span>
 
-                <span className="font-alpha">{rewardAsset?.symbol || ''}</span>
+                <span className="font-alpha">
+                  {transferAsset?.symbol || ''}
+                </span>
               </h3>
 
               {/** DISTRIBUTION STRATEGY */}
@@ -357,6 +365,7 @@ const RewardCard = ({
             <RewardRequirements
               dispatchStrategy={dispatchStrategy}
               rewardAsset={rewardAsset}
+              vegaAsset={vegaAsset}
             />
           )}
         </div>
@@ -379,8 +388,8 @@ export const DispatchMetricInfo = ({
   let additionalDispatchMetricInfo = null;
 
   // if asset found then display asset symbol
-  if (reward.asset) {
-    additionalDispatchMetricInfo = <span>{reward.asset.symbol}</span>;
+  if (reward.dispatchAsset) {
+    additionalDispatchMetricInfo = <span>{reward.dispatchAsset.symbol}</span>;
   }
   // but if scoped to only one market then display market name
   if (marketNames.length === 1) {

--- a/apps/trading/components/rewards-container/active-rewards.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.tsx
@@ -275,7 +275,7 @@ const RewardCard = ({
                   {rewardAmount}
                 </span>
 
-                <span className="font-alpha">
+                <span className="font-alpha" data-testid="reward-asset">
                   {transferAsset?.symbol || ''}
                 </span>
               </h3>

--- a/apps/trading/e2e/tests/teams/test_teams.py
+++ b/apps/trading/e2e/tests/teams/test_teams.py
@@ -61,7 +61,9 @@ def setup_teams_and_games(vega: VegaServiceNull):
             symbol="VEGA",
             decimals=5,
             max_faucet_amount=1e10,
+            quantum=100000, 
         )
+    
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
     VEGA_asset_id = vega.find_asset_id(symbol="VEGA")

--- a/apps/trading/e2e/tests/teams/test_teams.py
+++ b/apps/trading/e2e/tests/teams/test_teams.py
@@ -52,8 +52,23 @@ def setup_teams_and_games(vega: VegaServiceNull):
     vega.update_network_parameter(
         MM_WALLET.name, parameter="reward.asset", new_value=tDAI_asset_id
     )
+    
 
     next_epoch(vega=vega)
+    vega.create_asset(
+            MM_WALLET.name,
+            name="VEGA",
+            symbol="VEGA",
+            decimals=5,
+            max_faucet_amount=1e10,
+        )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    VEGA_asset_id = vega.find_asset_id(symbol="VEGA")
+    vega.mint(PARTY_A.name, VEGA_asset_id, 1e5)
+    vega.mint(PARTY_B.name, VEGA_asset_id, 1e5)
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
     team_name = create_team(vega)
 
     next_epoch(vega)
@@ -101,7 +116,7 @@ def setup_teams_and_games(vega: VegaServiceNull):
         from_key_name=PARTY_A.name,
         from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
         to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
-        asset=tDAI_asset_id,
+        asset=VEGA_asset_id,
         reference="reward",
         asset_for_metric=tDAI_asset_id,
         metric=vega_protos.vega.DISPATCH_METRIC_MAKER_FEES_PAID,
@@ -119,7 +134,7 @@ def setup_teams_and_games(vega: VegaServiceNull):
         from_key_name=PARTY_B.name,
         from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
         to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
-        asset=tDAI_asset_id,
+        asset=VEGA_asset_id,
         reference="reward",
         asset_for_metric=tDAI_asset_id,
         metric=vega_protos.vega.DISPATCH_METRIC_MAKER_FEES_PAID,
@@ -288,6 +303,7 @@ def test_game_card(competitions_page: Page):
     expect(game_1.get_by_test_id("entity-scope")).to_have_text("Individual")
     expect(game_1.get_by_test_id("locked-for")).to_have_text("1 epoch")
     expect(game_1.get_by_test_id("reward-value")).to_have_text("100.00")
+    expect(game_1.get_by_test_id("reward-asset")).to_have_text("VEGA")
     expect(game_1.get_by_test_id("distribution-strategy")).to_have_text("Pro rata")
     expect(game_1.get_by_test_id("dispatch-metric-info")).to_have_text(
         "Price maker fees paid • tDAI"

--- a/apps/trading/lib/hooks/use-rewards.ts
+++ b/apps/trading/lib/hooks/use-rewards.ts
@@ -31,7 +31,7 @@ export type RewardTransfer = TransferNode & {
 
 export type EnrichedRewardTransfer = RewardTransfer & {
   /** Dispatch metric asset (reward asset) */
-  asset?: AssetFieldsFragment;
+  dispatchAsset?: AssetFieldsFragment;
   /** A flag determining whether a reward asset is being traded on any of the active markets */
   isAssetTraded?: boolean;
   /** A list of markets in scope */
@@ -142,9 +142,10 @@ export const useRewards = ({
     .filter((node) => (scopeToTeams ? isScopedToTeams(node) : true))
     // enrich with dispatch asset and markets in scope details
     .map((node) => {
-      const asset =
-        assets &&
-        assets[node.transfer.kind.dispatchStrategy.dispatchMetricAssetId];
+      const dispatchAsset =
+        (assets &&
+          assets[node.transfer.kind.dispatchStrategy.dispatchMetricAssetId]) ||
+        undefined;
       const marketsInScope = compact(
         node.transfer.kind.dispatchStrategy.marketIdsInScope?.map(
           (id) => markets && markets[id]
@@ -167,7 +168,7 @@ export const useRewards = ({
         });
       return {
         ...node,
-        asset: asset ? asset : undefined,
+        dispatchAsset,
         isAssetTraded: isAssetTraded != null ? isAssetTraded : undefined,
         markets: marketsInScope.length > 0 ? marketsInScope : undefined,
       };


### PR DESCRIPTION
# Related issues 🔗

Closes #5886 

# Description ℹ️

Use `node.transfer.asset` for reward cards. 
Dispatch asset should be used for dispatch metric info. 

# Demo 📺

<img width="1680" alt="Screenshot 2024-02-28 at 18 48 28" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/87f74893-a275-4dec-97ac-95df5dd96da2">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
