### PR TITLE
fix(trading): revert max trades from 10 to 500

### DIFF
--- a/libs/trades/src/lib/trades-data-provider.ts
+++ b/libs/trades/src/lib/trades-data-provider.ts
@@ -18,7 +18,7 @@ import {
   type TradesUpdateSubscriptionVariables,
 } from './__generated__/Trades';
 
-export const MAX_TRADES = 10;
+export const MAX_TRADES = 500;
 
 const getData = (
   responseData: TradesQuery | null


### PR DESCRIPTION
# Related issues 🔗

Closes #6245 

# Description ℹ️

* reverts MAX_TRADES to 500

# Demo 📺

![image](https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/49ee9f02-410d-4737-adfa-dd5dd1ea309f)


# Technical 👨‍🔧

N/A
