### PR TITLE
feat(trading): improve close position transaction handling

### DIFF
--- a/libs/i18n/src/locales/en/positions.json
+++ b/libs/i18n/src/locales/en/positions.json
@@ -1,7 +1,7 @@
 {
   "Best case": "Best case",
   "Cross": "Cross",
-  "Close position": "Close position",
+  "Close this position at market price and cancel all open orders on this market": "Close this position at market price and cancel all open orders on this market",
   "Entry / Mark": "Entry / Mark",
   "General account: {{balance}}": "General account: {{balance}}",
   "Isolated": "Isolated",

--- a/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
+++ b/libs/orders/src/lib/components/order-list-manager/order-list-manager.tsx
@@ -143,7 +143,7 @@ export const OrderListManager = ({
               fields.limitPrice,
               fields.size
             );
-            const originalOrder: OrderTxUpdateFieldsFragment = {
+            const order: OrderTxUpdateFieldsFragment = {
               type: editOrder.type,
               id: editOrder.id,
               status: editOrder.status,
@@ -156,7 +156,7 @@ export const OrderListManager = ({
               marketId: editOrder.market.id,
               remaining: editOrder.remaining,
             };
-            create({ orderAmendment }, originalOrder);
+            create({ orderAmendment }, { order });
             setEditOrder(null);
           }}
         />

--- a/libs/positions/src/lib/positions-manager.tsx
+++ b/libs/positions/src/lib/positions-manager.tsx
@@ -36,28 +36,31 @@ export const PositionsManager = ({
 
   const onClose = useCallback(
     ({ marketId, openVolume }: { marketId: string; openVolume: string }) =>
-      create({
-        batchMarketInstructions: {
-          cancellations: [
-            {
-              marketId,
-              orderId: '', // omit order id to cancel all active orders
-            },
-          ],
-          submissions: [
-            {
-              marketId: marketId,
-              type: Schema.OrderType.TYPE_MARKET as const,
-              timeInForce: Schema.OrderTimeInForce.TIME_IN_FORCE_IOC as const,
-              side: openVolume.startsWith('-')
-                ? Schema.Side.SIDE_BUY
-                : Schema.Side.SIDE_SELL,
-              size: HALFMAXGOINT64, // improvement for avoiding leftovers filled in the meantime when close request has been sent
-              reduceOnly: true,
-            },
-          ],
+      create(
+        {
+          batchMarketInstructions: {
+            cancellations: [
+              {
+                marketId,
+                orderId: '', // omit order id to cancel all active orders
+              },
+            ],
+            submissions: [
+              {
+                marketId: marketId,
+                type: Schema.OrderType.TYPE_MARKET as const,
+                timeInForce: Schema.OrderTimeInForce.TIME_IN_FORCE_IOC as const,
+                side: openVolume.startsWith('-')
+                  ? Schema.Side.SIDE_BUY
+                  : Schema.Side.SIDE_SELL,
+                size: HALFMAXGOINT64, // improvement for avoiding leftovers filled in the meantime when close request has been sent
+                reduceOnly: true,
+              },
+            ],
+          },
         },
-      }),
+        { isClosePosition: true }
+      ),
     [create]
   );
 

--- a/libs/positions/src/lib/positions-table.tsx
+++ b/libs/positions/src/lib/positions-table.tsx
@@ -554,7 +554,9 @@ export const PositionsTable = ({
                     <ButtonLink
                       data-testid="close-position"
                       onClick={() => data && onClose(data)}
-                      title={t('Close position')}
+                      title={t(
+                        'Close this position at market price and cancel all open orders on this market'
+                      )}
                     >
                       <VegaIcon name={VegaIconNames.CROSS} size={16} />
                     </ButtonLink>

--- a/libs/web3/src/lib/TransactionResult.graphql
+++ b/libs/web3/src/lib/TransactionResult.graphql
@@ -74,6 +74,13 @@ subscription OrderTxUpdate($partyId: ID!) {
   }
 }
 
+subscription PositionUpdate($partyId: ID!) {
+  positions(partyId: $partyId) {
+    marketId
+    openVolume
+  }
+}
+
 fragment DepositBusEventFields on Deposit {
   id
   status

--- a/libs/web3/src/lib/__generated__/TransactionResult.ts
+++ b/libs/web3/src/lib/__generated__/TransactionResult.ts
@@ -30,6 +30,13 @@ export type OrderTxUpdateSubscriptionVariables = Types.Exact<{
 
 export type OrderTxUpdateSubscription = { __typename?: 'Subscription', orders?: Array<{ __typename?: 'OrderUpdate', type?: Types.OrderType | null, id: string, status: Types.OrderStatus, rejectionReason?: Types.OrderRejectionReason | null, createdAt: any, size: string, price: string, timeInForce: Types.OrderTimeInForce, expiresAt?: any | null, side: Types.Side, marketId: string, remaining: string }> | null };
 
+export type PositionUpdateSubscriptionVariables = Types.Exact<{
+  partyId: Types.Scalars['ID'];
+}>;
+
+
+export type PositionUpdateSubscription = { __typename?: 'Subscription', positions: Array<{ __typename?: 'PositionUpdate', marketId: string, openVolume: string }> };
+
 export type DepositBusEventFieldsFragment = { __typename?: 'Deposit', id: string, status: Types.DepositStatus, amount: string, createdTimestamp: any, creditedTimestamp?: any | null, txHash?: string | null, asset: { __typename?: 'Asset', id: string, symbol: string, decimals: number } };
 
 export type DepositBusEventSubscriptionVariables = Types.Exact<{
@@ -205,6 +212,37 @@ export function useOrderTxUpdateSubscription(baseOptions: Apollo.SubscriptionHoo
       }
 export type OrderTxUpdateSubscriptionHookResult = ReturnType<typeof useOrderTxUpdateSubscription>;
 export type OrderTxUpdateSubscriptionResult = Apollo.SubscriptionResult<OrderTxUpdateSubscription>;
+export const PositionUpdateDocument = gql`
+    subscription PositionUpdate($partyId: ID!) {
+  positions(partyId: $partyId) {
+    marketId
+    openVolume
+  }
+}
+    `;
+
+/**
+ * __usePositionUpdateSubscription__
+ *
+ * To run a query within a React component, call `usePositionUpdateSubscription` and pass it any options that fit your needs.
+ * When your component renders, `usePositionUpdateSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePositionUpdateSubscription({
+ *   variables: {
+ *      partyId: // value for 'partyId'
+ *   },
+ * });
+ */
+export function usePositionUpdateSubscription(baseOptions: Apollo.SubscriptionHookOptions<PositionUpdateSubscription, PositionUpdateSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<PositionUpdateSubscription, PositionUpdateSubscriptionVariables>(PositionUpdateDocument, options);
+      }
+export type PositionUpdateSubscriptionHookResult = ReturnType<typeof usePositionUpdateSubscription>;
+export type PositionUpdateSubscriptionResult = Apollo.SubscriptionResult<PositionUpdateSubscription>;
 export const DepositBusEventDocument = gql`
     subscription DepositBusEvent($partyId: ID!) {
   busEvents(partyId: $partyId, batchSize: 0, types: [Deposit]) {

--- a/libs/web3/src/lib/use-vega-transaction-store.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-store.tsx
@@ -34,11 +34,16 @@ export interface VegaStoredTxState extends VegaTxState {
   withdrawal?: WithdrawalBusEventFieldsFragment;
   withdrawalApproval?: WithdrawalApprovalQuery['erc20WithdrawalApproval'];
   order?: OrderTxUpdateFieldsFragment;
+  isClosePosition?: boolean;
+  openVolume?: string;
 }
 
 export interface VegaTransactionStore {
   transactions: (VegaStoredTxState | undefined)[];
-  create: (tx: Transaction, order?: OrderTxUpdateFieldsFragment) => number;
+  create: (
+    tx: Transaction,
+    props?: Pick<VegaStoredTxState, 'order' | 'isClosePosition'>
+  ) => number;
   update: (
     index: number,
     update: Partial<
@@ -53,6 +58,7 @@ export interface VegaTransactionStore {
     withdrawalApproval: NonNullable<VegaStoredTxState['withdrawalApproval']>
   ) => void;
   updateOrder: (order: OrderTxUpdateFieldsFragment) => void;
+  updatePosition: (position: { marketId: string; openVolume: string }) => void;
   updateTransactionResult: (
     transactionResult: TransactionEventFieldsFragment
   ) => void;
@@ -67,7 +73,10 @@ export const useVegaTransactionStore = create<VegaTransactionStore>()(
           transaction?.txHash && transaction.txHash.toLowerCase() === txHash
       );
     },
-    create: (body: Transaction, order?: OrderTxUpdateFieldsFragment) => {
+    create: (
+      body: Transaction,
+      props?: Pick<VegaStoredTxState, 'order' | 'isClosePosition'>
+    ) => {
       const transactions = get().transactions;
       const now = new Date();
       const transaction: VegaStoredTxState = {
@@ -80,7 +89,7 @@ export const useVegaTransactionStore = create<VegaTransactionStore>()(
         signature: null,
         status: VegaTxStatus.Requested,
         dialogOpen: true,
-        order,
+        ...props,
       };
       set({ transactions: transactions.concat(transaction) });
 
@@ -136,6 +145,29 @@ export const useVegaTransactionStore = create<VegaTransactionStore>()(
             transaction.status = VegaTxStatus.Complete;
             transaction.dialogOpen = true;
             transaction.updatedAt = new Date();
+          }
+        })
+      );
+    },
+    updatePosition: (position) => {
+      set(
+        produce((state: VegaTransactionStore) => {
+          const transaction = state.transactions.find((transaction) => {
+            if (
+              transaction &&
+              transaction?.isClosePosition &&
+              isBatchMarketInstructionsTransaction(transaction?.body) &&
+              transaction.body.batchMarketInstructions.cancellations?.[0]
+                ?.marketId === position.marketId &&
+              (transaction.order || transaction.transactionResult) &&
+              !transaction.openVolume
+            ) {
+              return true;
+            }
+            return false;
+          });
+          if (transaction) {
+            transaction.openVolume = position.openVolume;
           }
         })
       );

--- a/libs/web3/src/lib/use-vega-transaction-toasts.spec.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-toasts.spec.tsx
@@ -310,6 +310,7 @@ const closePosition: VegaStoredTxState = {
   id: 0,
   createdAt: new Date(),
   updatedAt: new Date(),
+  isClosePosition: true,
   body: {
     batchMarketInstructions: {
       cancellations: [{ marketId: 'market-1', orderId: '' }],

--- a/libs/web3/src/lib/use-vega-transaction-updater.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-updater.tsx
@@ -4,6 +4,7 @@ import {
   useOrderTxUpdateSubscription,
   useWithdrawalBusEventSubscription,
   useTransactionEventSubscription,
+  usePositionUpdateSubscription,
 } from './__generated__/TransactionResult';
 import { useVegaTransactionStore } from './use-vega-transaction-store';
 import { waitForWithdrawalApproval } from './wait-for-withdrawal-approval';
@@ -24,6 +25,9 @@ export const useVegaTransactionUpdater = () => {
     (state) => state.updateWithdrawal
   );
   const updateOrder = useVegaTransactionStore((state) => state.updateOrder);
+  const updatePosition = useVegaTransactionStore(
+    (state) => state.updatePosition
+  );
   const updateTransaction = useVegaTransactionStore(
     (state) => state.updateTransactionResult
   );
@@ -42,6 +46,16 @@ export const useVegaTransactionUpdater = () => {
     onData: ({ data: result }) =>
       result.data?.orders?.forEach((order) => {
         updateOrder(order);
+      }),
+  });
+
+  usePositionUpdateSubscription({
+    variables,
+    skip,
+    fetchPolicy: 'no-cache',
+    onData: ({ data: result }) =>
+      result.data?.positions.forEach((position) => {
+        updatePosition(position);
       }),
   });
 
@@ -64,7 +78,7 @@ export const useVegaTransactionUpdater = () => {
     variables,
     skip,
     fetchPolicy: 'no-cache',
-    onData: ({ data: result }) => {
+    onData: ({ data: result }) =>
       result.data?.busEvents?.forEach(({ event }) => {
         if (event.__typename === 'TransactionResult') {
           let updateImmediately = true;
@@ -100,7 +114,6 @@ export const useVegaTransactionUpdater = () => {
             updateTransaction(event);
           }
         }
-      });
-    },
+      }),
   });
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #5940

# Description ℹ️

Improve close position toast. Remove information about closing order. Show information about remaining open volume and use orange warning color only if position was not closed (open volume is different than 0) 

# Demo 📺

If transaction was confirmed but position is not closed
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/77fb8c64-8ce1-4110-80d0-d5ab126adfa7)

If transaction is confirmed (closing order can be stopped) but position was successfully closed

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/89679835-4f23-41c8-9969-b84fef271e4b)
  

# Technical 👨‍🔧

Use subscription to positions to update information about open volume in close position transaction. 
