### PR TITLE
fix(web3): set tx status as error if transacion result is falsy

### DIFF
--- a/libs/web3/src/lib/use-vega-transaction-store.spec.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-store.spec.tsx
@@ -156,6 +156,20 @@ describe('useVegaTransactionStore', () => {
     ).toEqual(transactionResult);
   });
 
+  it('sets status to Error if transaction result status is error', () => {
+    useVegaTransactionStore.getState().create(withdrawSubmission);
+    useVegaTransactionStore.getState().update(0, processedTransactionUpdate);
+    const error = 'error';
+    useVegaTransactionStore.getState().updateTransactionResult({
+      ...transactionResult,
+      status: false,
+      error,
+    });
+    const transaction = useVegaTransactionStore.getState().transactions[0];
+    expect(transaction?.status).toEqual(VegaTxStatus.Error);
+    expect(transaction?.error?.message).toEqual(error);
+  });
+
   it('updates withdrawal', () => {
     useVegaTransactionStore.getState().create(withdrawSubmission);
     useVegaTransactionStore.getState().update(0, processedTransactionUpdate);

--- a/libs/web3/src/lib/use-vega-transaction-store.tsx
+++ b/libs/web3/src/lib/use-vega-transaction-store.tsx
@@ -204,29 +204,31 @@ export const useVegaTransactionStore = create<VegaTransactionStore>()(
           );
           if (transaction) {
             transaction.transactionResult = transactionResult;
+            if (transactionResult.error) {
+              transaction.status = VegaTxStatus.Error;
+              transaction.error = new Error(transactionResult.error);
+            } else {
+              const isConfirmedOrderCancellation =
+                isOrderCancellationTransaction(transaction.body) &&
+                !transaction.body.orderCancellation.orderId;
+              const isConfirmedTransfer = isTransferTransaction(
+                transaction.body
+              );
+              const isConfirmedStopOrderCancellation =
+                isStopOrdersCancellationTransaction(transaction.body);
+              const isConfirmedStopOrderSubmission =
+                isStopOrdersSubmissionTransaction(transaction.body);
+              const isConfirmedMarginModeTransaction =
+                isMarginModeUpdateTransaction(transaction.body);
 
-            const isConfirmedOrderCancellation =
-              isOrderCancellationTransaction(transaction.body) &&
-              !transaction.body.orderCancellation.orderId;
-            const isConfirmedTransfer = isTransferTransaction(transaction.body);
-            const isConfirmedStopOrderCancellation =
-              isStopOrdersCancellationTransaction(transaction.body);
-            const isConfirmedStopOrderSubmission =
-              isStopOrdersSubmissionTransaction(transaction.body);
-            const isConfirmedMarginModeTransaction =
-              isMarginModeUpdateTransaction(transaction.body);
-
-            if (
-              isConfirmedOrderCancellation ||
-              isConfirmedTransfer ||
-              isConfirmedStopOrderCancellation ||
-              isConfirmedStopOrderSubmission ||
-              isConfirmedMarginModeTransaction
-            ) {
-              if (transactionResult.error) {
-                transaction.status = VegaTxStatus.Error;
-                transaction.error = new Error(transactionResult.error);
-              } else if (transactionResult.status) {
+              if (
+                (isConfirmedOrderCancellation ||
+                  isConfirmedTransfer ||
+                  isConfirmedStopOrderCancellation ||
+                  isConfirmedStopOrderSubmission ||
+                  isConfirmedMarginModeTransaction) &&
+                transactionResult.status
+              ) {
                 transaction.status = VegaTxStatus.Complete;
               }
             }


### PR DESCRIPTION
# Related issues 🔗

Closes #6251

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/573d9154-cd58-4ddd-a891-edfc12ccf3d5)

# Technical 👨‍🔧

Error status was not set for all types of transaction
