### PR TITLE
fix(trading,wallet): improve errors from browser wallet

### DIFF
--- a/libs/wallet/src/connectors/injected-connector.ts
+++ b/libs/wallet/src/connectors/injected-connector.ts
@@ -23,6 +23,7 @@ interface InjectedError {
         message: string;
         code: number;
       }
+    | string[]
     | string;
 }
 
@@ -104,11 +105,7 @@ export class InjectedConnector implements Connector {
           throw userRejectedError();
         }
 
-        if (typeof err.data === 'string') {
-          throw sendTransactionError(err.data);
-        } else {
-          throw sendTransactionError(err.data.message);
-        }
+        throw sendTransactionError(JSON.stringify(err.data));
       }
 
       throw sendTransactionError();

--- a/libs/wallet/src/connectors/injected-connector.ts
+++ b/libs/wallet/src/connectors/injected-connector.ts
@@ -49,6 +49,11 @@ export class InjectedConnector implements Connector {
       if (err instanceof ConnectorError) {
         throw err;
       }
+
+      if (this.isInjectedError(err)) {
+        throw connectError(err.message);
+      }
+
       throw connectError();
     }
   }
@@ -67,6 +72,10 @@ export class InjectedConnector implements Connector {
       const res = await window.vega.getChainId();
       return { chainId: res.chainID };
     } catch (err) {
+      if (this.isInjectedError(err)) {
+        throw connectError(err.message);
+      }
+
       throw chainIdError();
     }
   }
@@ -85,6 +94,10 @@ export class InjectedConnector implements Connector {
       const res = await window.vega.isConnected();
       return { connected: res };
     } catch (err) {
+      if (this.isInjectedError(err)) {
+        throw connectError(err.message);
+      }
+
       throw isConnectedError();
     }
   }

--- a/libs/web3/src/lib/use-vega-transaction-toasts.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.tsx
@@ -902,6 +902,7 @@ const VegaTxErrorToastContent = ({ tx }: VegaTxToastContentProps) => {
   const t = useT();
   let label = t('Error occurred');
   let errorMessage = tx.error?.message;
+  const errorData = tx.error instanceof ConnectorError ? tx.error.data : '';
 
   const reconnectVegaWallet = useReconnect();
 
@@ -912,7 +913,7 @@ const VegaTxErrorToastContent = ({ tx }: VegaTxToastContentProps) => {
     ConnectorErrors.noConnector.code,
   ];
 
-  const walletError =
+  const noConnectionError =
     tx.error instanceof ConnectorError &&
     walletNoConnectionCodes.includes(tx.error.code);
 
@@ -926,7 +927,7 @@ const VegaTxErrorToastContent = ({ tx }: VegaTxToastContentProps) => {
     );
   }
 
-  if (walletError) {
+  if (noConnectionError) {
     label = t('Wallet disconnected');
     errorMessage = t('The connection to your Vega Wallet has been lost.');
   }
@@ -935,7 +936,8 @@ const VegaTxErrorToastContent = ({ tx }: VegaTxToastContentProps) => {
     <>
       <ToastHeading>{label}</ToastHeading>
       <p className="first-letter:uppercase">{errorMessage}</p>
-      {walletError && (
+      {errorData && <p className="first-letter:uppercase">{errorData}</p>}
+      {noConnectionError && (
         <Button size="xs" onClick={reconnectVegaWallet}>
           {t('Connect vega wallet')}
         </Button>


### PR DESCRIPTION
# Related issues 🔗

Closes #5736

# Description ℹ️

- `error.message` was correctly being sent through by the wallet but often useful information in `error.data` was not shown.
- Fix useful message from the wallet not being shown for other methods


![Screenshot 2024-03-14 at 09 46 05](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/70f85672-126b-4b29-bc63-2877fedc1b88)
