### PR TITLE
feat(explorer): add full details to oracle page

### DIFF
--- a/apps/explorer/src/app/components/txs/details/shared/tx-details-shared.tsx
+++ b/apps/explorer/src/app/components/txs/details/shared/tx-details-shared.tsx
@@ -48,7 +48,7 @@ export const TxDetailsShared = ({
 }: TxDetailsSharedProps) => {
   const { data } = useExplorerEpochForBlockQuery({
     errorPolicy: 'ignore',
-    variables: { block: txData?.block.toString() || '' },
+    variables: { block: txData?.block?.toString() || '' },
   });
 
   if (!txData) {

--- a/apps/explorer/src/app/components/txs/tx-transfer.spec.tsx
+++ b/apps/explorer/src/app/components/txs/tx-transfer.spec.tsx
@@ -21,7 +21,7 @@ describe('TX: Transfer: getLabelForTransfer', () => {
       },
     };
 
-    expect(getTypeLabelForTransfer(mock)).toEqual('Reward top up transfer');
+    expect(getTypeLabelForTransfer(mock)).toEqual('Reward transfer');
   });
 
   it('renders reward top up label if the TO party is network', () => {
@@ -32,7 +32,7 @@ describe('TX: Transfer: getLabelForTransfer', () => {
       },
     };
 
-    expect(getTypeLabelForTransfer(mock)).toEqual('Reward top up transfer');
+    expect(getTypeLabelForTransfer(mock)).toEqual('Reward transfer');
   });
 
   it('renders recurring label if the tx has a recurring property', () => {
@@ -81,6 +81,7 @@ describe('TxDetailsTransfer', () => {
     hash: 'test',
     submitter:
       'e1943eea46fed576cf2be42972f3c5515ad3d0ac7ac013f56677c12a53a1b3ed',
+    block: '100',
     command: {
       nonce: '5188810881378065222',
       blockHeight: '14951513',

--- a/apps/explorer/src/app/routes/oracles/OraclesForMarkets.graphql
+++ b/apps/explorer/src/app/routes/oracles/OraclesForMarkets.graphql
@@ -89,7 +89,7 @@ fragment ExplorerOracleDataSourceSpec on ExternalDataSourceSpec {
 }
 
 query ExplorerOracleFormMarkets {
-  marketsConnection {
+  marketsConnection(includeSettled: false, pagination: { first: 20 }) {
     edges {
       node {
         ...ExplorerOracleForMarketsMarket
@@ -102,7 +102,7 @@ query ExplorerOracleFormMarkets {
         dataSourceSpec {
           ...ExplorerOracleDataSourceSpec
         }
-        dataConnection(pagination: { last: 1 }) {
+        dataConnection(pagination: { first: 1 }) {
           edges {
             node {
               externalData {

--- a/apps/explorer/src/app/routes/oracles/__generated__/OraclesForMarkets.ts
+++ b/apps/explorer/src/app/routes/oracles/__generated__/OraclesForMarkets.ts
@@ -113,7 +113,7 @@ export const ExplorerOracleDataSourceSpecFragmentDoc = gql`
     `;
 export const ExplorerOracleFormMarketsDocument = gql`
     query ExplorerOracleFormMarkets {
-  marketsConnection {
+  marketsConnection(includeSettled: false, pagination: {first: 20}) {
     edges {
       node {
         ...ExplorerOracleForMarketsMarket
@@ -126,7 +126,7 @@ export const ExplorerOracleFormMarketsDocument = gql`
         dataSourceSpec {
           ...ExplorerOracleDataSourceSpec
         }
-        dataConnection(pagination: {last: 1}) {
+        dataConnection(pagination: {first: 1}) {
           edges {
             node {
               externalData {

--- a/apps/explorer/src/app/routes/oracles/components/oracle-eth-source.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-eth-source.tsx
@@ -8,6 +8,9 @@ import { getExternalChainLabel } from '@vegaprotocol/environment';
 import { t } from 'i18next';
 import { SyntaxHighlighter } from '@vegaprotocol/ui-toolkit';
 import isArray from 'lodash/isArray';
+import type { components } from '../../../../types/explorer';
+
+type Normalisers = components['schemas']['vegaNormaliser'][];
 
 interface OracleDetailsEthSourceProps {
   sourceType: SourceType;
@@ -36,8 +39,9 @@ export function OracleEthSource({
 
   const chainLabel = getExternalChainLabel(chain);
 
-  const abi = prepareAbi(sourceType?.sourceType?.abi);
-  const args = prepareAbi(sourceType?.sourceType?.args);
+  const abi = prepareOracleSpecField(sourceType?.sourceType?.abi);
+  const args = prepareOracleSpecField(sourceType?.sourceType?.args);
+  const normalisers = serialiseNormalisers(sourceType.sourceType.normalisers);
 
   return (
     <TableRow modifier="bordered">
@@ -79,35 +83,72 @@ export function OracleEthSource({
             </>
           )}
 
-          <h2 className={'mt-5 mb-1 text-xl'}>{t('Normalisers')}</h2>
-          <div className="max-w-3 mb-3">
-            <SyntaxHighlighter
-              data={JSON.parse(
-                JSON.stringify(
-                  sourceType.sourceType.normalisers as unknown as string
-                )
-              )}
-            />
-          </div>
+          {normalisers && (
+            <>
+              <h2 className={'mt-5 mb-1 text-xl'}>{t('Normalisers')}</h2>
+              <div className="max-w-3 mb-3">
+                <SyntaxHighlighter data={normalisers} />
+              </div>
+            </>
+          )}
         </details>
       </TableCell>
     </TableRow>
   );
 }
 
+// Constant to define the absence of a valid string from the Oracle Spec fields
 const NO_DATA = false;
 
-export function prepareAbi(abi?: string[] | null): string | false {
-  if (!abi) {
+/**
+ * The ABI and args are stored as either a (JSON escaped, probably) string
+ * or array of strings. Given that OracleEthSource is simply throwing the
+ * data in to a SyntaxHighlighter, we don't really care about the format,
+ * so this function will just try to parse the data and return it as a string.
+ *
+ * @param abi
+ * @returns
+ */
+export function prepareOracleSpecField(
+  specField?: string[] | null
+): string | false {
+  if (!specField) {
     return NO_DATA;
   }
 
   try {
-    if (isArray(abi)) {
-      return JSON.parse(abi.join(''));
+    if (isArray(specField)) {
+      return JSON.parse(specField.join(''));
     } else {
-      return JSON.parse(abi);
+      return JSON.parse(specField);
     }
+  } catch (e) {
+    return NO_DATA;
+  }
+}
+
+/**
+ * Similar to prepareOracleSpecField above, but processes an array of normaliser objects
+ * removing the __typename and returning a serialised array of normalisers for
+ * SyntaxHighlighter
+ *
+ * @param normalisers
+ * @returns
+ */
+export function serialiseNormalisers(
+  normalisers?: Normalisers | null
+): Normalisers | false {
+  if (!normalisers) {
+    return NO_DATA;
+  }
+
+  try {
+    return normalisers.map((normaliser) => {
+      return {
+        name: normaliser.name,
+        expression: normaliser.expression,
+      };
+    });
   } catch (e) {
     return NO_DATA;
   }

--- a/apps/explorer/src/app/routes/oracles/components/oracle-eth-source.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-eth-source.tsx
@@ -6,6 +6,8 @@ import {
 } from '../../../components/links/external-explorer-link/external-explorer-link';
 import { getExternalChainLabel } from '@vegaprotocol/environment';
 import { t } from 'i18next';
+import { SyntaxHighlighter } from '@vegaprotocol/ui-toolkit';
+import isArray from 'lodash/isArray';
 
 interface OracleDetailsEthSourceProps {
   sourceType: SourceType;
@@ -34,21 +36,79 @@ export function OracleEthSource({
 
   const chainLabel = getExternalChainLabel(chain);
 
+  const abi = prepareAbi(sourceType?.sourceType?.abi);
+  const args = prepareAbi(sourceType?.sourceType?.args);
+
   return (
     <TableRow modifier="bordered">
-      <TableHeader scope="row">
+      <TableHeader scope="row" className="pt-1 align-text-top">
         {chainLabel} {t('Contract')}
       </TableHeader>
       <TableCell modifier="bordered">
-        <ExternalExplorerLink
-          chain={chain}
-          id={address}
-          type={EthExplorerLinkTypes.address}
-          code={true}
-        />
-        <span className="mx-3">&rArr;</span>
-        <code>{sourceType.sourceType.method}</code>
+        <details>
+          <summary className="cursor-pointer">
+            <ExternalExplorerLink
+              chain={chain}
+              id={address}
+              type={EthExplorerLinkTypes.address}
+              code={true}
+            />
+            <span className="mx-3">&rArr;</span>
+            <code>{sourceType.sourceType.method}</code>
+          </summary>
+
+          {args && (
+            <>
+              <h2 className={'mt-5 mb-1 text-xl'}>{t('Arguments')}</h2>
+              <div className="max-w-3">
+                <SyntaxHighlighter
+                  data={JSON.parse(
+                    sourceType.sourceType.args as unknown as string
+                  )}
+                />
+              </div>
+            </>
+          )}
+
+          {abi && (
+            <>
+              <h2 className={'mt-5 mb-1 text-xl'}>{t('ABI')}</h2>
+              <div className="max-w-3">
+                <SyntaxHighlighter data={abi} />
+              </div>
+            </>
+          )}
+
+          <h2 className={'mt-5 mb-1 text-xl'}>{t('Normalisers')}</h2>
+          <div className="max-w-3 mb-3">
+            <SyntaxHighlighter
+              data={JSON.parse(
+                JSON.stringify(
+                  sourceType.sourceType.normalisers as unknown as string
+                )
+              )}
+            />
+          </div>
+        </details>
       </TableCell>
     </TableRow>
   );
+}
+
+const NO_DATA = false;
+
+export function prepareAbi(abi?: string[] | null): string | false {
+  if (!abi) {
+    return NO_DATA;
+  }
+
+  try {
+    if (isArray(abi)) {
+      return JSON.parse(abi.join(''));
+    } else {
+      return JSON.parse(abi);
+    }
+  } catch (e) {
+    return NO_DATA;
+  }
 }

--- a/apps/explorer/src/app/routes/oracles/components/oracle-filter.spec.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-filter.spec.tsx
@@ -1,37 +1,8 @@
 import { render } from '@testing-library/react';
 import { OracleFilter } from './oracle-filter';
 import type { ExplorerOracleDataSourceFragment } from '../__generated__/Oracles';
-import {
-  ConditionOperator,
-  DataSourceSpecStatus,
-  PropertyKeyType,
-} from '@vegaprotocol/types';
+import { ConditionOperator, DataSourceSpecStatus } from '@vegaprotocol/types';
 import type { Condition } from '@vegaprotocol/types';
-
-type Spec =
-  ExplorerOracleDataSourceFragment['dataSourceSpec']['spec']['data']['sourceType'];
-
-const mockExternalSpec: Spec = {
-  sourceType: {
-    __typename: 'DataSourceSpecConfiguration',
-    filters: [
-      {
-        __typename: 'Filter',
-        key: {
-          type: PropertyKeyType.TYPE_INTEGER,
-          name: 'testKey',
-        },
-        conditions: [
-          {
-            __typename: 'Condition',
-            value: 'testValue',
-            operator: ConditionOperator.OPERATOR_EQUALS,
-          },
-        ],
-      },
-    ],
-  },
-};
 
 function renderComponent(data: ExplorerOracleDataSourceFragment) {
   return <OracleFilter data={data} />;
@@ -48,31 +19,6 @@ describe('Oracle Filter view', () => {
   it('Renders nothing when data is empty', () => {
     const res = render(renderComponent({} as ExplorerOracleDataSourceFragment));
     expect(res.container).toBeEmptyDOMElement();
-  });
-
-  it('Renders filters if type is DataSourceSpecConfiguration', () => {
-    const res = render(
-      renderComponent({
-        dataSourceSpec: {
-          spec: {
-            id: 'irrelevant-test-data',
-            createdAt: 'irrelevant-test-data',
-            status: DataSourceSpecStatus.STATUS_ACTIVE,
-            data: {
-              sourceType: mockExternalSpec,
-            },
-          },
-        },
-        dataConnection: {
-          edges: [],
-        },
-      })
-    );
-
-    // Renders a comprehensible summary of key = value
-    expect(res.getByText('testKey')).toBeInTheDocument();
-    expect(res.getByText('=')).toBeInTheDocument();
-    expect(res.getByText('testValue')).toBeInTheDocument();
   });
 
   it('Renders conditions if type is DataSourceSpecConfigurationTime', () => {
@@ -136,7 +82,7 @@ describe('Oracle Filter view', () => {
       })
     );
 
-    // This should never happen, but for coverage sake we test that it does this
+    // This should never happen, but for coverage we test that it does this
     const ul = res.getByRole('list');
     expect(ul).toBeInTheDocument();
     expect(ul).toBeEmptyDOMElement();

--- a/apps/explorer/src/app/routes/oracles/components/oracle-filter.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-filter.tsx
@@ -1,5 +1,8 @@
 import type { ExplorerOracleDataSourceFragment } from '../__generated__/Oracles';
-import { OracleSpecInternalTimeTrigger } from './oracle-spec/internal-time-trigger';
+import {
+  OracleSpecInternalTimeTrigger,
+  TimeTrigger,
+} from './oracle-spec/internal-time-trigger';
 import { OracleSpecCondition } from './oracle-spec/condition';
 import { getCharacterForOperator } from './oracle-spec/operator';
 
@@ -11,7 +14,7 @@ interface OracleFilterProps {
  * Shows the conditions that this oracle is using to filter
  * data sources, as a list.
  *
- * Renders nothing if there is no data (which will frequently)
+ * Renders nothing if there is no data (which will frequently
  * be the case) and if there is data, currently renders a simple
  * JSON view.
  */
@@ -21,6 +24,7 @@ export function OracleFilter({ data }: OracleFilterProps) {
   }
 
   const s = data.dataSourceSpec.spec.data.sourceType.sourceType;
+
   if (s.__typename === 'DataSourceSpecConfigurationTime' && s.conditions) {
     return (
       <ul>
@@ -41,30 +45,30 @@ export function OracleFilter({ data }: OracleFilterProps) {
     s.triggers
   ) {
     return <OracleSpecInternalTimeTrigger data={s} />;
-  } else if (
-    s.__typename === 'EthCallSpec' ||
-    s.__typename === 'DataSourceSpecConfiguration'
-  ) {
+  } else if (s.__typename === 'EthCallSpec') {
     if (s.filters !== null && s.filters && 'filters' in s) {
       return (
-        <ul>
-          {s.filters.map((f) => {
-            const prop = <code title={f.key.type}>{f.key.name}</code>;
+        <div>
+          <ul>
+            {s.filters.map((f) => {
+              const prop = <code title={f.key.type}>{f.key.name}</code>;
 
-            if (!f.conditions || f.conditions.length === 0) {
-              return prop;
-            } else {
-              return f.conditions.map((c) => {
-                return (
-                  <li key={`${prop}${c.value}`}>
-                    {prop} {getCharacterForOperator(c.operator)}{' '}
-                    <code>{c.value ? c.value : '-'}</code>
-                  </li>
-                );
-              });
-            }
-          })}
-        </ul>
+              if (!f.conditions || f.conditions.length === 0) {
+                return prop;
+              } else {
+                return f.conditions.map((c) => {
+                  return (
+                    <li key={`${prop}${c.value}`}>
+                      {prop} {getCharacterForOperator(c.operator)}{' '}
+                      <code>{c.value ? c.value : '-'}</code>
+                    </li>
+                  );
+                });
+              }
+            })}
+          </ul>
+          {s.trigger && <TimeTrigger data={s.trigger.trigger} />}
+        </div>
       );
     }
   }

--- a/apps/explorer/src/app/routes/oracles/components/oracle-spec/internal-time-trigger.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-spec/internal-time-trigger.tsx
@@ -1,5 +1,10 @@
 import { t } from '@vegaprotocol/i18n';
-import type { DataSourceSpecConfigurationTimeTrigger } from '@vegaprotocol/types';
+import type {
+  DataSourceSpecConfigurationTimeTrigger,
+  EthTimeTrigger,
+  InternalTimeTrigger,
+  Maybe,
+} from '@vegaprotocol/types';
 import secondsToMinutes from 'date-fns/secondsToMinutes';
 import fromUnixTime from 'date-fns/fromUnixTime';
 
@@ -13,32 +18,40 @@ export function OracleSpecInternalTimeTrigger({
   return (
     <div>
       <span>{t('Time')}</span>,&nbsp;
-      {data.triggers.map((tr) => {
-        return (
-          <span>
-            {tr?.initial ? (
-              <span title={`${tr.initial}`}>
-                <strong>{t('starting at')}</strong>{' '}
-                <em className="not-italic underline decoration-dotted">
-                  {fromUnixTime(tr.initial).toLocaleString()}
-                </em>
-              </span>
-            ) : (
-              ''
-            )}
-            {tr?.every ? (
-              <span title={`${tr.every} ${t('seconds')}`}>
-                , <strong>{t('every')}</strong>{' '}
-                <em className="not-italic underline decoration-dotted">
-                  {secondsToMinutes(tr.every)} {t('minutes')}
-                </em>{' '}
-              </span>
-            ) : (
-              ''
-            )}
-          </span>
-        );
-      })}
+      {data.triggers.map((tr) => (
+        <TimeTrigger data={tr} />
+      ))}
     </div>
+  );
+}
+
+export interface TimeTriggerProps {
+  data: Maybe<InternalTimeTrigger> | Maybe<EthTimeTrigger>;
+}
+
+export function TimeTrigger({ data }: TimeTriggerProps) {
+  return (
+    <span key={JSON.stringify(data)}>
+      {data?.initial ? (
+        <span title={`${data.initial}`}>
+          <strong>{t('starting at')}</strong>{' '}
+          <em className="not-italic underline decoration-dotted">
+            {fromUnixTime(data.initial).toLocaleString()}
+          </em>
+        </span>
+      ) : (
+        ''
+      )}
+      {data?.every ? (
+        <span title={`${data.every} ${t('seconds')}`}>
+          , <strong>{t('every')}</strong>{' '}
+          <em className="not-italic underline decoration-dotted">
+            {secondsToMinutes(data.every)} {t('minutes')}
+          </em>{' '}
+        </span>
+      ) : (
+        ''
+      )}
+    </span>
   );
 }

--- a/apps/explorer/src/app/routes/oracles/components/oracle-spec/internal-time-trigger.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-spec/internal-time-trigger.tsx
@@ -30,14 +30,14 @@ export interface TimeTriggerProps {
 }
 
 export function TimeTrigger({ data }: TimeTriggerProps) {
+  const d = parseDate(data?.initial);
+
   return (
     <span key={JSON.stringify(data)}>
       {data?.initial ? (
         <span title={`${data.initial}`}>
           <strong>{t('starting at')}</strong>{' '}
-          <em className="not-italic underline decoration-dotted">
-            {fromUnixTime(data.initial).toLocaleString()}
-          </em>
+          <em className="not-italic underline decoration-dotted">{d}</em>
         </span>
       ) : (
         ''
@@ -45,7 +45,7 @@ export function TimeTrigger({ data }: TimeTriggerProps) {
       {data?.every ? (
         <span title={`${data.every} ${t('seconds')}`}>
           , <strong>{t('every')}</strong>{' '}
-          <em className="not-italic underline decoration-dotted">
+          <em className="not-italic underline decor</em>ation-dotted">
             {secondsToMinutes(data.every)} {t('minutes')}
           </em>{' '}
         </span>
@@ -54,4 +54,24 @@ export function TimeTrigger({ data }: TimeTriggerProps) {
       )}
     </span>
   );
+}
+
+/**
+ * Dates in oracle triggers can be (or maybe were previously) Unix Time or timestamps
+ * depending on type. This function handles both cases and returns a nicely formatted date.
+ *
+ * @param date
+ * @returns string Localestring for date
+ */
+export function parseDate(date?: string | number): string {
+  if (!date) {
+    return 'Invalid date';
+  }
+  const d = fromUnixTime(+date).toLocaleString();
+
+  if (d === 'Invalid Date') {
+    return new Date(date).toLocaleString();
+  }
+
+  return d;
 }

--- a/apps/explorer/src/app/routes/oracles/components/oracle.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle.tsx
@@ -48,6 +48,11 @@ export const OracleDetails = ({
       ? dataSource.dataSourceSpec.spec.data.sourceType.sourceType.sourceChainId.toString()
       : undefined;
 
+  const requiredConfirmations =
+    (sourceType.sourceType.__typename === 'EthCallSpec' &&
+      sourceType.sourceType.requiredConfirmations) ||
+    '';
+
   return (
     <div>
       <TableWithTbody className="mb-2">
@@ -64,15 +69,23 @@ export const OracleDetails = ({
             {getStatusString(dataSource.dataSourceSpec.spec.status)}
           </TableCell>
         </TableRow>
+        <OracleMarkets id={id} />
         <OracleSigners sourceType={sourceType} />
         <OracleEthSource sourceType={sourceType} chain={chain} />
-        <OracleMarkets id={id} />
         <TableRow modifier="bordered">
-          <TableHeader scope="row">{t('Filter')}</TableHeader>
+          <TableHeader scope="row" className="pt-1 align-text-top">
+            {t('Filter')}
+          </TableHeader>
           <TableCell modifier="bordered">
             <OracleFilter data={dataSource} />
           </TableCell>
         </TableRow>
+        {requiredConfirmations && requiredConfirmations > 0 && (
+          <TableRow modifier="bordered">
+            <TableHeader scope="row">{t('Required Confirmations')}</TableHeader>
+            <TableCell modifier="bordered">{requiredConfirmations}</TableCell>
+          </TableRow>
+        )}
       </TableWithTbody>
       {dataConnection ? <OracleData data={dataConnection} /> : null}
     </div>


### PR DESCRIPTION
- **feat(explorer): show time trigger on non eth oracles**
- **feat(explorer): parsing abi and args**
- **feat(explorer): tidyup normaliser output**

# Related issues 🔗

Closes #5880

# Description ℹ️
Adds missing details to the oracles page:
- Add required confirmations
- Fix time triggers not rendering for some oracle types
- Fix date formatting of triggers for some oracle types
- Add an accordion type view to show ABI, args and normalisers for oracles

# Demo 📺
## Triggers shown on more oracles types + required confirmations, and an expandy section...
<img width="905" alt="Screenshot 2024-03-14 at 12 48 05" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/f679a2b9-a82e-490b-8f35-a2303ee8a073">

## ... that shows the ABI, args and normalisers (if available)
<img width="451" alt="Screenshot 2024-03-14 at 12 48 25" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/4f254f0f-b648-49a8-afc0-202aa7cde56c">

