### PR TITLE
chore(trading): remove view as pubkey banner

### DIFF
--- a/apps/trading/pages/_app.page.tsx
+++ b/apps/trading/pages/_app.page.tsx
@@ -24,7 +24,6 @@ import {
   ProtocolUpgradeInProgressNotification,
   ProtocolUpgradeProposalNotification,
 } from '@vegaprotocol/proposals';
-import { ViewingBanner } from '../components/viewing-banner';
 import { Telemetry } from '../components/telemetry';
 import { SSRLoader } from './ssr-loader';
 import { PartyActiveOrdersHandler } from './party-active-orders-handler';
@@ -77,7 +76,6 @@ function AppBody({ Component }: AppProps) {
             mode={ProtocolUpgradeCountdownMode.IN_ESTIMATED_TIME_REMAINING}
           />
           <ProtocolUpgradeInProgressNotification />
-          <ViewingBanner />
         </div>
         <div data-testid={`pathname-${location.pathname}`}>
           <Component />


### PR DESCRIPTION
# Related issues 🔗

Closes #4087 

# Description ℹ️

Remove `view as` banner

# Demo 📺

<img width="1680" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/06688333-096f-4f8f-b1b1-e205fc78e50f">



Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
