### PR TITLE
fix(trading): dont show margin mode selector on spot markets

### DIFF
--- a/apps/trading/components/market-selector/market-selector.spec.tsx
+++ b/apps/trading/components/market-selector/market-selector.spec.tsx
@@ -198,7 +198,7 @@ describe('MarketSelector', () => {
     await userEvent.click(screen.getByTestId('product-Spot'));
     expect(screen.queryAllByTestId(/market-\d/)).toHaveLength(0);
     expect(screen.getByTestId('no-items')).toHaveTextContent(
-      'Spot markets coming soon.'
+      'No spot markets.'
     );
 
     await userEvent.click(screen.getByTestId('product-Perpetual'));

--- a/apps/trading/components/market-selector/market-selector.tsx
+++ b/apps/trading/components/market-selector/market-selector.tsx
@@ -129,7 +129,7 @@ export const MarketSelector = ({
             filter.product === Product.Perpetual
               ? t('No perpetual markets.')
               : filter.product === Product.Spot
-              ? t('Spot markets coming soon.')
+              ? t('No spot markets.')
               : filter.product === Product.Future
               ? t('No future markets.')
               : t('No markets.')

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-container.tsx
@@ -9,6 +9,7 @@ import {
   useMarketPrice,
   marketInfoProvider,
   markPriceProvider,
+  getProductType,
 } from '@vegaprotocol/markets';
 import { AsyncRendererInline } from '@vegaprotocol/ui-toolkit';
 import { DealTicket } from './deal-ticket';
@@ -53,6 +54,9 @@ export const DealTicketContainer = ({
     variables: { marketId },
   });
   const create = useVegaTransactionStore((state) => state.create);
+
+  const productType = market && getProductType(market);
+
   return (
     <AsyncRendererInline
       data={market && marketData}
@@ -62,7 +66,7 @@ export const DealTicketContainer = ({
     >
       {market && marketData ? (
         <>
-          {featureFlags.ISOLATED_MARGIN && (
+          {featureFlags.ISOLATED_MARGIN && productType !== 'Spot' && (
             <>
               <MarginModeSelector marketId={marketId} />
               <hr className="border-vega-clight-500 dark:border-vega-cdark-500 mb-4" />

--- a/libs/i18n/src/locales/en/trading.json
+++ b/libs/i18n/src/locales/en/trading.json
@@ -388,7 +388,7 @@
   "Slippage": "Slippage",
   "Solo team / lone wolf": "Solo team / lone wolf",
   "Something went wrong": "Something went wrong",
-  "Spot markets coming soon.": "Spot markets coming soon.",
+  "No spot markets.": "No spot markets.",
   "Spot": "Spot",
   "Spread": "Spread",
   "Stake a minimum of {{minimumStakedTokens}} $VEGA tokens": "Stake a minimum of {{minimumStakedTokens}} $VEGA tokens",


### PR DESCRIPTION
# Related issues 🔗

Closes #6236

# Description ℹ️

A couple small changes to support spot markets
- Don't show margin mode selection when on spot
- Change the no markets found message when filtering the markets by type so that it doesn't include 'coming soon'

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
