### PR TITLE
chore(trading): scoped to teams games

### DIFF
--- a/apps/trading/e2e/tests/teams/test_teams.py
+++ b/apps/trading/e2e/tests/teams/test_teams.py
@@ -299,7 +299,7 @@ def test_leaderboard(competitions_page: Page, setup_teams_and_games):
 
 
 def test_game_card(competitions_page: Page):
-    expect(competitions_page.get_by_test_id("active-rewards-card")).to_have_count(2)
+    expect(competitions_page.get_by_test_id("active-rewards-card")).to_have_count(1)
     game_1 = competitions_page.get_by_test_id("active-rewards-card").first
     expect(game_1).to_be_visible()
     expect(game_1.get_by_test_id("entity-scope")).to_have_text("Individual")

--- a/apps/trading/e2e/tests/teams/test_teams.py
+++ b/apps/trading/e2e/tests/teams/test_teams.py
@@ -302,7 +302,7 @@ def test_game_card(competitions_page: Page):
     expect(competitions_page.get_by_test_id("active-rewards-card")).to_have_count(1)
     game_1 = competitions_page.get_by_test_id("active-rewards-card").first
     expect(game_1).to_be_visible()
-    expect(game_1.get_by_test_id("entity-scope")).to_have_text("Individual")
+    expect(game_1.get_by_test_id("entity-scope")).to_have_text("Team")
     expect(game_1.get_by_test_id("locked-for")).to_have_text("1 epoch")
     expect(game_1.get_by_test_id("reward-value")).to_have_text("100.00")
     expect(game_1.get_by_test_id("reward-asset")).to_have_text("VEGA")
@@ -311,7 +311,7 @@ def test_game_card(competitions_page: Page):
         "Price maker fees paid • tDAI"
     )
     expect(game_1.get_by_test_id("assessed-over")).to_have_text("15 epochs")
-    expect(game_1.get_by_test_id("scope")).to_have_text("In team")
+    expect(game_1.get_by_test_id("scope")).to_have_text("All teams")
     expect(game_1.get_by_test_id("staking-requirement")).to_have_text("0.00")
     expect(game_1.get_by_test_id("average-position")).to_have_text("0.00")
 

--- a/apps/trading/lib/hooks/use-rewards.spec.ts
+++ b/apps/trading/lib/hooks/use-rewards.spec.ts
@@ -194,11 +194,11 @@ describe('isScopedToTeams', () => {
         undefined,
         makeDispatchStrategy(
           EntityScope.ENTITY_SCOPE_INDIVIDUALS,
-          IndividualScope.INDIVIDUAL_SCOPE_IN_TEAM // individual in teams
+          IndividualScope.INDIVIDUAL_SCOPE_IN_TEAM // individual in teams but not a team game
         ),
         'RecurringTransfer'
       ),
-      true,
+      false,
     ],
     [
       makeReward(

--- a/apps/trading/lib/hooks/use-rewards.ts
+++ b/apps/trading/lib/hooks/use-rewards.ts
@@ -14,7 +14,6 @@ import {
   TransferStatus,
   type DispatchStrategy,
   EntityScope,
-  IndividualScope,
   MarketState,
   AccountType,
 } from '@vegaprotocol/types';
@@ -75,20 +74,11 @@ export const isActiveReward = (node: RewardTransfer, currentEpoch: number) => {
 
 /**
  * Checks if given reward (transfer) is scoped to teams.
- *
- * A reward is scoped to teams if it's entity scope is set to teams or
- * if the scope is set to individuals but the individuals are in a team.
  */
 export const isScopedToTeams = (node: EnrichedRewardTransfer) =>
   // scoped to teams
   node.transfer.kind.dispatchStrategy?.entityScope ===
-    EntityScope.ENTITY_SCOPE_TEAMS ||
-  // or to individuals
-  (node.transfer.kind.dispatchStrategy?.entityScope ===
-    EntityScope.ENTITY_SCOPE_INDIVIDUALS &&
-    // but they have to be in a team
-    node.transfer.kind.dispatchStrategy?.individualScope ===
-      IndividualScope.INDIVIDUAL_SCOPE_IN_TEAM);
+  EntityScope.ENTITY_SCOPE_TEAMS;
 
 /** Retrieves rewards (transfers) */
 export const useRewards = ({


### PR DESCRIPTION
# Related issues 🔗

Closes #5898

# Description ℹ️

* removes the "crazy" condition determining the scoped to teams games

# Demo 📺

N/A

# Technical 👨‍🔧

N/A
