### PR TITLE
feat(trading): enhance auction features - part 1 banner and warnings

### DIFF
--- a/apps/trading/components/market-banner/market-monitoring-auction.tsx
+++ b/apps/trading/components/market-banner/market-monitoring-auction.tsx
@@ -1,0 +1,68 @@
+import {
+  marketDataProvider,
+  type MarketFieldsFragment,
+} from '@vegaprotocol/markets';
+import { useT } from '../../lib/use-t';
+import { DocsLinks } from '@vegaprotocol/environment';
+import { ExternalLink } from '@vegaprotocol/ui-toolkit';
+import { getDateTimeFormat, getTimeFormat } from '@vegaprotocol/utils';
+import { useThrottledDataProvider } from '@vegaprotocol/data-provider';
+
+export const MarketAuctionBanner = ({
+  market,
+}: {
+  market: MarketFieldsFragment;
+}) => {
+  const t = useT();
+  const { data: marketData } = useThrottledDataProvider(
+    {
+      dataProvider: marketDataProvider,
+      variables: { marketId: market.id },
+      skip: !market.id,
+    },
+    1000
+  );
+  if (!marketData) return null;
+  const { auctionEnd, auctionStart } = marketData;
+  const startDate =
+    auctionStart && getDateTimeFormat().format(new Date(auctionStart));
+  const endDate =
+    auctionEnd && getDateTimeFormat().format(new Date(auctionEnd));
+
+  const remaining = auctionEnd
+    ? new Date(auctionEnd).getTime() - Date.now()
+    : 0;
+
+  const timeRemaining =
+    remaining > 0 ? getTimeFormat().format(new Date(remaining)) : 0;
+
+  return (
+    <p>
+      <span>
+        {t(
+          'This market is in auction due to high price volatility, but you can still place orders. '
+        )}
+      </span>
+      {timeRemaining && (
+        <span>
+          {t(
+            'Time remaining: {{timeRemaining}} (from {{startDate}} to {{endDate}})',
+            {
+              startDate,
+              endDate,
+              timeRemaining,
+            }
+          )}
+        </span>
+      )}
+      {DocsLinks && (
+        <ExternalLink
+          href={DocsLinks.AUCTION_TYPE_PRICE_MONITORING}
+          className="ml-1"
+        >
+          {t('Find out more')}
+        </ExternalLink>
+      )}
+    </p>
+  );
+};

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -833,6 +833,7 @@ export const DealTicket = ({
         isReadOnly={isReadOnly}
         pubKey={pubKey}
         onDeposit={onDeposit}
+        type={type}
       />
       <Button
         data-testid="place-order"
@@ -885,6 +886,7 @@ interface SummaryMessageProps {
   isReadOnly: boolean;
   pubKey: string | undefined;
   onDeposit: (assetId: string) => void;
+  type: Schema.OrderType;
 }
 
 export const NoWalletWarning = ({
@@ -927,6 +929,7 @@ const SummaryMessage = memo(
     isReadOnly,
     pubKey,
     onDeposit,
+    type,
   }: SummaryMessageProps) => {
     const t = useT();
     // Specific error UI for if balance is so we can
@@ -977,6 +980,19 @@ const SummaryMessage = memo(
         Schema.MarketTradingMode.TRADING_MODE_OPENING_AUCTION,
       ].includes(marketTradingMode)
     ) {
+      if (type === Schema.OrderType.TYPE_MARKET) {
+        return (
+          <div className="mb-2">
+            <Notification
+              intent={Intent.Primary}
+              testId={'deal-ticket-warning-auction'}
+              message={t(
+                'Market orders cannot be placed while in auction, click to switch to limit orders'
+              )}
+            />
+          </div>
+        );
+      }
       return (
         <div className="mb-2">
           <Notification

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -980,7 +980,7 @@ const SummaryMessage = memo(
       return (
         <div className="mb-2">
           <Notification
-            intent={Intent.Warning}
+            intent={Intent.Primary}
             testId={'deal-ticket-warning-auction'}
             message={t(
               'Any orders placed now will not trade until the auction ends'

--- a/libs/i18n/src/locales/en/deal-ticket.json
+++ b/libs/i18n/src/locales/en/deal-ticket.json
@@ -60,6 +60,7 @@
   "Make a deposit": "Make a deposit",
   "Maker fee": "Maker fee",
   "Margin required": "Margin required",
+  "Market orders cannot be placed while in auction, click to switch to limit orders": "Market orders cannot be placed while in auction, click to switch to limit orders",
   "MARGIN_ACCOUNT_TOOLTIP_TEXT": "Margin account balance.",
   "MARGIN_DIFF_TOOLTIP_TEXT": "The additional margin required for your new position (taking into account volume and open orders), compared to your current margin. Measured in the market's settlement asset ({{assetSymbol}}).",
   "Market": "Market",


### PR DESCRIPTION
# Related issues 🔗

Part 1 #6112 

# Description ℹ️

Enhance auction features in console

- [x] Show the normal blue warning banner
- [x]  I can see when the auction started
- [x]  I can see when the auction might end
- [x]  I can see a live countdown to that time
- [x] warnings in blue
- [x] update wording

# Demo 📺

<img width="1679" alt="Screenshot 2024-04-12 at 09 44 44" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/efd37a7c-1d09-4620-85e1-8ddbe58445b1">
<img width="1680" alt="Screenshot 2024-04-12 at 09 51 38" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/04a7cf4a-6c4b-4846-a5bd-762691878118">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
