### PR TITLE
fix(trading): do not show tick or cross for rewards that will start in the future

### DIFF
--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -251,6 +251,7 @@ const RewardCard = ({
               vegaAsset={vegaAsset}
               requirements={requirements}
               gameId={gameId}
+              startsIn={startsIn}
             />
           )}
         </div>
@@ -534,12 +535,14 @@ const RewardRequirements = ({
   vegaAsset,
   requirements,
   gameId,
+  startsIn,
 }: {
   dispatchStrategy: DispatchStrategy;
   rewardAsset?: BasicAssetDetails;
   vegaAsset?: BasicAssetDetails;
   requirements?: Requirements;
   gameId?: string | null;
+  startsIn?: number;
 }) => {
   const t = useT();
 
@@ -654,6 +657,7 @@ const RewardRequirements = ({
           >
             {requirements &&
               averagePositionRequirements &&
+              !startsIn &&
               (new BigNumber(averagePosition || 0).isGreaterThan(
                 averagePositionRequirements
               ) ? (


### PR DESCRIPTION
# Related issues 🔗

Closes #6050 

# Description ℹ️

Do not show tick or cross for rewards that will start in the future

# Demo 📺

Fixes: 
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/3f32b31d-17ee-48f3-bd17-dcccf12fbe9e)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
