### PR TITLE
fix(trading): add team id to games query

### DIFF
--- a/apps/trading/lib/hooks/Games.graphql
+++ b/apps/trading/lib/hooks/Games.graphql
@@ -25,8 +25,12 @@ fragment GameFields on Game {
   }
 }
 
-query Games($epochFrom: Int) {
-  games(epochFrom: $epochFrom, entityScope: ENTITY_SCOPE_TEAMS) {
+query Games($epochFrom: Int, $teamId: ID) {
+  games(
+    epochFrom: $epochFrom
+    teamId: $teamId
+    entityScope: ENTITY_SCOPE_TEAMS
+  ) {
     edges {
       node {
         ...GameFields

--- a/apps/trading/lib/hooks/__generated__/Games.ts
+++ b/apps/trading/lib/hooks/__generated__/Games.ts
@@ -9,6 +9,7 @@ export type GameFieldsFragment = { __typename?: 'Game', id: string, epoch: numbe
 
 export type GamesQueryVariables = Types.Exact<{
   epochFrom?: Types.InputMaybe<Types.Scalars['Int']>;
+  teamId?: Types.InputMaybe<Types.Scalars['ID']>;
 }>;
 
 
@@ -44,8 +45,8 @@ export const GameFieldsFragmentDoc = gql`
 }
     ${TeamEntityFragmentDoc}`;
 export const GamesDocument = gql`
-    query Games($epochFrom: Int) {
-  games(epochFrom: $epochFrom, entityScope: ENTITY_SCOPE_TEAMS) {
+    query Games($epochFrom: Int, $teamId: ID) {
+  games(epochFrom: $epochFrom, teamId: $teamId, entityScope: ENTITY_SCOPE_TEAMS) {
     edges {
       node {
         ...GameFields
@@ -68,6 +69,7 @@ export const GamesDocument = gql`
  * const { data, loading, error } = useGamesQuery({
  *   variables: {
  *      epochFrom: // value for 'epochFrom'
+ *      teamId: // value for 'teamId'
  *   },
  * });
  */

--- a/apps/trading/lib/hooks/use-games.ts
+++ b/apps/trading/lib/hooks/use-games.ts
@@ -51,6 +51,7 @@ export const useGames = (teamId?: string, epochFrom?: number): GamesData => {
   const { data, loading, error } = useGamesQuery({
     variables: {
       epochFrom: from,
+      teamId: teamId,
     },
     skip: !from,
     fetchPolicy: 'cache-and-network',

--- a/libs/types/src/__generated__/types.ts
+++ b/libs/types/src/__generated__/types.ts
@@ -936,6 +936,8 @@ export enum DispatchMetric {
 /** Dispatch strategy for a recurring transfer */
 export type DispatchStrategy = {
   __typename?: 'DispatchStrategy';
+  /** Optional multiplier on taker fees used to cap the rewards a party may receive in an epoch */
+  capRewardFeeMultiple?: Maybe<Scalars['String']>;
   /** Defines the data that will be used to compare markets so as to distribute rewards appropriately */
   dispatchMetric: DispatchMetric;
   /** The asset to use for measuring contribution to the metric */
@@ -2391,6 +2393,8 @@ export type Market = {
   state: MarketState;
   /** Optional: Market ID of the successor to this market if one exists */
   successorMarketID?: Maybe<Scalars['ID']>;
+  /** The market minimum tick size */
+  tickSize: Scalars['String'];
   /** An instance of, or reference to, a tradable instrument. */
   tradableInstrument: TradableInstrument;
   /** @deprecated Simplify and consolidate trades query and remove nesting. Use trades query instead */
@@ -2816,6 +2820,8 @@ export type NewMarket = {
   riskParameters: RiskModel;
   /** Successor market configuration. If this proposed market is meant to succeed a given market, then this needs to be set. */
   successorConfiguration?: Maybe<SuccessorConfiguration>;
+  /** The market minimum tick size */
+  tickSize: Scalars['String'];
 };
 
 /** Configuration for a new spot market on Vega */
@@ -2839,6 +2845,8 @@ export type NewSpotMarket = {
   riskParameters?: Maybe<RiskModel>;
   /** Specifies parameters related to liquidity target stake calculation */
   targetStakeParameters: TargetStakeParameters;
+  /** The market minimum tick size */
+  tickSize: Scalars['String'];
 };
 
 export type NewTransfer = {
@@ -7074,6 +7082,8 @@ export type UpdateMarketConfiguration = {
   quadraticSlippageFactor: Scalars['String'];
   /** Updated futures market risk model parameters. */
   riskParameters: UpdateMarketRiskParameters;
+  /** The market minimum tick size */
+  tickSize: Scalars['String'];
 };
 
 export type UpdateMarketLogNormalRiskModel = {
@@ -7171,6 +7181,8 @@ export type UpdateSpotMarketConfiguration = {
   riskParameters: RiskModel;
   /** Specifies parameters related to target stake calculation */
   targetStakeParameters: TargetStakeParameters;
+  /** The market minimum tick size */
+  tickSize: Scalars['String'];
 };
 
 export type UpdateVolumeDiscountProgram = {


### PR DESCRIPTION
# Related issues 🔗

Closes #5899 

# Description ℹ️

* adds additional `teamId` variable to the `games` query in order to get the historical results for a team

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/71a14648-5b33-4e03-bd97-80c7d47e1e58)


# Technical 👨‍🔧

N/A
