### PR TITLE
chore(trading): remove CAF copy from games page

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-home.tsx
+++ b/apps/trading/client-pages/competitions/competitions-home.tsx
@@ -218,7 +218,7 @@ export const CompetitionsHome = () => {
       <p className="mb-6 text-sm">
         <Trans
           i18nKey={
-            'See all the live games on the cards below. Every on-chain game is community funded and designed. <0>Find out how to create one</0>.'
+            'See all the live games on the cards below. <0>Find out how to create one</0>.'
           }
           components={[
             <ExternalLink

--- a/libs/i18n/src/locales/en/trading.json
+++ b/libs/i18n/src/locales/en/trading.json
@@ -375,7 +375,7 @@
   "SCCR": "SCCR",
   "Search": "Search",
   "See all markets": "See all markets",
-  "See all the live games on the cards below. Every on-chain game is community funded and designed. <0>Find out how to create one</0>.": "See all the live games on the cards below. Every on-chain game is community funded and designed. <0>Find out how to create one</0>.",
+  "See all the live games on the cards below. <0>Find out how to create one</0>.": "See all the live games on the cards below. <0>Find out how to create one</0>.",
   "See details of {{count}} rewards": "See details of {{count}} rewards",
   "Select market": "Select market",
   "Set party alias": "Set party alias",


### PR DESCRIPTION
# Related issues 🔗

Closes #6305 

# Description ℹ️

Remove CAF copy from games page.

