### PR TITLE
fix(trading): wallet key alias instead of party alias in transfer form

### DIFF
--- a/libs/accounts/src/lib/Accounts.graphql
+++ b/libs/accounts/src/lib/Accounts.graphql
@@ -12,21 +12,6 @@ fragment AccountFields on AccountBalance {
   }
 }
 
-query PartyProfiles($partyIds: [ID!]) {
-  partiesProfilesConnection(ids: $partyIds) {
-    edges {
-      node {
-        partyId
-        alias
-        metadata {
-          key
-          value
-        }
-      }
-    }
-  }
-}
-
 query Accounts($partyId: ID!) {
   party(id: $partyId) {
     id

--- a/libs/accounts/src/lib/__generated__/Accounts.ts
+++ b/libs/accounts/src/lib/__generated__/Accounts.ts
@@ -5,13 +5,6 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type AccountFieldsFragment = { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, market?: { __typename?: 'Market', id: string } | null, asset: { __typename?: 'Asset', id: string }, party?: { __typename?: 'Party', id: string } | null };
 
-export type PartyProfilesQueryVariables = Types.Exact<{
-  partyIds?: Types.InputMaybe<Array<Types.Scalars['ID']> | Types.Scalars['ID']>;
-}>;
-
-
-export type PartyProfilesQuery = { __typename?: 'Query', partiesProfilesConnection?: { __typename?: 'PartiesProfilesConnection', edges: Array<{ __typename?: 'PartyProfileEdge', node: { __typename?: 'PartyProfile', partyId: string, alias: string, metadata: Array<{ __typename?: 'Metadata', key: string, value: string }> } }> } | null };
-
 export type AccountsQueryVariables = Types.Exact<{
   partyId: Types.Scalars['ID'];
 }>;
@@ -41,50 +34,6 @@ export const AccountFieldsFragmentDoc = gql`
   }
 }
     `;
-export const PartyProfilesDocument = gql`
-    query PartyProfiles($partyIds: [ID!]) {
-  partiesProfilesConnection(ids: $partyIds) {
-    edges {
-      node {
-        partyId
-        alias
-        metadata {
-          key
-          value
-        }
-      }
-    }
-  }
-}
-    `;
-
-/**
- * __usePartyProfilesQuery__
- *
- * To run a query within a React component, call `usePartyProfilesQuery` and pass it any options that fit your needs.
- * When your component renders, `usePartyProfilesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = usePartyProfilesQuery({
- *   variables: {
- *      partyIds: // value for 'partyIds'
- *   },
- * });
- */
-export function usePartyProfilesQuery(baseOptions?: Apollo.QueryHookOptions<PartyProfilesQuery, PartyProfilesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<PartyProfilesQuery, PartyProfilesQueryVariables>(PartyProfilesDocument, options);
-      }
-export function usePartyProfilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PartyProfilesQuery, PartyProfilesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<PartyProfilesQuery, PartyProfilesQueryVariables>(PartyProfilesDocument, options);
-        }
-export type PartyProfilesQueryHookResult = ReturnType<typeof usePartyProfilesQuery>;
-export type PartyProfilesLazyQueryHookResult = ReturnType<typeof usePartyProfilesLazyQuery>;
-export type PartyProfilesQueryResult = Apollo.QueryResult<PartyProfilesQuery, PartyProfilesQueryVariables>;
 export const AccountsDocument = gql`
     query Accounts($partyId: ID!) {
   party(id: $partyId) {

--- a/libs/accounts/src/lib/transfer-container.tsx
+++ b/libs/accounts/src/lib/transfer-container.tsx
@@ -54,7 +54,7 @@ export const TransferContainer = ({ assetId }: { assetId?: string }) => {
       </p>
       <TransferForm
         pubKey={pubKey}
-        pubKeys={pubKeys ? pubKeys?.map((pk) => pk.publicKey) : null}
+        pubKeys={pubKeys}
         isReadOnly={isReadOnly}
         assetId={assetId}
         minQuantumMultiple={params.transfer_minTransferQuantumMultiple}

--- a/libs/accounts/src/lib/transfer-form.spec.tsx
+++ b/libs/accounts/src/lib/transfer-form.spec.tsx
@@ -16,7 +16,6 @@ import {
 import { AccountType, AccountTypeMapping } from '@vegaprotocol/types';
 import { removeDecimal } from '@vegaprotocol/utils';
 import type { TransferFeeQuery } from './__generated__/TransferFee';
-import type { PartyProfilesQuery } from './__generated__/Accounts';
 
 const feeFactor = 0.001;
 
@@ -37,38 +36,9 @@ const mockUseTransferFeeQuery = jest.fn(
   }
 );
 
-const mockUsePartyProfilesQuery = jest.fn(
-  ({
-    variables: { partyIds },
-  }: {
-    variables: { partyIds: string[] };
-  }): { data: PartyProfilesQuery } => {
-    return {
-      data: {
-        partiesProfilesConnection: {
-          edges: [
-            {
-              node: {
-                partyId: partyIds[0],
-                alias: 'alias01',
-                metadata: [],
-              },
-            },
-          ],
-        },
-      },
-    };
-  }
-);
-
 jest.mock('./__generated__/TransferFee', () => ({
   useTransferFeeQuery: (props: { variables: { amount: string } }) =>
     mockUseTransferFeeQuery(props),
-}));
-
-jest.mock('./__generated__/Accounts', () => ({
-  usePartyProfilesQuery: (props: { variables: { partyIds: ['party01'] } }) =>
-    mockUsePartyProfilesQuery(props),
 }));
 
 describe('TransferForm', () => {
@@ -110,7 +80,10 @@ describe('TransferForm', () => {
   };
   const props = {
     pubKey,
-    pubKeys: [pubKey, '2'.repeat(64)],
+    pubKeys: [
+      { publicKey: pubKey, name: 'name-1' },
+      { publicKey: '2'.repeat(64), name: 'name-2' },
+    ],
     submitTransfer: jest.fn(),
     accounts: [
       {
@@ -130,8 +103,12 @@ describe('TransferForm', () => {
   const propsNoAssets = {
     pubKey,
     pubKeys: [
-      pubKey,
-      'a4b6e3de5d7ef4e31ae1b090be49d1a2ef7bcefff60cccf7658a0d4922651cce',
+      { publicKey: pubKey, name: 'name-1' },
+      {
+        publicKey:
+          'a4b6e3de5d7ef4e31ae1b090be49d1a2ef7bcefff60cccf7658a0d4922651cce',
+        name: 'name-2',
+      },
     ],
     submitTransfer: jest.fn(),
     accounts: [],
@@ -164,7 +141,7 @@ describe('TransferForm', () => {
     // Select a pubkey
     await userEvent.selectOptions(
       screen.getByLabelText('To Vega key'),
-      props.pubKeys[1]
+      props.pubKeys[1].publicKey
     );
 
     // Select asset
@@ -222,7 +199,7 @@ describe('TransferForm', () => {
     expect(Array.from(keySelect.options).map((o) => o.value)).toEqual([
       '',
       pubKey,
-      props.pubKeys[1],
+      props.pubKeys[1].publicKey,
     ]);
 
     await submit();
@@ -231,7 +208,7 @@ describe('TransferForm', () => {
     // Select a pubkey
     await userEvent.selectOptions(
       screen.getByLabelText('To Vega key'),
-      props.pubKeys[1]
+      props.pubKeys[1].publicKey
     );
 
     // Select asset
@@ -273,7 +250,7 @@ describe('TransferForm', () => {
       expect(props.submitTransfer).toHaveBeenCalledWith({
         fromAccountType: AccountType.ACCOUNT_TYPE_GENERAL,
         toAccountType: AccountType.ACCOUNT_TYPE_GENERAL,
-        to: props.pubKeys[1],
+        to: props.pubKeys[1].publicKey,
         asset: asset.id,
         amount: removeDecimal(amount, asset.decimals),
         oneOff: {},
@@ -291,7 +268,7 @@ describe('TransferForm', () => {
 
     // check current pubkey not shown
     const keySelect: HTMLSelectElement = screen.getByLabelText('To Vega key');
-    const pubKeyOptions = ['', pubKey, props.pubKeys[1]];
+    const pubKeyOptions = ['', pubKey, props.pubKeys[1].publicKey];
     expect(keySelect.children).toHaveLength(pubKeyOptions.length);
     expect(Array.from(keySelect.options).map((o) => o.value)).toEqual(
       pubKeyOptions
@@ -303,7 +280,7 @@ describe('TransferForm', () => {
     // Select a pubkey
     await userEvent.selectOptions(
       screen.getByLabelText('To Vega key'),
-      props.pubKeys[1] // Use not current pubkey so we can check it switches to current pubkey later
+      props.pubKeys[1].publicKey // Use not current pubkey so we can check it switches to current pubkey later
     );
 
     // Select asset
@@ -382,7 +359,7 @@ describe('TransferForm', () => {
     // Select a pubkey
     await userEvent.selectOptions(
       screen.getByLabelText('To Vega key'),
-      props.pubKeys[1] // Use not current pubkey so we can check it switches to current pubkey later
+      props.pubKeys[1].publicKey // Use not current pubkey so we can check it switches to current pubkey later
     );
 
     // Select asset
@@ -439,7 +416,7 @@ describe('TransferForm', () => {
 
     // check current pubkey not shown
     const keySelect: HTMLSelectElement = screen.getByLabelText('To Vega key');
-    const pubKeyOptions = ['', pubKey, props.pubKeys[1]];
+    const pubKeyOptions = ['', pubKey, props.pubKeys[1].publicKey];
     expect(keySelect.children).toHaveLength(pubKeyOptions.length);
     expect(Array.from(keySelect.options).map((o) => o.value)).toEqual(
       pubKeyOptions
@@ -451,7 +428,7 @@ describe('TransferForm', () => {
     // Select a pubkey
     await userEvent.selectOptions(
       screen.getByLabelText('To Vega key'),
-      props.pubKeys[1]
+      props.pubKeys[1].publicKey
     );
 
     // Select asset


### PR DESCRIPTION
# Related issues 🔗

Closes #5743 

# Description ℹ️

Transfer form should make use of **wallet key aliases** instead of **party profile** aliases

# Demo 📺

Now it is using **wallet alias**
<img width="1680" alt="Screenshot 2024-04-23 at 15 20 34" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/25b54eba-e943-4015-a18b-3577bce6803f">

Before it was using **party alias**. 
<img width="656" alt="Screenshot 2024-04-10 at 16 26 25" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/83d4ec96-6436-426f-8ef1-647073ef7c28">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
