### PR TITLE
fix(markets,explorer): fallback to ethereum mainnet chain Id if sourceChain is not provided

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -917,7 +917,7 @@ export const EthOraclePanel = ({ sourceType }: { sourceType: EthCallSpec }) => {
             >
               {t('View on {{chainLabel}}', {
                 chainLabel: getExternalChainLabel(
-                  sourceType.sourceChainId.toString()
+                  (sourceType.sourceChainId || 1).toString()
                 ),
               })}
             </EtherscanLink>


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

If no sourceChainId is provided for the oracel spec fall back to chain id 1