### PR TITLE
chore(trading): fix ssr loader server mismatch, remove preload

### DIFF
--- a/apps/trading/pages/_document.page.tsx
+++ b/apps/trading/pages/_document.page.tsx
@@ -12,16 +12,10 @@ export default function Document() {
         {/* preload fonts */}
         <link
           rel="preload"
-          href="/AlphaLyrae.woff"
-          as="font"
-          type="font/woff"
-        />
-
-        <link
-          rel="preload"
           href="/AlphaLyrae.woff2"
           as="font"
           type="font/woff2"
+          crossOrigin="anonymous"
         />
 
         {/* icons */}

--- a/apps/trading/pages/ssr-loader.tsx
+++ b/apps/trading/pages/ssr-loader.tsx
@@ -1,8 +1,8 @@
 import { pseudoRandom } from '@vegaprotocol/ui-toolkit';
-
-const generate = pseudoRandom(1);
+import { useRef } from 'react';
 
 export const SSRLoader = () => {
+  const generateRef = useRef(pseudoRandom(1));
   return (
     <div
       style={{
@@ -38,7 +38,7 @@ export const SSRLoader = () => {
                 width: 10,
                 height: 10,
                 animation: 'flickering 0.4s linear alternate infinite',
-                animationDelay: `-${generate()}s`,
+                animationDelay: `-${generateRef.current()}s`,
                 animationDirection: i % 2 === 0 ? 'reverse' : 'alternate',
                 background: 'black',
               }}


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Fixes a couple annoying issues when running the development server

- Server render mismatch from the client, this was because the seed would not reset between hmr updates
- Preload warning for woff. Because most browsers support woff2 the woff version never gets used resulting in a warning