### PR TITLE
fix(governance): withdrawals dissapearing when the withdraw dialog is opened

### DIFF
--- a/apps/governance/src/i18n/index.ts
+++ b/apps/governance/src/i18n/index.ts
@@ -31,7 +31,7 @@ i18n
     load: 'languageOnly',
     debug: isInDev,
     // have a common namespace used around the full app
-    ns: ['governance', 'wallet', 'wallet-react'],
+    ns: ['governance', 'wallet', 'wallet-react', 'assets', 'utils'],
     defaultNS: 'governance',
     keySeparator: false, // we use content as keys
     nsSeparator: false,


### PR DESCRIPTION
# Related issues 🔗

Closes #5970 

# Description ℹ️

Adds assets and utils to default loaded i18n namespaces. 

Because they weren't included here once the dialog was opened it would fetch the translations, therefore triggering the Suspense component, resulting in the loss of the withdrawals list state