### PR TITLE
feat(trading): reward cards grouping

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-team.tsx
+++ b/apps/trading/client-pages/competitions/competitions-team.tsx
@@ -14,7 +14,12 @@ import {
   Intent,
   CopyWithTooltip,
 } from '@vegaprotocol/ui-toolkit';
-import { TransferStatus, type Asset } from '@vegaprotocol/types';
+import {
+  type DispatchStrategy,
+  type StakingDispatchStrategy,
+  TransferStatus,
+  type Asset,
+} from '@vegaprotocol/types';
 import classNames from 'classnames';
 import { useT } from '../../lib/use-t';
 import { Table } from '../../components/table';
@@ -139,7 +144,9 @@ const TeamPage = ({
   members?: Member[];
   games?: TeamGame[];
   gamesLoading?: boolean;
-  transfers?: EnrichedRewardTransfer[];
+  transfers?: EnrichedRewardTransfer<
+    DispatchStrategy | StakingDispatchStrategy
+  >[];
   transfersLoading?: boolean;
   allMarkets?: MarketMap;
   refetch: () => void;
@@ -259,7 +266,9 @@ const Games = ({
 }: {
   games?: TeamGame[];
   gamesLoading?: boolean;
-  transfers?: EnrichedRewardTransfer[];
+  transfers?: EnrichedRewardTransfer<
+    DispatchStrategy | StakingDispatchStrategy
+  >[];
   transfersLoading?: boolean;
   allMarkets?: MarketMap;
 }) => {
@@ -539,7 +548,7 @@ const GameTypeCell = ({
   transfer,
   allMarkets,
 }: {
-  transfer?: EnrichedRewardTransfer;
+  transfer?: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>;
   allMarkets?: MarketMap;
 }) => {
   const [open, setOpen] = useState(false);
@@ -578,7 +587,7 @@ const ActiveRewardCardDialog = ({
   open: boolean;
   onChange: (isOpen: boolean) => void;
   trigger?: HTMLElement | null;
-  transfer: EnrichedRewardTransfer;
+  transfer: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>;
   allMarkets?: MarketMap;
 }) => {
   const t = useT();

--- a/apps/trading/components/competitions/games-container.tsx
+++ b/apps/trading/components/competitions/games-container.tsx
@@ -20,6 +20,8 @@ import {
   DispatchMetricLabels,
   EntityScopeLabelMapping,
   AccountType,
+  type DispatchStrategy,
+  type StakingDispatchStrategy,
 } from '@vegaprotocol/types';
 
 export type Filter = {
@@ -81,7 +83,7 @@ export const GamesContainer = ({
   data,
   currentEpoch,
 }: {
-  data: EnrichedRewardTransfer[];
+  data: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>[];
   currentEpoch: number;
 }) => {
   const t = useT();

--- a/apps/trading/components/rewards-container/active-rewards.spec.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.spec.tsx
@@ -4,9 +4,11 @@ import {
   AccountType,
   AssetStatus,
   DispatchMetric,
+  type DispatchStrategy,
   DistributionStrategy,
   EntityScope,
   IndividualScope,
+  type StakingDispatchStrategy,
   TransferStatus,
   type Transfer,
 } from '@vegaprotocol/types';
@@ -24,7 +26,9 @@ jest.mock('../../lib/hooks/__generated__/Rewards', () => ({
 }));
 
 describe('ActiveRewards', () => {
-  const reward: EnrichedRewardTransfer = {
+  const reward: EnrichedRewardTransfer<
+    DispatchStrategy | StakingDispatchStrategy
+  > = {
     __typename: 'TransferNode',
     transfer: {
       __typename: 'Transfer',

--- a/apps/trading/components/rewards-container/active-rewards.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.tsx
@@ -9,16 +9,26 @@ import {
   DispatchMetricLabels,
   EntityScopeLabelMapping,
   AccountType,
+  type DispatchStrategy,
+  type StakingDispatchStrategy,
 } from '@vegaprotocol/types';
 import { Card } from '../card/card';
 import { useState } from 'react';
 import { type AssetFieldsFragment } from '@vegaprotocol/assets';
 import { type MarketFieldsFragment } from '@vegaprotocol/markets';
-import { useRewards } from '../../lib/hooks/use-rewards';
+import {
+  type EnrichedRewardTransfer,
+  useRewards,
+} from '../../lib/hooks/use-rewards';
 import { useMyTeam } from '../../lib/hooks/use-my-team';
 import { useVegaWallet } from '@vegaprotocol/wallet-react';
 import { useStakeAvailable } from '../../lib/hooks/use-stake-available';
-import { ActiveRewardCard, areAllMarketsSettled } from './reward-card';
+import {
+  ActiveRewardCard,
+  GroupRewardCard,
+  areAllMarketsSettled,
+} from './reward-card';
+import { groupBy } from 'lodash';
 
 export type Filter = {
   searchTerm: string;
@@ -99,6 +109,14 @@ export const ActiveRewards = ({ currentEpoch }: { currentEpoch: number }) => {
 
   if (!data || !data.length) return null;
 
+  const cards = data
+    .filter((n) => applyFilter(n, filter))
+    // filter out the cards (rewards) for which all of the markets
+    // are settled
+    .filter((n) => !areAllMarketsSettled(n));
+
+  const groupedCards = Object.values(groupBy(cards, determineCardGroup));
+
   return (
     <Card
       title={t('Active rewards')}
@@ -123,20 +141,44 @@ export const ActiveRewards = ({ currentEpoch }: { currentEpoch: number }) => {
       )}
       {/** CARDS */}
       <div className="grid gap-x-8 gap-y-10 h-fit grid-cols-[repeat(auto-fill,_minmax(230px,_1fr))] md:grid-cols-[repeat(auto-fill,_minmax(230px,_1fr))] lg:grid-cols-[repeat(auto-fill,_minmax(320px,_1fr))] xl:grid-cols-[repeat(auto-fill,_minmax(335px,_1fr))] pr-2">
-        {data
-          .filter((n) => applyFilter(n, filter))
-          // filter out the cards (rewards) for which all of the markets
-          // are settled
-          .filter((n) => !areAllMarketsSettled(n))
-          .map((node, i) => (
-            <ActiveRewardCard
-              key={i}
-              transferNode={node}
-              currentEpoch={currentEpoch}
-              requirements={requirements}
-            />
-          ))}
+        {groupedCards.map((group, i) => {
+          if (group.length === 0) return;
+          if (group.length === 1) {
+            return (
+              <ActiveRewardCard
+                key={i}
+                transferNode={group[0]}
+                currentEpoch={currentEpoch}
+                requirements={requirements}
+              />
+            );
+          } else {
+            return (
+              <GroupRewardCard
+                key={i}
+                transferNodes={group}
+                currentEpoch={currentEpoch}
+                requirements={requirements}
+              />
+            );
+          }
+        })}
       </div>
     </Card>
   );
 };
+
+const determineCardGroup = (
+  reward: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>
+) =>
+  [
+    // groups by:
+    // reward asset (usually VEGA)
+    reward.transfer.asset?.symbol,
+    // reward for (dispatch metric)
+    reward.transfer.kind.dispatchStrategy.dispatchMetric,
+    // reward scope (teams vs individuals)
+    reward.transfer.kind.dispatchStrategy.entityScope,
+    // reward distribution strategy
+    reward.transfer.kind.dispatchStrategy.distributionStrategy,
+  ].join('-');

--- a/apps/trading/components/rewards-container/active-rewards.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.tsx
@@ -19,6 +19,7 @@ import { type MarketFieldsFragment } from '@vegaprotocol/markets';
 import {
   type EnrichedRewardTransfer,
   useRewards,
+  isScopedToTeams,
 } from '../../lib/hooks/use-rewards';
 import { useMyTeam } from '../../lib/hooks/use-my-team';
 import { useVegaWallet } from '@vegaprotocol/wallet-react';
@@ -87,9 +88,13 @@ export const applyFilter = (
 
 export const ActiveRewards = ({ currentEpoch }: { currentEpoch: number }) => {
   const t = useT();
-  const { data } = useRewards({
+  const { data: allRewards } = useRewards({
     onlyActive: true,
   });
+  // filter out the rewards that are scoped to teams on this page
+  // we display those on the `Competitions` page
+  const data = allRewards.filter((r) => !isScopedToTeams(r));
+
   const { pubKey } = useVegaWallet();
   const { team } = useMyTeam();
   const { stakeAvailable, isEligible, requiredStake } = useStakeAvailable();

--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -50,6 +50,7 @@ import { Link } from 'react-router-dom';
 import max from 'lodash/max';
 import min from 'lodash/min';
 import flatten from 'lodash/flatten';
+import sum from 'lodash/sum';
 
 const Tick = () => (
   <VegaIcon
@@ -998,7 +999,7 @@ export const GroupRewardCard = ({
   const rewardAmounts = transferNodes.map((n) =>
     toBigNum(n.transfer.amount, n.transfer.asset?.decimals || 0).toNumber()
   );
-  const maxRewardAmount = max(rewardAmounts) as number;
+  const maxRewardAmount = sum(rewardAmounts) as number;
   const rewardAmount = formatNumber(maxRewardAmount, 6);
 
   const transferAsset = transferNodes[0].transfer.asset || undefined;

--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -100,10 +100,10 @@ const GroupCard = ({
   const t = useT();
 
   return (
-    <div data-reward-card>
+    <div data-reward-card className="min-h-[366px] h-full">
       <div
         className={classNames(
-          'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full min-h-[360px]',
+          'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full',
           'rounded-lg',
           CardColourStyles[colour].gradientClassName
         )}
@@ -264,7 +264,7 @@ const RewardCard = ({
   const t = useT();
 
   return (
-    <div data-reward-card className="h-full">
+    <div data-reward-card className="min-h-[366px] h-full">
       <div
         className={classNames(
           'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full',
@@ -365,78 +365,80 @@ const RewardCard = ({
             </div>
           </div>
 
-          {/** DISPATCH METRIC */}
-          <div>
-            {dispatchMetricInfo ? (
-              dispatchMetricInfo
-            ) : (
-              <span data-testid="dispatch-metric-info">
-                {DispatchMetricLabels[dispatchStrategy.dispatchMetric]}
-              </span>
-            )}
-          </div>
+          <div className="h-full flex flex-col gap-4">
+            {/** DISPATCH METRIC */}
+            <div>
+              {dispatchMetricInfo ? (
+                dispatchMetricInfo
+              ) : (
+                <span data-testid="dispatch-metric-info">
+                  {DispatchMetricLabels[dispatchStrategy.dispatchMetric]}
+                </span>
+              )}
+            </div>
 
-          <div className="flex items-center gap-8 flex-wrap">
-            {/** ENDS IN or STARTS IN */}
-            {startsIn ? (
+            <div className="flex items-center gap-8 flex-wrap">
+              {/** ENDS IN or STARTS IN */}
+              {startsIn ? (
+                <span className="flex flex-col">
+                  <span className="text-muted text-xs">{t('Starts in')} </span>
+                  <span data-testid="starts-in" data-startsin={startsIn}>
+                    {t('numberEpochs', '{{count}} epochs', {
+                      count: startsIn,
+                    })}
+                  </span>
+                </span>
+              ) : (
+                endsIn && (
+                  <span className="flex flex-col">
+                    <span className="text-muted text-xs">{t('Ends in')} </span>
+                    <span data-testid="ends-in" data-endsin={endsIn}>
+                      {endsIn >= 0
+                        ? t('numberEpochs', '{{count}} epochs', {
+                            count: endsIn,
+                          })
+                        : t('Ended')}
+                    </span>
+                  </span>
+                )
+              )}
+              {/** WINDOW LENGTH */}
               <span className="flex flex-col">
-                <span className="text-muted text-xs">{t('Starts in')} </span>
-                <span data-testid="starts-in" data-startsin={startsIn}>
+                <span className="text-muted text-xs">{t('Assessed over')}</span>
+                <span data-testid="assessed-over">
                   {t('numberEpochs', '{{count}} epochs', {
-                    count: startsIn,
+                    count: dispatchStrategy.windowLength,
                   })}
                 </span>
               </span>
-            ) : (
-              endsIn && (
+              {/** CAPPED AT */}
+              {dispatchStrategy.capRewardFeeMultiple && (
                 <span className="flex flex-col">
-                  <span className="text-muted text-xs">{t('Ends in')} </span>
-                  <span data-testid="ends-in" data-endsin={endsIn}>
-                    {endsIn >= 0
-                      ? t('numberEpochs', '{{count}} epochs', {
-                          count: endsIn,
-                        })
-                      : t('Ended')}
-                  </span>
+                  <span className="text-muted text-xs">{t('Capped at')}</span>
+                  <Tooltip
+                    description={t(
+                      'Reward will be capped at {{capRewardFeeMultiple}} X of taker fees paid in the epoch',
+                      {
+                        capRewardFeeMultiple:
+                          dispatchStrategy.capRewardFeeMultiple,
+                      }
+                    )}
+                  >
+                    <span data-testid="cappedAt">
+                      x{dispatchStrategy.capRewardFeeMultiple}
+                    </span>
+                  </Tooltip>
                 </span>
-              )
-            )}
-            {/** WINDOW LENGTH */}
-            <span className="flex flex-col">
-              <span className="text-muted text-xs">{t('Assessed over')}</span>
-              <span data-testid="assessed-over">
-                {t('numberEpochs', '{{count}} epochs', {
-                  count: dispatchStrategy.windowLength,
-                })}
-              </span>
-            </span>
-            {/** CAPPED AT */}
-            {dispatchStrategy.capRewardFeeMultiple && (
-              <span className="flex flex-col">
-                <span className="text-muted text-xs">{t('Capped at')}</span>
-                <Tooltip
-                  description={t(
-                    'Reward will be capped at {{capRewardFeeMultiple}} X of taker fees paid in the epoch',
-                    {
-                      capRewardFeeMultiple:
-                        dispatchStrategy.capRewardFeeMultiple,
-                    }
-                  )}
-                >
-                  <span data-testid="cappedAt">
-                    x{dispatchStrategy.capRewardFeeMultiple}
-                  </span>
-                </Tooltip>
-              </span>
+              )}
+            </div>
+
+            {/** DISPATCH METRIC DESCRIPTION */}
+            {dispatchStrategy?.dispatchMetric && (
+              <p className="text-muted text-sm">
+                {t(DispatchMetricDescription[dispatchStrategy?.dispatchMetric])}
+              </p>
             )}
           </div>
-
-          {/** DISPATCH METRIC DESCRIPTION */}
-          {dispatchStrategy?.dispatchMetric && (
-            <p className="text-muted text-sm">
-              {t(DispatchMetricDescription[dispatchStrategy?.dispatchMetric])}
-            </p>
-          )}
 
           {/** REQUIREMENTS */}
           {dispatchStrategy && (

--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -1,5 +1,9 @@
 import { useT } from '../../lib/use-t';
-import { addDecimalsFormatNumber, formatNumber } from '@vegaprotocol/utils';
+import {
+  addDecimalsFormatNumber,
+  formatNumber,
+  toBigNum,
+} from '@vegaprotocol/utils';
 import classNames from 'classnames';
 import {
   type VegaIconSize,
@@ -7,6 +11,8 @@ import {
   VegaIcon,
   VegaIconNames,
   truncateMiddle,
+  TradingButton,
+  Dialog,
 } from '@vegaprotocol/ui-toolkit';
 import {
   DistributionStrategyDescriptionMapping,
@@ -20,16 +26,20 @@ import {
   MarketState,
   type DispatchStrategy,
   IndividualScopeDescriptionMapping,
-  AccountType,
-  DistributionStrategy,
   IndividualScope,
   type Asset,
   type Team,
   IndividualScopeMapping,
+  type StakingRewardMetric,
+  type StakingDispatchStrategy,
+  type DistributionStrategy,
 } from '@vegaprotocol/types';
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { type BasicAssetDetails } from '@vegaprotocol/assets';
-import { type EnrichedRewardTransfer } from '../../lib/hooks/use-rewards';
+import {
+  isScopedToTeams,
+  type EnrichedRewardTransfer,
+} from '../../lib/hooks/use-rewards';
 import compact from 'lodash/compact';
 import BigNumber from 'bignumber.js';
 import { useTWAPQuery } from '../../lib/hooks/__generated__/Rewards';
@@ -37,6 +47,9 @@ import { RankPayoutTable } from './rank-table';
 import { useFeatureFlags } from '@vegaprotocol/environment';
 import { Links } from '../../lib/links';
 import { Link } from 'react-router-dom';
+import max from 'lodash/max';
+import min from 'lodash/min';
+import flatten from 'lodash/flatten';
 
 const Tick = () => (
   <VegaIcon
@@ -62,10 +75,162 @@ export type Requirements = {
   pubKey: string;
 };
 
+const GroupCard = ({
+  colour,
+  rewardAmount,
+  dispatchMetric,
+  transferAsset,
+  entityScope,
+  distributionStrategy,
+  distributionDelay,
+  count,
+  onClick,
+}: {
+  colour: CardColour;
+  rewardAmount: string;
+  dispatchMetric: DispatchMetric | StakingDispatchStrategy['dispatchMetric'];
+  transferAsset?: Asset | undefined;
+  entityScope?: EntityScope;
+  distributionStrategy?: DistributionStrategy;
+  distributionDelay?: string | number;
+  count: number;
+  onClick: () => void;
+}) => {
+  const t = useT();
+
+  return (
+    <div data-reward-card>
+      <div
+        className={classNames(
+          'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full min-h-[360px]',
+          'rounded-lg',
+          CardColourStyles[colour].gradientClassName
+        )}
+        data-testid="active-rewards-card"
+      >
+        <div
+          className={classNames(
+            CardColourStyles[colour].mainClassName,
+            'bg-gradient-to-b bg-vega-clight-800 dark:bg-vega-cdark-800 h-full w-full rounded-md p-4',
+            'flex flex-col gap-4 justify-items-start'
+          )}
+        >
+          <div
+            className={classNames(
+              'flex justify-between gap-2',
+              'pb-3 border-b-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500'
+            )}
+          >
+            {/** ENTITY SCOPE */}
+            <div className="flex flex-col gap-2 items-center text-center">
+              {entityScope && (
+                <>
+                  <EntityIcon entityScope={entityScope} />
+                  <span
+                    className="text-muted text-xs"
+                    data-testid="entity-scope"
+                  >
+                    {EntityScopeLabelMapping[entityScope] || t('Unspecified')}
+                  </span>
+                </>
+              )}
+            </div>
+
+            {/** AMOUNT AND DISTRIBUTION STRATEGY */}
+            <div className="flex flex-col gap-2 items-center text-center">
+              {/** AMOUNT */}
+              <h3 className="flex flex-col gap-1 text-2xl shrink-1 text-center">
+                <span>
+                  {t('Up to')}{' '}
+                  <span className="font-glitch" data-testid="reward-value">
+                    {rewardAmount}
+                  </span>
+                </span>
+
+                <span className="font-alpha" data-testid="reward-asset">
+                  {transferAsset?.symbol || ''}
+                </span>
+              </h3>
+
+              {/** DISTRIBUTION STRATEGY */}
+              {distributionStrategy && (
+                <Tooltip
+                  description={
+                    <div className="flex flex-col gap-4">
+                      <p>
+                        {t(
+                          DistributionStrategyDescriptionMapping[
+                            distributionStrategy
+                          ]
+                        )}
+                        .
+                      </p>
+                    </div>
+                  }
+                  underline={true}
+                >
+                  <span className="text-xs" data-testid="distribution-strategy">
+                    {DistributionStrategyMapping[distributionStrategy]}
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+
+            {/** DISTRIBUTION DELAY */}
+            <div className="flex flex-col gap-2 items-center text-center">
+              <CardIcon
+                iconName={VegaIconNames.LOCK}
+                tooltip={t(
+                  'Number of epochs after distribution to delay vesting of rewards by'
+                )}
+              />
+              <span
+                className="text-muted text-xs whitespace-nowrap"
+                data-testid="locked-for"
+              >
+                {typeof distributionDelay === 'number'
+                  ? t('numberEpochs', '{{count}} epochs', {
+                      count: distributionDelay,
+                    })
+                  : t('numberEpochs', '{{count}} epochs', {
+                      replace: {
+                        count: distributionDelay,
+                      },
+                    })}
+              </span>
+            </div>
+          </div>
+
+          <div className={classNames('flex flex-col gap-3 h-full')}>
+            {/** DISPATCH METRIC */}
+            <span data-testid="dispatch-metric-info">
+              {DispatchMetricLabels[dispatchMetric]}
+            </span>
+            {/** DISPATCH METRIC DESCRIPTION */}
+            <p className="text-muted text-sm">
+              {t(DispatchMetricDescription[dispatchMetric])}
+            </p>
+          </div>
+
+          <div>
+            <TradingButton
+              intent={null}
+              className={classNames(CardColourStyles[colour].btn, 'w-full')}
+              onClick={onClick}
+            >
+              {t('See details of {{count}} rewards', { count })}
+            </TradingButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const RewardCard = ({
   colour,
   rewardAmount,
-  rewardAsset,
+  dispatchAsset,
   transferAsset,
   vegaAsset,
   dispatchStrategy,
@@ -78,13 +243,13 @@ const RewardCard = ({
   colour: CardColour;
   rewardAmount: string;
   /** The asset linked to the dispatch strategy via `dispatchMetricAssetId` property. */
-  rewardAsset?: BasicAssetDetails;
+  dispatchAsset?: BasicAssetDetails;
   /** The VEGA asset details, required to format the min staking amount. */
   transferAsset?: Asset | undefined;
   /** The VEGA asset details, required to format the min staking amount. */
   vegaAsset?: BasicAssetDetails;
   /** The transfer's dispatch strategy. */
-  dispatchStrategy: DispatchStrategy;
+  dispatchStrategy: DispatchStrategy | StakingDispatchStrategy;
   /** The number of epochs until the transfer starts. */
   startsIn?: number;
   /** The number of epochs until the transfer stops. */
@@ -98,7 +263,7 @@ const RewardCard = ({
   const t = useT();
 
   return (
-    <div>
+    <div data-reward-card className="h-full">
       <div
         className={classNames(
           'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full',
@@ -113,7 +278,12 @@ const RewardCard = ({
             'bg-gradient-to-b bg-vega-clight-800 dark:bg-vega-cdark-800 h-full w-full rounded-md p-4 flex flex-col gap-4'
           )}
         >
-          <div className="flex justify-between gap-4">
+          <div
+            className={classNames(
+              'flex justify-between gap-4',
+              'pb-4 border-b-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500'
+            )}
+          >
             {/** ENTITY SCOPE */}
             <div className="flex flex-col gap-2 items-center text-center">
               <EntityIcon entityScope={dispatchStrategy.entityScope} />
@@ -194,15 +364,16 @@ const RewardCard = ({
             </div>
           </div>
 
-          <span className="border-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500" />
           {/** DISPATCH METRIC */}
-          {dispatchMetricInfo ? (
-            dispatchMetricInfo
-          ) : (
-            <span data-testid="dispatch-metric-info">
-              {DispatchMetricLabels[dispatchStrategy.dispatchMetric]}
-            </span>
-          )}
+          <div>
+            {dispatchMetricInfo ? (
+              dispatchMetricInfo
+            ) : (
+              <span data-testid="dispatch-metric-info">
+                {DispatchMetricLabels[dispatchStrategy.dispatchMetric]}
+              </span>
+            )}
+          </div>
 
           <div className="flex items-center gap-8 flex-wrap">
             {/** ENDS IN or STARTS IN */}
@@ -261,251 +432,24 @@ const RewardCard = ({
 
           {/** DISPATCH METRIC DESCRIPTION */}
           {dispatchStrategy?.dispatchMetric && (
-            <p className="text-muted text-sm h-16">
+            <p className="text-muted text-sm">
               {t(DispatchMetricDescription[dispatchStrategy?.dispatchMetric])}
             </p>
           )}
-          <span className="border-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500" />
+
           {/** REQUIREMENTS */}
           {dispatchStrategy && (
-            <RewardRequirements
-              dispatchStrategy={dispatchStrategy}
-              rewardAsset={rewardAsset}
-              vegaAsset={vegaAsset}
-              requirements={requirements}
-              gameId={gameId}
-              startsIn={startsIn}
-            />
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const StakingRewardCard = ({
-  colour,
-  rewardAmount,
-  rewardAsset,
-  startsIn,
-  endsIn,
-  requirements,
-  vegaAsset,
-  gameId,
-}: {
-  colour: CardColour;
-  rewardAmount: string;
-  /** The asset linked to the dispatch strategy via `dispatchMetricAssetId` property. */
-  rewardAsset?: Asset;
-  /** The number of epochs until the transfer starts. */
-  startsIn?: number;
-  /** The number of epochs until the transfer stops. */
-  endsIn?: number;
-  /** The VEGA asset details, required to format the min staking amount. */
-  vegaAsset?: BasicAssetDetails;
-  /** Eligibility requirements for rewards */
-  requirements?: Requirements;
-  /** The game id of the transfer */
-  gameId?: string | null;
-}) => {
-  const t = useT();
-  const stakeAvailable = requirements?.stakeAvailable;
-  const tickOrCross = requirements ? (
-    stakeAvailable && stakeAvailable > 1 ? (
-      <Tick />
-    ) : (
-      <Cross />
-    )
-  ) : null;
-  return (
-    <div>
-      <div
-        className={classNames(
-          'bg-gradient-to-r col-span-full p-0.5 lg:col-auto h-full',
-          'rounded-lg',
-          CardColourStyles[colour].gradientClassName
-        )}
-        data-testid="active-rewards-card"
-      >
-        <div
-          className={classNames(
-            CardColourStyles[colour].mainClassName,
-            'bg-gradient-to-b bg-vega-clight-800 dark:bg-vega-cdark-800 h-full w-full rounded-md p-4 flex flex-col gap-4'
-          )}
-        >
-          <div className="flex justify-between gap-4">
-            {/** ENTITY SCOPE */}
-            <div className="flex flex-col gap-2 items-center text-center">
-              <EntityIcon entityScope={EntityScope.ENTITY_SCOPE_INDIVIDUALS} />
-              {
-                <span className="text-muted text-xs" data-testid="entity-scope">
-                  {EntityScopeLabelMapping[
-                    EntityScope.ENTITY_SCOPE_INDIVIDUALS
-                  ] || t('Unspecified')}
-                </span>
-              }
-            </div>
-
-            {/** AMOUNT AND DISTRIBUTION STRATEGY */}
-            <div className="flex flex-col gap-2 items-center text-center">
-              {/** AMOUNT */}
-              <h3 className="flex flex-col gap-1 text-2xl shrink-1 text-center">
-                <span className="font-glitch" data-testid="reward-value">
-                  {rewardAmount}
-                </span>
-
-                <span className="font-alpha">{rewardAsset?.symbol || ''}</span>
-              </h3>
-
-              {/** DISTRIBUTION STRATEGY */}
-              <Tooltip
-                description={t(
-                  DistributionStrategyDescriptionMapping[
-                    DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA
-                  ]
-                )}
-                underline={true}
-              >
-                <span className="text-xs" data-testid="distribution-strategy">
-                  {
-                    DistributionStrategyMapping[
-                      DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA
-                    ]
-                  }
-                </span>
-              </Tooltip>
-            </div>
-
-            {/** DISTRIBUTION DELAY */}
-            <div className="flex flex-col gap-2 items-center text-center">
-              <CardIcon
-                iconName={VegaIconNames.LOCK}
-                tooltip={t(
-                  'Number of epochs after distribution to delay vesting of rewards by'
-                )}
+            <div className="pt-4 border-t-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500">
+              <RewardRequirements
+                dispatchStrategy={dispatchStrategy}
+                dispatchAsset={dispatchAsset}
+                vegaAsset={vegaAsset}
+                requirements={requirements}
+                gameId={gameId}
+                startsIn={startsIn}
               />
-              <span
-                className="text-muted text-xs whitespace-nowrap"
-                data-testid="locked-for"
-              >
-                {t('numberEpochs', '{{count}} epochs', {
-                  count: 0,
-                })}
-              </span>
             </div>
-          </div>
-
-          <span className="border-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500" />
-          {/** DISPATCH METRIC */}
-          {
-            <span data-testid="dispatch-metric-info">
-              {t('Staking rewards')}
-            </span>
-          }
-          <div className="flex items-center gap-8 flex-wrap">
-            {/** ENDS IN or STARTS IN */}
-            {startsIn ? (
-              <span className="flex flex-col">
-                <span className="text-muted text-xs">{t('Starts in')} </span>
-                <span data-testid="starts-in" data-startsin={startsIn}>
-                  {t('numberEpochs', '{{count}} epochs', {
-                    count: startsIn,
-                  })}
-                </span>
-              </span>
-            ) : (
-              endsIn && (
-                <span className="flex flex-col">
-                  <span className="text-muted text-xs">{t('Ends in')} </span>
-                  <span data-testid="ends-in" data-endsin={endsIn}>
-                    {endsIn >= 0
-                      ? t('numberEpochs', '{{count}} epochs', {
-                          count: endsIn,
-                        })
-                      : t('Ended')}
-                  </span>
-                </span>
-              )
-            )}
-
-            {/** WINDOW LENGTH */}
-            <span className="flex flex-col">
-              <span className="text-muted text-xs">{t('Assessed over')}</span>
-              <span data-testid="assessed-over">
-                {t('numberEpochs', '{{count}} epochs', {
-                  count: 1,
-                })}
-              </span>
-            </span>
-          </div>
-          {/** DISPATCH METRIC DESCRIPTION */}
-          {
-            <p className="text-muted text-sm h-16">
-              {t(
-                'Global staking reward for staking $VEGA on the network via the Governance app'
-              )}
-            </p>
-          }
-          <span className="border-[0.5px] dark:border-vega-cdark-500 border-vega-clight-500" />
-          {/** REQUIREMENTS */}
-          <dl className="flex justify-between flex-wrap items-center gap-3 text-xs">
-            <div className="flex flex-col gap-1">
-              <dt className="flex items-center gap-1 text-muted">
-                {t('Team scope')}
-              </dt>
-              <dd className="flex items-center gap-1" data-testid="scope">
-                <Tooltip
-                  description={
-                    IndividualScopeDescriptionMapping[
-                      IndividualScope.INDIVIDUAL_SCOPE_ALL
-                    ]
-                  }
-                >
-                  <span>
-                    {tickOrCross} {t('Individual')}
-                  </span>
-                </Tooltip>
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1">
-              <dt className="flex items-center gap-1 text-muted">
-                {t('Staked VEGA')}
-              </dt>
-              <dd
-                className="flex items-center gap-1"
-                data-testid="staking-requirement"
-              >
-                {stakeAvailable ? (
-                  stakeAvailable > 1 ? (
-                    <Tick />
-                  ) : (
-                    <Cross />
-                  )
-                ) : undefined}
-                {stakeAvailable
-                  ? addDecimalsFormatNumber(
-                      stakeAvailable?.toString() || '0',
-                      vegaAsset?.decimals || 18, // vega asset decimals
-                      6
-                    )
-                  : '1.00'}
-              </dd>
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <dt className="flex items-center gap-1 text-muted">
-                {t('Average position')}
-              </dt>
-              <dd
-                className="flex items-center gap-1"
-                data-testid="average-position"
-              >
-                {' '}
-                {tickOrCross}
-                {formatNumber(0, 2)}
-              </dd>
-            </div>
-          </dl>
+          )}
         </div>
       </div>
     </div>
@@ -515,10 +459,10 @@ const StakingRewardCard = ({
 export const DispatchMetricInfo = ({
   reward,
 }: {
-  reward: EnrichedRewardTransfer;
+  reward: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>;
 }) => {
   const t = useT();
-  const dispatchStrategy = reward.transfer.kind.dispatchStrategy;
+  const dispatchMetric = reward.transfer.kind.dispatchStrategy?.dispatchMetric;
   const marketNames = compact(
     reward.markets?.map((m) => m.tradableInstrument.instrument.name)
   );
@@ -544,7 +488,7 @@ export const DispatchMetricInfo = ({
 
   return (
     <span data-testid="dispatch-metric-info" className="h-12">
-      {DispatchMetricLabels[dispatchStrategy.dispatchMetric]}
+      {dispatchMetric ? DispatchMetricLabels[dispatchMetric] : t('Unknown')}
       {additionalDispatchMetricInfo != null && (
         <> • {additionalDispatchMetricInfo}</>
       )}
@@ -554,14 +498,14 @@ export const DispatchMetricInfo = ({
 
 const RewardRequirements = ({
   dispatchStrategy,
-  rewardAsset,
+  dispatchAsset,
   vegaAsset,
   requirements,
   gameId,
   startsIn,
 }: {
-  dispatchStrategy: DispatchStrategy;
-  rewardAsset?: BasicAssetDetails;
+  dispatchStrategy: DispatchStrategy | StakingDispatchStrategy;
+  dispatchAsset?: BasicAssetDetails;
   vegaAsset?: BasicAssetDetails;
   requirements?: Requirements;
   gameId?: string | null;
@@ -582,7 +526,7 @@ const RewardRequirements = ({
     variables: {
       gameId: gameId || '',
       partyId: requirements?.pubKey || '',
-      assetId: rewardAsset?.id || '',
+      assetId: dispatchAsset?.id || '',
     },
     skip: !featureFlags.TWAP_REWARDS || !requirements,
     errorPolicy: 'ignore',
@@ -592,17 +536,18 @@ const RewardRequirements = ({
 
   const averagePositionFormatted =
     averagePosition &&
-    addDecimalsFormatNumber(averagePosition, rewardAsset?.decimals || 0);
+    addDecimalsFormatNumber(averagePosition, dispatchAsset?.decimals || 0);
 
   const averagePositionRequirementsFormatted =
     averagePositionRequirements &&
     addDecimalsFormatNumber(
       averagePositionRequirements,
-      rewardAsset?.decimals || 0
+      dispatchAsset?.decimals || 0
     );
 
   return (
     <dl className="flex justify-between flex-wrap items-center gap-3 text-xs">
+      {/** SCOPE */}
       <div className="flex flex-col gap-1">
         <dt className="flex items-center gap-1 text-muted">
           {entityLabel
@@ -619,6 +564,7 @@ const RewardRequirements = ({
         </dd>
       </div>
 
+      {/** STAKING REQUIREMENT */}
       <div className="flex flex-col gap-1">
         <dt className="flex items-center gap-1 text-muted">
           {t('Staked VEGA')}
@@ -651,6 +597,7 @@ const RewardRequirements = ({
         </dd>
       </div>
 
+      {/** AVERAGE POSITION REQUIREMENT */}
       <div className="flex flex-col gap-1">
         <dt className="flex items-center gap-1 text-muted">
           {t('Average position')}
@@ -705,7 +652,7 @@ const RewardEntityScope = ({
   dispatchStrategy,
   requirements,
 }: {
-  dispatchStrategy: DispatchStrategy;
+  dispatchStrategy: DispatchStrategy | StakingDispatchStrategy;
   requirements?: Requirements;
 }) => {
   const t = useT();
@@ -849,44 +796,55 @@ enum CardColour {
 
 const CardColourStyles: Record<
   CardColour,
-  { gradientClassName: string; mainClassName: string }
+  { gradientClassName: string; mainClassName: string; btn: string }
 > = {
   [CardColour.BLUE]: {
     gradientClassName: 'from-vega-blue-500 to-vega-green-400',
     mainClassName: 'from-vega-blue-400 dark:from-vega-blue-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-blue-500 from-50% to-vega-green-400 !text-white',
   },
   [CardColour.GREEN]: {
     gradientClassName: 'from-vega-green-500 to-vega-yellow-500',
     mainClassName: 'from-vega-green-400 dark:from-vega-green-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-green-500 from-50% to-vega-yellow-400 !text-black',
   },
   [CardColour.GREY]: {
     gradientClassName: 'from-vega-cdark-500 to-vega-clight-200',
     mainClassName: 'from-vega-cdark-400 dark:from-vega-cdark-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-cdark-500 from-50% to-vega-clight-200 !text-white',
   },
   [CardColour.ORANGE]: {
     gradientClassName: 'from-vega-orange-500 to-vega-pink-400',
     mainClassName: 'from-vega-orange-400 dark:from-vega-orange-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-orange-500 from-50% to-vega-pink-600 !text-black',
   },
   [CardColour.PINK]: {
     gradientClassName: 'from-vega-pink-500 to-vega-purple-400',
     mainClassName: 'from-vega-pink-400 dark:from-vega-pink-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-pink-500 from-50% to-vega-purple-600 !text-white',
   },
   [CardColour.PURPLE]: {
     gradientClassName: 'from-vega-purple-500 to-vega-blue-400',
     mainClassName: 'from-vega-purple-400 dark:from-vega-purple-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-purple-500 from-50% to-vega-blue-600 !text-white',
   },
   [CardColour.WHITE]: {
     gradientClassName:
       'from-vega-clight-600 dark:from-vega-clight-900 to-vega-yellow-500 dark:to-vega-yellow-400',
     mainClassName: 'from-white dark:from-vega-clight-100 to-20%',
+    btn: '!bg-gradient-to-br from-white from-50% to-vega-yellow-500 !text-black',
   },
   [CardColour.YELLOW]: {
     gradientClassName: 'from-vega-yellow-500 to-vega-orange-400',
     mainClassName: 'from-vega-yellow-400 dark:from-vega-yellow-600 to-20%',
+    btn: '!bg-gradient-to-br from-vega-yellow-500 from-50% to-vega-orange-400 !text-black',
   },
 };
 
-const DispatchMetricColourMap: Record<DispatchMetric, CardColour> = {
+const DispatchMetricColourMap: Record<
+  DispatchMetric | StakingRewardMetric,
+  CardColour
+> = {
   // Liquidity provision fees received
   [DispatchMetric.DISPATCH_METRIC_LP_FEES_RECEIVED]: CardColour.BLUE,
   // Price maker fees paid
@@ -903,6 +861,7 @@ const DispatchMetricColourMap: Record<DispatchMetric, CardColour> = {
   [DispatchMetric.DISPATCH_METRIC_RETURN_VOLATILITY]: CardColour.YELLOW,
   // Validator ranking
   [DispatchMetric.DISPATCH_METRIC_VALIDATOR_RANKING]: CardColour.WHITE,
+  STAKING_REWARD_METRIC: CardColour.WHITE,
 };
 
 const CardIcon = ({
@@ -951,7 +910,12 @@ const EntityIcon = ({
   );
 };
 
-export const areAllMarketsSettled = (transferNode: EnrichedRewardTransfer) => {
+export const areAllMarketsSettled = (
+  transferNode: Pick<
+    EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>,
+    'markets'
+  >
+) => {
   const settledMarkets = transferNode.markets?.filter(
     (m) =>
       m?.data?.marketState &&
@@ -970,7 +934,10 @@ export const areAllMarketsSettled = (transferNode: EnrichedRewardTransfer) => {
 };
 
 export const areAllMarketsSuspended = (
-  transferNode: EnrichedRewardTransfer
+  transferNode: Pick<
+    EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>,
+    'markets'
+  >
 ) => {
   return (
     transferNode.markets?.filter(
@@ -982,12 +949,137 @@ export const areAllMarketsSuspended = (
   );
 };
 
+export const GroupRewardCard = ({
+  transferNodes,
+  currentEpoch,
+  requirements,
+}: {
+  transferNodes: EnrichedRewardTransfer<
+    DispatchStrategy | StakingDispatchStrategy
+  >[];
+  currentEpoch: number;
+  requirements?: Requirements;
+}) => {
+  const startsIns = transferNodes.map(
+    (n) => n.transfer.kind.startEpoch - currentEpoch
+  );
+  const allNotStarted =
+    startsIns.filter((s) => s > 0).length === startsIns.length &&
+    startsIns.length > 0;
+  const allNotTraded =
+    transferNodes.filter((n) => !n.isAssetTraded).length ===
+    transferNodes.length;
+  const markets = compact(flatten(transferNodes.map((n) => n.markets)));
+
+  const dispatchStrategies = transferNodes.map(
+    (n) => n.transfer.kind.dispatchStrategy
+  );
+
+  let colour = DispatchMetricColourMap[dispatchStrategies[0].dispatchMetric];
+
+  /**
+   * Display the card as grey if any of the condition is `true`:
+   *
+   * - all markets scoped to the reward are settled
+   * - all markets scoped to the reward are suspended
+   * - the reward's asset is not actively traded on any of the active markets
+   * - it start in the future
+   *
+   */
+  if (
+    areAllMarketsSettled({ markets }) ||
+    areAllMarketsSuspended({ markets }) ||
+    allNotTraded ||
+    allNotStarted
+  ) {
+    colour = CardColour.GREY;
+  }
+
+  const rewardAmounts = transferNodes.map((n) =>
+    toBigNum(n.transfer.amount, n.transfer.asset?.decimals || 0).toNumber()
+  );
+  const maxRewardAmount = max(rewardAmounts) as number;
+  const rewardAmount = formatNumber(maxRewardAmount, 6);
+
+  const transferAsset = transferNodes[0].transfer.asset || undefined;
+
+  const dispatchMetric =
+    transferNodes[0].transfer.kind.dispatchStrategy.dispatchMetric;
+
+  const entityScope =
+    transferNodes[0].transfer.kind.dispatchStrategy.entityScope;
+
+  const distributionStrategy =
+    transferNodes[0].transfer.kind.dispatchStrategy.distributionStrategy;
+
+  const delays = transferNodes.map(
+    (n) => n.transfer.kind.dispatchStrategy.lockPeriod
+  );
+  const minDelay = min(delays) || 0;
+  const maxDelay = max(delays) || 0;
+
+  const distributionDelay =
+    minDelay === maxDelay ? minDelay : `${minDelay} - ${maxDelay}`;
+
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <GroupCard
+        colour={colour}
+        rewardAmount={rewardAmount}
+        transferAsset={transferAsset}
+        dispatchMetric={dispatchMetric}
+        entityScope={entityScope}
+        distributionStrategy={distributionStrategy}
+        distributionDelay={distributionDelay}
+        count={transferNodes.length}
+        onClick={() => {
+          setOpen(true);
+        }}
+      />
+      <Dialog
+        size="large"
+        open={open}
+        onChange={(isOpen) => {
+          setOpen(isOpen);
+        }}
+        title={
+          DispatchMetricLabels[
+            transferNodes[0].transfer.kind.dispatchStrategy.dispatchMetric
+          ]
+        }
+      >
+        <div
+          data-card-from-group
+          className={classNames(
+            'pt-4',
+
+            'grid gap-x-8 gap-y-10 h-fit grid-cols-[repeat(auto-fill,_minmax(230px,_1fr))] md:grid-cols-[repeat(auto-fill,_minmax(230px,_1fr))] lg:grid-cols-[repeat(auto-fill,_minmax(320px,_1fr))] xl:grid-cols-[repeat(auto-fill,_minmax(335px,_1fr))]'
+          )}
+        >
+          {transferNodes.map((n, i) => (
+            <ActiveRewardCard
+              key={i}
+              transferNode={n}
+              currentEpoch={currentEpoch}
+              requirements={requirements}
+            />
+          ))}
+        </div>
+      </Dialog>
+    </>
+  );
+};
+
 export const ActiveRewardCard = ({
   transferNode,
   currentEpoch,
   requirements,
 }: {
-  transferNode: EnrichedRewardTransfer;
+  transferNode: EnrichedRewardTransfer<
+    DispatchStrategy | StakingDispatchStrategy
+  >;
   currentEpoch: number;
   requirements?: Requirements;
 }) => {
@@ -997,34 +1089,9 @@ export const ActiveRewardCard = ({
       ? transferNode.transfer.kind.endEpoch - currentEpoch
       : undefined;
 
-  if (
-    !transferNode.transfer.kind.dispatchStrategy &&
-    transferNode.transfer.toAccountType ===
-      AccountType.ACCOUNT_TYPE_GLOBAL_REWARD
-  ) {
-    return (
-      <LinkToGame gameId={transferNode.transfer.gameId}>
-        <StakingRewardCard
-          colour={CardColour.WHITE}
-          rewardAmount={addDecimalsFormatNumber(
-            transferNode.transfer.amount,
-            transferNode.transfer.asset?.decimals || 0,
-            6
-          )}
-          rewardAsset={transferNode.transfer.asset || undefined}
-          startsIn={startsIn > 0 ? startsIn : undefined}
-          endsIn={endsIn}
-          requirements={requirements}
-          gameId={transferNode.transfer.gameId}
-        />
-      </LinkToGame>
-    );
-  }
+  const dispatchStrategy = transferNode.transfer.kind.dispatchStrategy;
 
-  let colour =
-    DispatchMetricColourMap[
-      transferNode.transfer.kind.dispatchStrategy.dispatchMetric
-    ];
+  let colour = DispatchMetricColourMap[dispatchStrategy.dispatchMetric];
 
   /**
    * Display the card as grey if any of the condition is `true`:
@@ -1045,7 +1112,7 @@ export const ActiveRewardCard = ({
   }
 
   return (
-    <LinkToGame gameId={transferNode.transfer.gameId}>
+    <LinkToGame reward={transferNode}>
       <RewardCard
         colour={colour}
         rewardAmount={addDecimalsFormatNumber(
@@ -1053,11 +1120,11 @@ export const ActiveRewardCard = ({
           transferNode.transfer.asset?.decimals || 0,
           6
         )}
-        rewardAsset={transferNode.dispatchAsset}
+        dispatchAsset={transferNode.dispatchAsset}
         transferAsset={transferNode.transfer.asset || undefined}
         startsIn={startsIn > 0 ? startsIn : undefined}
         endsIn={endsIn}
-        dispatchStrategy={transferNode.transfer.kind.dispatchStrategy}
+        dispatchStrategy={dispatchStrategy}
         dispatchMetricInfo={<DispatchMetricInfo reward={transferNode} />}
         requirements={requirements}
         gameId={transferNode.transfer.gameId}
@@ -1067,13 +1134,15 @@ export const ActiveRewardCard = ({
 };
 
 const LinkToGame = ({
-  gameId,
+  reward,
   children,
 }: {
-  gameId?: string | null;
+  reward: EnrichedRewardTransfer<DispatchStrategy | StakingDispatchStrategy>;
   children: ReactNode;
 }) => {
-  if (gameId && gameId.length > 0) {
+  const gameId = reward.transfer.gameId;
+  const scoped = isScopedToTeams(reward);
+  if (scoped && gameId && gameId.length > 0) {
     return <Link to={Links.COMPETITIONS_GAME(gameId)}>{children}</Link>;
   }
   return children;

--- a/apps/trading/e2e/tests/rewards/test_reward_group.py
+++ b/apps/trading/e2e/tests/rewards/test_reward_group.py
@@ -1,0 +1,266 @@
+import pytest
+from rewards_test_ids import *
+from typing import Tuple, Generator
+import vega_sim.proto.vega as vega_protos
+from playwright.sync_api import Page, expect
+from conftest import init_vega, init_page, auth_setup, risk_accepted_setup, cleanup_container
+from fixtures.market import setup_continuous_market
+from actions.utils import next_epoch, change_keys
+from wallet_config import MM_WALLET
+from vega_sim.null_service import VegaServiceNull
+
+
+@pytest.fixture(scope="module")
+def setup_environment(request, browser) -> Generator[Tuple[Page, str, str], None, None]:
+    with init_vega(request) as vega_instance:
+        request.addfinalizer(lambda: cleanup_container(vega_instance))
+
+        tDAI_market, tDAI_asset_id = setup_market_with_reward_program(
+            vega_instance)
+
+        with init_page(vega_instance, browser, request) as page:
+            risk_accepted_setup(page)
+            auth_setup(vega_instance, page)
+            page.goto(REWARDS_URL)
+            change_keys(page, vega_instance, PARTY_B)
+            yield page, tDAI_market, tDAI_asset_id
+
+
+def setup_market_with_reward_program(vega: VegaServiceNull):
+    tDAI_market = setup_continuous_market(vega)
+    PARTY_A, PARTY_B, PARTY_C, PARTY_D = keys(vega)
+    tDAI_asset_id = vega.find_asset_id(symbol="tDAI")
+    vega.mint(key_name=PARTY_B.name, asset=tDAI_asset_id, amount=100000)
+    vega.mint(key_name=PARTY_C.name, asset=tDAI_asset_id, amount=100000)
+    vega.mint(key_name=PARTY_A.name, asset=tDAI_asset_id, amount=100000)
+    vega.mint(key_name=PARTY_D.name, asset=tDAI_asset_id, amount=100000)
+    tDAI_market2 = setup_continuous_market(vega, custom_asset_name="tDAI2", custom_market_name="BTC:DAI2", custom_asset_symbol="tDAI2")
+    next_epoch(vega=vega)
+    vega.update_network_parameter(
+        proposal_key=MM_WALLET.name,
+        parameter="rewards.activityStreak.benefitTiers",
+        new_value=ACTIVITY_STREAKS,
+    )
+    print("update_network_parameter activity done")
+    next_epoch(vega=vega)
+
+    vega.update_network_parameter(
+        proposal_key=MM_WALLET.name,
+        parameter="rewards.vesting.benefitTiers",
+        new_value=VESTING,
+    )
+    next_epoch(vega=vega)
+
+    tDAI_asset_id = vega.find_asset_id(symbol="tDAI")
+    print(tDAI_asset_id)
+    vega.update_network_parameter(
+        MM_WALLET.name, parameter="reward.asset", new_value=tDAI_asset_id
+    )
+
+    next_epoch(vega=vega)
+    vega.recurring_transfer(
+        from_key_name=PARTY_A.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_GLOBAL_REWARD,
+        asset=tDAI_asset_id,
+        amount=100,
+        factor=1.0,
+    )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    vega.recurring_transfer(
+        from_key_name=PARTY_A.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
+        asset=tDAI_asset_id,
+        reference="reward",
+        asset_for_metric=tDAI_asset_id,
+        metric=vega_protos.vega.DISPATCH_METRIC_MAKER_FEES_PAID,
+        amount=100,
+        factor=1.0,
+    )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    tDAI_asset_id2 = vega.find_asset_id(symbol="tDAI2")
+    vega.mint(key_name=PARTY_B.name, asset=tDAI_asset_id2, amount=100000)
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    vega.recurring_transfer(
+        from_key_name=PARTY_A.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
+        asset=tDAI_asset_id,
+        reference="reward",
+        markets=[tDAI_market2],
+        asset_for_metric=tDAI_asset_id2,
+        metric=vega_protos.vega.DISPATCH_METRIC_MAKER_FEES_PAID,
+        amount=100,
+        factor=1.0,
+    )
+    current_epoch = vega.statistics().epoch_seq
+    game_start = current_epoch + 1
+    game_end = current_epoch + 14
+    vega.recurring_transfer(
+        from_key_name=PARTY_B.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
+        asset=tDAI_asset_id,
+        reference="reward",
+        asset_for_metric=tDAI_asset_id,
+        metric=vega_protos.vega.DISPATCH_METRIC_MAKER_FEES_PAID,
+        entity_scope=vega_protos.vega.ENTITY_SCOPE_TEAMS,
+        n_top_performers=1,
+        amount=100,
+        factor=1.0,
+        start_epoch=game_start,
+        end_epoch=game_end,
+        window_length=15,
+    )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    vega.submit_order(
+        trading_key=PARTY_B.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.submit_order(
+        trading_key=PARTY_A.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    next_epoch(vega=vega)
+    vega.submit_order(
+        trading_key=PARTY_B.name,
+        market_id=tDAI_market,
+        order_type="TYPE_LIMIT",
+        time_in_force="TIME_IN_FORCE_GTC",
+        side="SIDE_BUY",
+        price=1,
+        volume=1,
+    )
+    next_epoch(vega=vega)
+    vega.submit_order(
+        trading_key=PARTY_B.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.submit_order(
+        trading_key=PARTY_D.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.wait_fn(1)
+    vega.wait_for_total_catchup()
+    next_epoch(vega=vega)
+    next_epoch(vega=vega)
+    vega.submit_order(
+        trading_key=PARTY_B.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.submit_order(
+        trading_key=PARTY_D.name,
+        market_id=tDAI_market,
+        order_type="TYPE_MARKET",
+        time_in_force="TIME_IN_FORCE_IOC",
+        side="SIDE_BUY",
+        volume=1,
+    )
+    vega.wait_for_total_catchup()
+    next_epoch(vega=vega)
+    next_epoch(vega=vega)
+    next_epoch(vega=vega)
+    return tDAI_market, tDAI_asset_id
+
+def test_reward_group_card(
+    setup_environment: Tuple[Page, str, str],
+):
+    page, tDAI_market, tDAI_asset_id = setup_environment
+    expect(page.get_by_test_id("active-rewards-card")).to_have_count(2)
+    reward_group_card = page.get_by_test_id("active-rewards-card").first
+    expect(reward_group_card).to_be_visible()
+    expect(reward_group_card.get_by_test_id(
+        "entity-scope")).to_have_text("Individual")
+    expect(reward_group_card.get_by_test_id(
+        "locked-for")).to_have_text("1 epoch")
+    expect(reward_group_card.get_by_test_id(
+        "reward-value")).to_have_text("200.00")
+    expect(reward_group_card.get_by_test_id(
+        "distribution-strategy")).to_have_text("Pro rata")
+    expect(reward_group_card.get_by_test_id("dispatch-metric-info")).to_have_text(
+        "Price maker fees paid"
+    )
+    expect(reward_group_card.locator("button")).to_have_text(
+        "See details of 2 rewards"
+    )
+
+def test_reward_group_popup(
+    setup_environment: Tuple[Page, str, str],
+):
+    page, tDAI_market, tDAI_asset_id = setup_environment
+    expect(page.get_by_test_id("active-rewards-card")).to_have_count(2)
+    staking_reward_card = page.get_by_test_id("active-rewards-card").first
+    staking_reward_card.locator("button").click()
+
+    expect(page.get_by_test_id("dialog-content").first).to_be_visible()
+    reward_popup = page.get_by_test_id("dialog-content").first
+    expect(reward_popup.get_by_test_id("dialog-title")).to_have_text("Price maker fees paid")
+
+    expect(reward_popup.get_by_test_id("active-rewards-card")).to_have_count(2)
+    popup_reward_card_1 = reward_popup.get_by_test_id("active-rewards-card").first
+    expect(popup_reward_card_1).to_be_visible()
+    expect(popup_reward_card_1.get_by_test_id(
+        "entity-scope")).to_have_text("Individual")
+    expect(popup_reward_card_1.get_by_test_id(
+        "locked-for")).to_have_text("1 epoch")
+    expect(popup_reward_card_1.get_by_test_id(
+        "reward-value")).to_have_text("100.00")
+    expect(popup_reward_card_1.get_by_test_id(
+        "distribution-strategy")).to_have_text("Pro rata")
+    expect(popup_reward_card_1.get_by_test_id("dispatch-metric-info")).to_have_text(
+        "Price maker fees paid • BTC:DAI2"
+    )
+    expect(popup_reward_card_1.get_by_test_id(
+        "scope")).to_have_text("Eligible")
+    expect(popup_reward_card_1.get_by_test_id(
+        "staking-requirement")).to_have_text("-")
+    expect(popup_reward_card_1.get_by_test_id(
+        "average-position")).to_have_text("-")
+    
+    popup_reward_card_2 = reward_popup.get_by_test_id("active-rewards-card").nth(1)
+    expect(popup_reward_card_2).to_be_visible()
+    expect(popup_reward_card_2.get_by_test_id(
+        "entity-scope")).to_have_text("Individual")
+    expect(popup_reward_card_2.get_by_test_id(
+        "locked-for")).to_have_text("1 epoch")
+    expect(popup_reward_card_2.get_by_test_id(
+        "reward-value")).to_have_text("100.00")
+    expect(popup_reward_card_2.get_by_test_id(
+        "distribution-strategy")).to_have_text("Pro rata")
+    expect(popup_reward_card_2.get_by_test_id("dispatch-metric-info")).to_have_text(
+        "Price maker fees paid • tDAI"
+    )
+    expect(popup_reward_card_2.get_by_test_id(
+        "scope")).to_have_text("Eligible")
+    expect(popup_reward_card_2.get_by_test_id(
+        "staking-requirement")).to_have_text("-")
+    expect(popup_reward_card_2.get_by_test_id(
+        "average-position")).to_have_text("-")
+

--- a/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
+++ b/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
@@ -213,7 +213,7 @@ def test_staking_reward(
     expect(staking_reward_card.get_by_test_id(
         "assessed-over")).to_have_text("1 epoch")
     expect(staking_reward_card.get_by_test_id(
-        "scope")).to_have_text("Individual")
+        "scope")).to_have_text("Not eligible ")
     expect(staking_reward_card.get_by_test_id(
         "staking-requirement")).to_have_text("1.00")
     expect(staking_reward_card.get_by_test_id(

--- a/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
+++ b/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
@@ -217,4 +217,4 @@ def test_staking_reward(
     expect(staking_reward_card.get_by_test_id(
         "staking-requirement")).to_have_text("1.00")
     expect(staking_reward_card.get_by_test_id(
-        "average-position")).to_have_text("0.00")
+        "average-position")).to_have_text("-")

--- a/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
+++ b/apps/trading/e2e/tests/rewards/test_rewards_combo_tier_1.py
@@ -208,7 +208,7 @@ def test_staking_reward(
     expect(staking_reward_card.get_by_test_id(
         "distribution-strategy")).to_have_text("Pro rata")
     expect(staking_reward_card.get_by_test_id("dispatch-metric-info")).to_have_text(
-        "Staking rewards"
+        "Staking rewards • tDAI"
     )
     expect(staking_reward_card.get_by_test_id(
         "assessed-over")).to_have_text("1 epoch")

--- a/apps/trading/lib/hooks/use-rewards.spec.ts
+++ b/apps/trading/lib/hooks/use-rewards.spec.ts
@@ -5,6 +5,7 @@ import {
   type TransferKind,
   TransferStatus,
   IndividualScope,
+  type StakingDispatchStrategy,
 } from '@vegaprotocol/types';
 import {
   type RewardTransfer,
@@ -28,7 +29,7 @@ const makeReward = (
   endEpoch?: number,
   dispatchStrategy?: DispatchStrategy,
   kind: TransferKind['__typename'] = 'OneOffTransfer'
-): RewardTransfer =>
+): RewardTransfer<DispatchStrategy | StakingDispatchStrategy> =>
   ({
     transfer: {
       status,
@@ -39,7 +40,7 @@ const makeReward = (
         endEpoch,
       },
     },
-  } as RewardTransfer);
+  } as RewardTransfer<DispatchStrategy | StakingDispatchStrategy>);
 
 describe('isReward', () => {
   it.each([

--- a/apps/trading/lib/hooks/use-rewards.ts
+++ b/apps/trading/lib/hooks/use-rewards.ts
@@ -16,6 +16,9 @@ import {
   EntityScope,
   MarketState,
   AccountType,
+  DispatchMetric,
+  type StakingDispatchStrategy,
+  DistributionStrategy,
 } from '@vegaprotocol/types';
 import { type ApolloError } from '@apollo/client';
 import compact from 'lodash/compact';
@@ -23,19 +26,69 @@ import { useEpochInfoQuery } from './__generated__/Epoch';
 import { useDataProvider } from '@vegaprotocol/data-provider';
 import { removePaginationWrapper } from '@vegaprotocol/utils';
 import first from 'lodash/first';
+import set from 'lodash/set';
+import omit from 'lodash/omit';
 
-export type RewardTransfer = TransferNode & {
+type Strategy = DispatchStrategy | StakingDispatchStrategy;
+
+export type RewardTransfer<T> = TransferNode & {
   transfer: {
-    kind: RecurringTransfer & {
-      dispatchStrategy: DispatchStrategy;
+    kind: Omit<RecurringTransfer, 'dispatchStrategy'> & {
+      dispatchStrategy: T;
     };
   };
 };
 
-export type EnrichedRewardTransfer = RewardTransfer & {
+// This is the `de facto` dispatch strategy for staking rewards:
+const STAKING_DISPATCH_STRATEGY: StakingDispatchStrategy = {
+  dispatchMetric: 'STAKING_REWARD_METRIC',
+  dispatchMetricAssetId: '', // <-- replace empty string here with correct value of the reward asset
+  distributionStrategy: DistributionStrategy.DISTRIBUTION_STRATEGY_PRO_RATA,
+  entityScope: EntityScope.ENTITY_SCOPE_INDIVIDUALS,
+  lockPeriod: 0,
+  notionalTimeWeightedAveragePositionRequirement: '',
+  stakingRequirement: '1000000000000000000', // 1 VEGA
+  windowLength: 1,
+};
+
+/**
+ * Maps raw transfer node to the reward transfer type. If a given node is
+ * staking reward then it derives the dispatch strategy.
+ * @returns `RewardTransfer<DispatchStrategy>` or
+ * `RewardTransfer<StakingDispatchStrategy>`, otherwise `undefined`.
+ */
+const mapTransferNodeToRewardTransfer = (
+  node: TransferNode
+): RewardTransfer<Strategy> | undefined => {
+  if (isReward(node)) {
+    return node as RewardTransfer<DispatchStrategy>;
+  }
+  if (isStakingReward(node)) {
+    let n = { ...node } as RewardTransfer<StakingDispatchStrategy>;
+    const stakingDispatchStrategy: StakingDispatchStrategy = {
+      ...STAKING_DISPATCH_STRATEGY,
+      dispatchMetricAssetId: node.transfer.asset?.id || '',
+    };
+    n = set(
+      omit(n, 'transfer.kind.dispatchStrategy'),
+      'transfer.kind.dispatchStrategy',
+      stakingDispatchStrategy
+    );
+    return n;
+  }
+  return undefined;
+};
+
+export type EnrichedRewardTransfer<T> = RewardTransfer<T> & {
   /** Dispatch metric asset (reward asset) */
   dispatchAsset?: AssetFieldsFragment;
-  /** A flag determining whether a reward asset is being traded on any of the active markets */
+  /**
+   * A flag determining whether a reward asset is being traded on any
+   * of the active markets.
+   *
+   * It evaluates to `true` even if asset is not actively traded when a reward
+   * is for staking VEGA or validator ranking.
+   */
   isAssetTraded?: boolean;
   /** A list of markets in scope */
   markets?: MarketMaybeWithData[];
@@ -45,25 +98,33 @@ export type EnrichedRewardTransfer = RewardTransfer & {
  * Checks if given transfer is a reward.
  *
  * A reward has to be a recurring transfer and has to have a
- * dispatch strategy.
+ * dispatch strategy unless it's a staking reward then see `isStakingReward`.
  */
-export const isReward = (node: TransferNode): node is RewardTransfer => {
-  const isRecurringTransfer =
-    (node.transfer.kind.__typename === 'RecurringTransfer' ||
-      node.transfer.kind.__typename === 'RecurringGovernanceTransfer') &&
-    node.transfer.kind.dispatchStrategy != null;
-  const isStakingReward =
-    node.transfer.toAccountType === AccountType.ACCOUNT_TYPE_GLOBAL_REWARD;
-  if (isRecurringTransfer || isStakingReward) {
-    return true;
-  }
-  return false;
-};
+export const isReward = (
+  node: TransferNode
+): node is RewardTransfer<DispatchMetric> =>
+  (node.transfer.kind.__typename === 'RecurringTransfer' ||
+    node.transfer.kind.__typename === 'RecurringGovernanceTransfer') &&
+  node.transfer.kind.dispatchStrategy != null;
+
+/**
+ * Checks if given reward (transfer) is for staking VEGA.
+ */
+export const isStakingReward = (
+  node: TransferNode
+): node is RewardTransfer<StakingDispatchStrategy> =>
+  (node.transfer.kind.__typename === 'RecurringGovernanceTransfer' ||
+    node.transfer.kind.__typename === 'RecurringTransfer') &&
+  !node.transfer.kind.dispatchStrategy &&
+  node.transfer.toAccountType === AccountType.ACCOUNT_TYPE_GLOBAL_REWARD;
 
 /**
  * Checks if given reward (transfer) is has not ended. If it is active or due to start in the future.
  */
-export const isActiveReward = (node: RewardTransfer, currentEpoch: number) => {
+export const isActiveReward = (
+  node: RewardTransfer<Strategy>,
+  currentEpoch: number
+) => {
   const { transfer } = node;
 
   const pending = transfer.status === TransferStatus.STATUS_PENDING;
@@ -79,10 +140,61 @@ export const isActiveReward = (node: RewardTransfer, currentEpoch: number) => {
 /**
  * Checks if given reward (transfer) is scoped to teams.
  */
-export const isScopedToTeams = (node: EnrichedRewardTransfer) =>
+export const isScopedToTeams = (node: RewardTransfer<Strategy>) =>
   // scoped to teams
   node.transfer.kind.dispatchStrategy?.entityScope ===
   EntityScope.ENTITY_SCOPE_TEAMS;
+
+/**
+ * Creates a function that enriches the given reward transfer with additional
+ * data based on the given markets and assets.
+ */
+const createTransferEnrichment =
+  (
+    markets: MarketMaybeWithData[] | null,
+    assets: Record<string, AssetFieldsFragment> | null
+  ) =>
+  (node: RewardTransfer<Strategy>): EnrichedRewardTransfer<Strategy> => {
+    const isAssetTraded = [
+      // do not grey out a card when a reward is for validator ranking
+      // or staking (VEGA doesn't need to be traded)
+      DispatchMetric.DISPATCH_METRIC_VALIDATOR_RANKING,
+      'STAKING_REWARD_METRIC',
+    ].includes(node.transfer.kind.dispatchStrategy.dispatchMetric)
+      ? true
+      : markets &&
+        Object.values(markets).some((m) => {
+          try {
+            const mAsset = getAsset(m);
+            return (
+              mAsset.id ===
+                node.transfer.kind.dispatchStrategy?.dispatchMetricAssetId &&
+              m.data?.marketState === MarketState.STATE_ACTIVE
+            );
+          } catch {
+            // NOOP
+          }
+          return false;
+        });
+
+    const dispatchAsset =
+      (assets &&
+        assets[node.transfer.kind.dispatchStrategy.dispatchMetricAssetId]) ||
+      undefined;
+
+    const marketsInScope = compact(
+      node.transfer.kind.dispatchStrategy.marketIdsInScope?.map(
+        (id) => markets && markets.find((m) => m.id === id)
+      )
+    );
+
+    return {
+      ...node,
+      dispatchAsset,
+      isAssetTraded: isAssetTraded != null ? isAssetTraded : undefined,
+      markets: marketsInScope?.length > 0 ? marketsInScope : undefined,
+    };
+  };
 
 /** Retrieves rewards (transfers) */
 export const useRewards = ({
@@ -93,7 +205,7 @@ export const useRewards = ({
   onlyActive: boolean;
   scopeToTeams?: boolean;
 }): {
-  data: EnrichedRewardTransfer[];
+  data: EnrichedRewardTransfer<Strategy>[];
   loading: boolean;
   error?: ApolloError | Error;
 } => {
@@ -133,50 +245,24 @@ export const useRewards = ({
     variables: undefined,
   });
 
+  const enrich = createTransferEnrichment(markets, assets);
   const transfers = removePaginationWrapper(data?.transfersConnection?.edges);
+  const rewardTransfers = compact(
+    transfers
+      .map((n) => n as TransferNode)
+      // make sure we have only rewards and staking rewards here
+      .filter((n) => isReward(n) || isStakingReward(n))
+      // derive dispatch strategy for staking rewards
+      .map((n) => mapTransferNodeToRewardTransfer(n))
+  );
 
-  const enriched = transfers
-    .map((n) => n as TransferNode)
-    // make sure we have only rewards here
-    .filter(isReward)
+  const enriched = rewardTransfers
     // take only active rewards if required, otherwise take all
     .filter((node) => (onlyActive ? isActiveReward(node, currentEpoch) : true))
     // take only those rewards that are scoped to teams if required, otherwise take all
     .filter((node) => (scopeToTeams ? isScopedToTeams(node) : true))
     // enrich with dispatch asset and markets in scope details
-    .map((node) => {
-      if (!node.transfer.kind.dispatchStrategy) return node;
-      const dispatchAsset =
-        (assets &&
-          assets[node.transfer.kind.dispatchStrategy.dispatchMetricAssetId]) ||
-        undefined;
-      const marketsInScope = compact(
-        node.transfer.kind.dispatchStrategy.marketIdsInScope?.map(
-          (id) => markets && markets.find((m) => m.id === id)
-        )
-      );
-      const isAssetTraded =
-        markets &&
-        Object.values(markets).some((m) => {
-          try {
-            const mAsset = getAsset(m);
-            return (
-              mAsset.id ===
-                node.transfer.kind.dispatchStrategy.dispatchMetricAssetId &&
-              m.data?.marketState === MarketState.STATE_ACTIVE
-            );
-          } catch {
-            // NOOP
-          }
-          return false;
-        });
-      return {
-        ...node,
-        dispatchAsset,
-        isAssetTraded: isAssetTraded != null ? isAssetTraded : undefined,
-        markets: marketsInScope?.length > 0 ? marketsInScope : undefined,
-      };
-    });
+    .map(enrich);
 
   return {
     data: enriched,
@@ -209,44 +295,19 @@ export const useReward = (gameId?: string) => {
     variables: undefined,
   });
 
-  const enriched = compact(
-    data?.transfersConnection?.edges?.map((n) => n?.node)
-  )
-    .map((n) => n as TransferNode)
-    .filter(isReward)
-    .map((node) => {
-      if (!node.transfer.kind.dispatchStrategy) return node;
-      const dispatchAsset =
-        (assets &&
-          assets[node.transfer.kind.dispatchStrategy.dispatchMetricAssetId]) ||
-        undefined;
-      const marketsInScope = compact(
-        node.transfer.kind.dispatchStrategy.marketIdsInScope?.map(
-          (id) => markets && markets.find((m) => m.id === id)
-        )
-      );
-      const isAssetTraded =
-        markets &&
-        Object.values(markets).some((m) => {
-          try {
-            const mAsset = getAsset(m);
-            return (
-              mAsset.id ===
-                node.transfer.kind.dispatchStrategy.dispatchMetricAssetId &&
-              m.data?.marketState === MarketState.STATE_ACTIVE
-            );
-          } catch {
-            // NOOP
-          }
-          return false;
-        });
-      return {
-        ...node,
-        dispatchAsset,
-        isAssetTraded: isAssetTraded != null ? isAssetTraded : undefined,
-        markets: marketsInScope?.length > 0 ? marketsInScope : undefined,
-      };
-    });
+  const enrich = createTransferEnrichment(markets, assets);
+  const transfers = removePaginationWrapper(data?.transfersConnection?.edges);
+  const rewardTransfers = compact(
+    transfers
+      .map((n) => n as TransferNode)
+      // make sure we have only rewards and staking rewards here
+      .filter((n) => isReward(n) || isStakingReward(n))
+      // derive dispatch strategy for staking rewards
+      .map((n) => mapTransferNodeToRewardTransfer(n))
+  );
+  const enriched = rewardTransfers
+    // enrich with dispatch asset and markets in scope details
+    .map(enrich);
 
   return {
     data: first(enriched),

--- a/libs/i18n/src/locales/en/trading.json
+++ b/libs/i18n/src/locales/en/trading.json
@@ -464,6 +464,7 @@
   "Unknown settlement date": "Unknown settlement date",
   "Unknown": "Unknown",
   "Unnamed key": "Unnamed key",
+  "Up to": "Up to",
   "Update team": "Update team",
   "URL": "URL",
   "Use a comma separated list to allow only specific public keys to join the team": "Use a comma separated list to allow only specific public keys to join the team",

--- a/libs/i18n/src/locales/en/trading.json
+++ b/libs/i18n/src/locales/en/trading.json
@@ -371,6 +371,7 @@
   "Search": "Search",
   "See all markets": "See all markets",
   "See all the live games on the cards below. Every on-chain game is community funded and designed. <0>Find out how to create one</0>.": "See all the live games on the cards below. Every on-chain game is community funded and designed. <0>Find out how to create one</0>.",
+  "See details of {{count}} rewards": "See details of {{count}} rewards",
   "Select market": "Select market",
   "Set party alias": "Set party alias",
   "Settings": "Settings",

--- a/libs/types/src/global-types-mappings.ts
+++ b/libs/types/src/global-types-mappings.ts
@@ -12,32 +12,33 @@ import {
 } from './__generated__/types';
 import type {
   AccountType,
+  DispatchStrategy,
   StopOrderRejectionReason,
 } from './__generated__/types';
-import type {
-  AuctionTrigger,
-  DataSourceSpecStatus,
-  DepositStatus,
-  Interval,
-  LiquidityProvisionStatus,
-  MarketState,
-  MarketTradingMode,
-  NodeStatus,
-  OrderRejectionReason,
-  OrderStatus,
-  OrderTimeInForce,
-  OrderType,
-  PositionStatus,
-  ProposalRejectionReason,
-  ProposalState,
-  Side,
-  StakeLinkingStatus,
-  TransferType,
-  ValidatorStatus,
-  VoteValue,
-  WithdrawalStatus,
-  DispatchMetric,
-  StopOrderStatus,
+import {
+  type AuctionTrigger,
+  type DataSourceSpecStatus,
+  type DepositStatus,
+  type Interval,
+  type LiquidityProvisionStatus,
+  type MarketState,
+  type MarketTradingMode,
+  type NodeStatus,
+  type OrderRejectionReason,
+  type OrderStatus,
+  type OrderTimeInForce,
+  type OrderType,
+  type PositionStatus,
+  type ProposalRejectionReason,
+  type ProposalState,
+  type Side,
+  type StakeLinkingStatus,
+  type TransferType,
+  type ValidatorStatus,
+  type VoteValue,
+  type WithdrawalStatus,
+  type DispatchMetric,
+  type StopOrderStatus,
 } from './__generated__/types';
 import type { ProductType, ProposalProductType } from './product';
 
@@ -636,8 +637,24 @@ export const GovernanceTransferKindMapping: GovernanceTransferKindMap = {
   RecurringGovernanceTransfer: 'Recurring',
 };
 
+/**
+ * The below dispatch metric labels are extended by additional
+ * `StakingRewardMetric` which handles the case when a reward (transfer)
+ * has undefined dispatch strategy and it targetted to
+ * `AccountType.ACCOUNT_TYPE_GLOBAL_REWARD`.
+ */
+
+export type StakingRewardMetric = 'STAKING_REWARD_METRIC';
+
+export type StakingDispatchStrategy = Omit<
+  DispatchStrategy,
+  'dispatchMetric'
+> & {
+  dispatchMetric: StakingRewardMetric;
+};
+
 type DispatchMetricLabel = {
-  [T in DispatchMetric]: string;
+  [T in DispatchMetric | StakingRewardMetric]: string;
 };
 
 export const DispatchMetricLabels: DispatchMetricLabel = {
@@ -649,6 +666,7 @@ export const DispatchMetricLabels: DispatchMetricLabel = {
   DISPATCH_METRIC_RELATIVE_RETURN: 'Relative return',
   DISPATCH_METRIC_RETURN_VOLATILITY: 'Return volatility',
   DISPATCH_METRIC_VALIDATOR_RANKING: 'Validator ranking',
+  STAKING_REWARD_METRIC: 'Staking rewards',
 };
 
 export const DispatchMetricDescription: DispatchMetricLabel = {
@@ -667,6 +685,8 @@ export const DispatchMetricDescription: DispatchMetricLabel = {
     'Get rewards for having the least amount of variance in your returns while you have a position open during the rewards window.',
   DISPATCH_METRIC_VALIDATOR_RANKING:
     'Get rewards if you run a validator node with a high ranking score.',
+  STAKING_REWARD_METRIC:
+    'Global staking reward for staking $VEGA on the network via the Governance app',
 };
 
 export const PositionStatusMapping: {

--- a/libs/ui-toolkit/src/components/trading-button/trading-button.tsx
+++ b/libs/ui-toolkit/src/components/trading-button/trading-button.tsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom';
 
 type TradingButtonProps = {
   size?: 'large' | 'medium' | 'small' | 'extra-small';
-  intent?: Intent;
+  intent?: Intent | null;
   children?: ReactNode;
   icon?: ReactNode;
   subLabel?: ReactNode;


### PR DESCRIPTION
# Related issues 🔗

Closes #5580 
Closes #6182 

# Description ℹ️

* removed `StakingRewardCard`, added special `dispatchStrategy` for this type of reward,
* added groups (`GroupRewardCard`) of reward cards based on:
  - reward asset (usually VEGA),
  - reward for (dispatch metric),
  - reward scope (teams vs individuals),
  - reward distribution strategy
* added dialogs with cards from a group
* excludes scoped to teams rewards from 'Rewards' page

# Demo 📺

https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/bd49af42-ec18-4a90-b18a-bbc4891e713c

# Technical 👨‍🔧

Button colours:

![Screenshot 2024-04-12 at 17 32 54](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/d05c1ee1-6a35-42da-9734-7662b4a0c0ae)

