### PR TITLE
fix(markets): fix link to explorer oracle

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -1948,7 +1948,7 @@ export const PriceConfigurationOraclePanel = ({
             </KeyValueTableRow>
             <ExternalLink
               data-testid="oracle-spec-links"
-              href={`${VEGA_EXPLORER_URL}/market/${marketId}/oracles#${sourceType.address}`}
+              href={`${VEGA_EXPLORER_URL}/markets/${marketId}/oracles#${sourceType.address}`}
               className="text-xs my-1"
             >
               {t('Oracle specification')}


### PR DESCRIPTION
# Description ℹ️

The new link to Explorer, from the Market Info panel, for oracles for a market was incorrect. This PR makes it correct

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/6678/193eaf7d-823f-447d-b3d5-bbda8e3814cc)

* Old and broken: https://explorer.fairground.wtf/market/6291cac44e47d8b89af0b6230296ea8024a30d7fa6630a4c1a1ce784df9e7c4f/oracles#0x719abd606155442c21b7d561426d42bd0e40a776
* New and fixed: https://explorer.fairground.wtf/markets/6291cac44e47d8b89af0b6230296ea8024a30d7fa6630a4c1a1ce784df9e7c4f/oracles#0x719abd606155442c21b7d561426d42bd0e40a776