### PR TITLE
fix(explorer): fix lp tx filters

### DIFF
--- a/apps/explorer/src/app/components/txs/tx-filter.tsx
+++ b/apps/explorer/src/app/components/txs/tx-filter.tsx
@@ -16,12 +16,12 @@ import { FilterLabel } from './tx-filter-label';
 
 // All possible transaction types. Should be generated.
 export type FilterOption =
-  | 'Amend LiquidityProvision Order'
+  | 'Amend Liquidity Provision Order'
   | 'Amend Order'
   | 'Apply Referral Code'
   | 'Batch Market Instructions'
   | 'Batch Proposal'
-  | 'Cancel LiquidityProvision Order'
+  | 'Cancel Liquidity Provision Order'
   | 'Cancel Order'
   | 'Cancel Transfer Funds'
   | 'Chain Event'
@@ -53,10 +53,10 @@ export type FilterOption =
 
 export const filterOptions: Record<string, FilterOption[]> = {
   'Market Instructions': [
-    'Amend LiquidityProvision Order',
+    'Amend Liquidity Provision Order',
     'Amend Order',
     'Batch Market Instructions',
-    'Cancel LiquidityProvision Order',
+    'Cancel Liquidity Provision Order',
     'Cancel Order',
     'Liquidity Provision Order',
     'Stop Orders Submission',


### PR DESCRIPTION
# Description ℹ️

A typo in the filters for Cancel and Amend LP order meant that filtering the TX list for these transactions
resulted in an empty list.
