### PR TITLE
feat(deal-ticket): use order price if markPrice is not available in useMaxSize

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
@@ -8,6 +8,7 @@ import {
   useStaticMarketData,
   useMarketPrice,
   marketInfoProvider,
+  markPriceProvider,
 } from '@vegaprotocol/markets';
 import { AsyncRendererInline } from '@vegaprotocol/ui-toolkit';
 import { DealTicket } from './deal-ticket';
@@ -46,7 +47,11 @@ export const DealTicketContainer = ({
     loading: marketDataLoading,
     reload,
   } = useStaticMarketData(marketId);
-  const { data: marketPrice } = useMarketPrice(market?.id);
+  const { data: marketPrice } = useMarketPrice(marketId);
+  const { data: markPrice } = useDataProvider({
+    dataProvider: markPriceProvider,
+    variables: { marketId },
+  });
   const create = useVegaTransactionStore((state) => state.create);
   return (
     <AsyncRendererInline
@@ -80,6 +85,7 @@ export const DealTicketContainer = ({
               }
               market={market}
               marketPrice={marketPrice}
+              markPrice={markPrice}
               marketData={marketData}
               submit={(transaction) => create(transaction)}
             />

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-fee-details.tsx
@@ -16,17 +16,17 @@ export interface DealTicketFeeDetailsProps {
   assetSymbol: string;
   order: OrderSubmissionBody['orderSubmission'];
   market: Market;
-  isMarketInAuction?: boolean;
+  marketIsInAuction?: boolean;
 }
 
 export const DealTicketFeeDetails = ({
   assetSymbol,
   order,
   market,
-  isMarketInAuction,
+  marketIsInAuction,
 }: DealTicketFeeDetailsProps) => {
   const t = useT();
-  const feeEstimate = useEstimateFees(order, isMarketInAuction);
+  const feeEstimate = useEstimateFees(order, marketIsInAuction);
   const asset = getAsset(market);
   const { decimals: assetDecimals, quantum } = asset;
 

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -393,6 +393,7 @@ export const DealTicket = ({
   const disableIcebergCheckbox = nonPersistentOrder;
   const featureFlags = useFeatureFlags((state) => state.flags);
   const sizeStep = determineSizeStep(market);
+  const marketIsInAuction = isMarketInAuction(marketData.marketTradingMode);
 
   const maxSize = useMaxSize({
     accountDecimals: accountDecimals ?? undefined,
@@ -411,6 +412,7 @@ export const DealTicket = ({
     generalAccountBalance,
     openVolume,
     positionDecimalPlaces: market.positionDecimalPlaces,
+    marketIsInAuction,
   });
 
   const onSubmit = useCallback(
@@ -595,7 +597,7 @@ export const DealTicket = ({
           }
           assetSymbol={assetSymbol}
           market={market}
-          isMarketInAuction={isMarketInAuction(marketData.marketTradingMode)}
+          marketIsInAuction={marketIsInAuction}
         />
       </div>
       <Controller

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -97,6 +97,7 @@ export interface DealTicketProps {
   market: Market;
   marketData: StaticMarketData;
   marketPrice?: string | null;
+  markPrice?: string | null;
   onMarketClick?: (marketId: string, metaKey?: boolean) => void;
   submit: (order: Transaction) => void;
   onDeposit: (assetId: string) => void;
@@ -151,6 +152,7 @@ export const DealTicket = ({
   onMarketClick,
   marketData,
   marketPrice,
+  markPrice,
   submit,
   onDeposit,
 }: DealTicketProps) => {
@@ -402,7 +404,7 @@ export const DealTicket = ({
     marginAccountBalance,
     marginFactor: margin?.marginFactor,
     marginMode: margin?.marginMode,
-    marketPrice: marketPrice ?? undefined,
+    markPrice: markPrice ?? undefined,
     price,
     riskFactors,
     scalingFactors,

--- a/libs/deal-ticket/src/hooks/use-max-size.ts
+++ b/libs/deal-ticket/src/hooks/use-max-size.ts
@@ -13,7 +13,7 @@ interface UseMaxSizeProps {
   marginAccountBalance: string;
   marginFactor?: string;
   marginMode?: MarginMode;
-  marketPrice?: string;
+  markPrice?: string;
   openVolume: string;
   positionDecimalPlaces: number;
   price?: string;
@@ -43,7 +43,7 @@ export const useMaxSize = ({
   activeOrders,
   riskFactors,
   scalingFactors,
-  marketPrice,
+  markPrice,
   marketIsInAuction,
 }: UseMaxSizeProps) =>
   useMemo(() => {
@@ -69,9 +69,7 @@ export const useMaxSize = ({
         .div(toBigNum(price, decimalPlaces));
     } else {
       const effectivePrice =
-        type === OrderType.TYPE_LIMIT && marketIsInAuction
-          ? price
-          : marketPrice;
+        type === OrderType.TYPE_LIMIT && marketIsInAuction ? price : markPrice;
       if (
         !scalingFactors?.initialMargin ||
         !riskFactors ||
@@ -138,5 +136,6 @@ export const useMaxSize = ({
     activeOrders,
     riskFactors,
     scalingFactors,
-    marketPrice,
+    markPrice,
+    marketIsInAuction,
   ]);

--- a/libs/deal-ticket/src/hooks/use-max-size.ts
+++ b/libs/deal-ticket/src/hooks/use-max-size.ts
@@ -66,10 +66,12 @@ export const useMaxSize = ({
         .div(marginFactor)
         .div(toBigNum(price, decimalPlaces));
     } else {
+      const effectivePrice =
+        type === OrderType.TYPE_LIMIT ? marketPrice || price : marketPrice;
       if (
         !scalingFactors?.initialMargin ||
         !riskFactors ||
-        !marketPrice ||
+        !effectivePrice ||
         accountDecimals === undefined
       ) {
         return maxSize;
@@ -86,7 +88,7 @@ export const useMaxSize = ({
           )
         )
         .div(scalingFactors.initialMargin)
-        .div(toBigNum(marketPrice, decimalPlaces));
+        .div(toBigNum(effectivePrice, decimalPlaces));
       maxSize = maxSize
         .minus(
           // subtract remaining orders

--- a/libs/deal-ticket/src/hooks/use-max-size.ts
+++ b/libs/deal-ticket/src/hooks/use-max-size.ts
@@ -24,6 +24,7 @@ interface UseMaxSizeProps {
   side: Side;
   sizeStep: string;
   type: OrderType;
+  marketIsInAuction: boolean;
 }
 
 export const useMaxSize = ({
@@ -43,6 +44,7 @@ export const useMaxSize = ({
   riskFactors,
   scalingFactors,
   marketPrice,
+  marketIsInAuction,
 }: UseMaxSizeProps) =>
   useMemo(() => {
     let maxSize = new BigNumber(0);
@@ -67,7 +69,9 @@ export const useMaxSize = ({
         .div(toBigNum(price, decimalPlaces));
     } else {
       const effectivePrice =
-        type === OrderType.TYPE_LIMIT ? marketPrice || price : marketPrice;
+        type === OrderType.TYPE_LIMIT && marketIsInAuction
+          ? price
+          : marketPrice;
       if (
         !scalingFactors?.initialMargin ||
         !riskFactors ||


### PR DESCRIPTION
# Related issues 🔗

Closes #6047

# Description ℹ️

If market is in action markPrice is not available. In that case when calculating max order size use order price for cross margin limit orders