### PR TITLE
fix(trading): add bg color to depth chart labels to clarify numbers

### DIFF
--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -111,6 +111,8 @@ html [data-theme='light'] {
 
   --pennant-color-volume-buy: theme(colors.market.green.DEFAULT);
   --pennant-color-volume-sell: theme(colors.market.red.DEFAULT);
+
+  --pennant-background-label-color: theme(colors.vega.clight.600);
 }
 
 html [data-theme='dark'] {
@@ -132,6 +134,7 @@ html [data-theme='dark'] {
 
   --pennant-color-volume-buy: theme(colors.market.green.600);
   --pennant-color-volume-sell: theme(colors.market.red.DEFAULT);
+  --pennant-background-label-color: theme(colors.vega.cdark.600);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jsondiffpatch": "^0.4.1",
     "lodash": "^4.17.21",
     "next": "13.3.0",
-    "pennant": "^1.16.2",
+    "pennant": "^1.17.0",
     "react": "18.2.0",
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18374,10 +18374,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-pennant@^1.16.2:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/pennant/-/pennant-1.16.2.tgz#5c6a63a2beda07ff86f7e33400d8570c171ac479"
-  integrity sha512-/n1GzSWZFlgYCfSZubmZA2eiIoOvZPJJP9RKc/u2pOIPlp5Bn2Lq5uKyAT9bvjh/YDQtMhBKf92Q6DxJEDnJNw==
+pennant@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/pennant/-/pennant-1.17.0.tgz#dee8ea466e086ad8a296b08943b3cb85087e618d"
+  integrity sha512-sXU3Uko0lvXfs/gcJOH2o0jUuu0kIHXKZJS0HbsT/Ify7Cr8QoyJG4syHbQovlhEIAwQr4jYHJXTCcoFsnRsdQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@d3fc/d3fc-technical-indicator" "^8.0.1"


### PR DESCRIPTION
# Related issues 🔗

Closes #5198 

# Description ℹ️

- Updates pennant to v1.17.0 so the depth chart label bg can be set
- Adds a bg color to the depth chart labels so they are more distinct from the x axis labels

# Demo 📺

![Screenshot 2024-03-25 at 14 22 52](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/78d5cbcf-0ddd-4733-8c33-83ce6b0dc80e)

![Screenshot 2024-03-25 at 14 23 05](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/44c69fce-1c9b-4b46-b2b5-22f9442f416c)
