### PR TITLE
Update instructions and version for running in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,23 +133,23 @@ The [`docker`](./docker) subfolder has some docker configurations for easily set
 
 ### nx build inside the docker
 
-Using multistage dockerfile dist is compiled using [node](https://hub.docker.com/_/node) image and later packed to nginx as in [dist build](#dist-build). The multistage builds ensures consistent CPU architecture and build toolchains are used so that the result will be identical.
+Using multistage dockerfile dist is compiled using [node](https://hub.docker.com/_/node) image and later packed to nginx as in [dist-build](#dist-build). The multistage builds ensures consistent CPU architecture and build toolchains are used so that the result will be identical.
 
 ```bash
-docker build --build-arg APP=[YOUR APP] --build-arg NODE_VERSION=20.9.1 --build-arg ENV_NAME=mainnet -t [TAG] -f docker/node-inside-docker.Dockerfile .
+docker build --build-arg APP=[YOUR APP] --build-arg NODE_VERSION=20.11 --build-arg ENV_NAME=mainnet -t [TAG] -f docker/node-inside-docker.Dockerfile .
 ```
 
 ### Computing ipfs-hash of the build
 
 At the moment this feature is important only for Console releases.
 
-Each docker build finishes with hash calculation for ` dist`` directory. Resulting hash is added to file named as  `/ipfs-hash`. Once docker image is produced you can run following commad to display ipfs-hash:
+Each docker build finishes with hash calculation for `dist` directory. Resulting hash is added to file named as  `/ipfs-hash`. Once docker image is produced you can run following command to display ipfs-hash:
 
 ```bash
 make recalculate-ipfs TAG=vegaprotocol/trading:{YOUR_VERSION}
 ```
 
-**updating hash:** recompiling dist directory (even if there are no changed to source code) results in different hash computed by ipfs command.
+**updating hash:** recompiling dist directory (even if there are no changes to source code) results in different hash computed by ipfs command.
 
 ### nx build outside the docker
 

--- a/docker/node-inside-docker.Dockerfile
+++ b/docker/node-inside-docker.Dockerfile
@@ -1,14 +1,15 @@
 # Build container
 ARG NODE_VERSION
-FROM --platform=amd64 node:${NODE_VERSION}-alpine3.16 as build
+FROM --platform=amd64 node:${NODE_VERSION}-alpine3.18 as build
 WORKDIR /app
 # Argument to allow building of different apps
 ARG APP
 ARG ENV_NAME=""
 RUN apk add --update --no-cache \
-  make==4.3-r0 \
-  gcc==11.2.1_git20220219-r2 \
-  g++==11.2.1_git20220219-r2
+  git \
+  make==4.4.1-r1 \
+  gcc==12.2.1_git20220924-r10 \
+  g++==12.2.1_git20220924-r10
 COPY . ./
 RUN yarn --pure-lockfile
 # work around for different build process in trading


### PR DESCRIPTION
The docker image `node:20.9.1-alpine3.16` does not exist. This fix uses an available image