### PR TITLE
feat(trading): clean up max size spot orders

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket-validation/margin-warning.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-validation/margin-warning.tsx
@@ -17,9 +17,16 @@ interface Props {
     decimals: number;
   };
   onDeposit: (assetId: string) => void;
+  isSpotMarket?: boolean;
 }
 
-export const MarginWarning = ({ margin, balance, asset, onDeposit }: Props) => {
+export const MarginWarning = ({
+  margin,
+  balance,
+  asset,
+  onDeposit,
+  isSpotMarket,
+}: Props) => {
   const t = useT();
   const description = (
     <div className="flex flex-col items-start gap-2 p-2">
@@ -56,7 +63,13 @@ export const MarginWarning = ({ margin, balance, asset, onDeposit }: Props) => {
         <span className="text-yellow-500 mr-2">
           <VegaIcon name={VegaIconNames.WARNING} />
         </span>
-        {t('You may not have enough margin available to open this position.')}
+        {isSpotMarket
+          ? t(
+              'You may not have enough balance available to complete this order.'
+            )
+          : t(
+              'You may not have enough margin available to open this position.'
+            )}
       </div>
     </Tooltip>
   );

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -435,6 +435,7 @@ export const DealTicket = ({
     positionDecimalPlaces: market.positionDecimalPlaces,
     marketIsInAuction,
     isSpotMarket,
+    feesFactors: market.fees.factors,
   });
 
   const onSubmit = useCallback(
@@ -852,10 +853,16 @@ export const DealTicket = ({
         error={summaryError}
         asset={(useBaseAsset && baseAsset) || asset}
         marketTradingMode={marketData.marketTradingMode}
-        balance={generalAccountBalance}
+        balance={useBaseAsset ? baseAssetAccountBalance : generalAccountBalance}
+        isSpotMarket={isSpotMarket}
         margin={
-          positionEstimate?.estimatePosition?.collateralIncreaseEstimate
-            .bestCase || '0'
+          isSpotMarket
+            ? removeDecimal(
+                (useBaseAsset ? normalizedOrder.size : notionalSize) || '0',
+                asset.decimals - market.decimalPlaces
+              )
+            : positionEstimate?.estimatePosition?.collateralIncreaseEstimate
+                .bestCase || '0'
         }
         isReadOnly={isReadOnly}
         pubKey={pubKey}
@@ -905,6 +912,7 @@ export const DealTicket = ({
  * renders warnings about current state of the market
  */
 interface SummaryMessageProps {
+  isSpotMarket?: boolean;
   error?: { message: string; type: string };
   asset: { id: string; symbol: string; name: string; decimals: number };
   marketTradingMode: MarketData['marketTradingMode'];
@@ -948,6 +956,7 @@ export const NoWalletWarning = ({
 
 const SummaryMessage = memo(
   ({
+    isSpotMarket,
     error,
     asset,
     marketTradingMode,
@@ -991,6 +1000,7 @@ const SummaryMessage = memo(
       return (
         <div className="mb-2">
           <MarginWarning
+            isSpotMarket={isSpotMarket}
             balance={balance}
             margin={margin}
             asset={asset}
@@ -999,6 +1009,7 @@ const SummaryMessage = memo(
         </div>
       );
     }
+
     // Show auction mode warning
     if (
       [

--- a/libs/deal-ticket/src/hooks/use-max-size.spec.ts
+++ b/libs/deal-ticket/src/hooks/use-max-size.spec.ts
@@ -32,6 +32,11 @@ describe('useMaxSize', () => {
     scalingFactors: {
       initialMargin: 1.5,
     },
+    feesFactors: {
+      infrastructureFee: '0.001',
+      liquidityFee: '0.002',
+      makerFee: '0.003',
+    },
     marketIsInAuction: false,
   };
 
@@ -46,15 +51,15 @@ describe('useMaxSize', () => {
         ...initialProps,
         isSpotMarket: true,
       });
-      // generalAccountBalance / markPrice = 100 / 10 = 10
-      expect(result.current).toEqual(10);
+      // generalAccountBalance / markPrice = 100 / 10 = 10 (-fees)
+      expect(result.current).toEqual(9.9);
       rerender({
         ...initialProps,
         type: OrderType.TYPE_LIMIT,
         isSpotMarket: true,
       });
-      // generalAccountBalance / price = 100 / 8 = 10
-      expect(result.current).toEqual(12.5);
+      // generalAccountBalance / price = 100 / 8 = 10 (-fees)
+      expect(result.current).toEqual(12.4);
     });
 
     it('calculates maxSize = baseAssetAccountBalance for sell orders', () => {
@@ -66,7 +71,7 @@ describe('useMaxSize', () => {
         baseAssetDecimals,
         isSpotMarket: true,
       });
-      expect(result.current).toEqual(50);
+      expect(result.current).toEqual(49.7);
     });
   });
 

--- a/libs/deal-ticket/src/hooks/use-max-size.ts
+++ b/libs/deal-ticket/src/hooks/use-max-size.ts
@@ -24,6 +24,7 @@ export interface UseMaxSizeProps {
   positionDecimalPlaces: number;
   price?: string;
   riskFactors: MarketInfo['riskFactors'];
+  feesFactors: MarketInfo['fees']['factors'];
   scalingFactors?: Pick<
     NonNullable<
       MarketInfo['tradableInstrument']['marginCalculator']
@@ -57,6 +58,7 @@ export const useMaxSize = ({
   isSpotMarket,
   baseAssetAccountBalance,
   baseAssetDecimals,
+  feesFactors,
 }: UseMaxSizeProps) =>
   useMemo(() => {
     let maxSize = new BigNumber(0);
@@ -73,6 +75,12 @@ export const useMaxSize = ({
           maxSize = toBigNum(baseAssetAccountBalance, baseAssetDecimals);
         }
       }
+      maxSize = maxSize.multipliedBy(
+        1 -
+          Number(feesFactors.infrastructureFee) -
+          Number(feesFactors.liquidityFee) -
+          Number(feesFactors.makerFee)
+      );
       // round to size step
       maxSize = maxSize.minus(
         maxSize.mod(determineSizeStep({ positionDecimalPlaces }))
@@ -190,4 +198,7 @@ export const useMaxSize = ({
     baseAssetAccountBalance,
     baseAssetDecimals,
     isSpotMarket,
+    feesFactors.infrastructureFee,
+    feesFactors.liquidityFee,
+    feesFactors.makerFee,
   ]);

--- a/libs/i18n/src/locales/en/deal-ticket.json
+++ b/libs/i18n/src/locales/en/deal-ticket.json
@@ -168,6 +168,7 @@
   "You have only {{amount}}.": "You have only {{amount}}.",
   "You have an existing position and open orders on this market": "You have an existing position and open orders on this market",
   "You may not have enough margin available to open this position.": "You may not have enough margin available to open this position.",
+  "You may not have enough balance available to complete this order.": "You may not have enough balance available to complete this order.",
   "You need {{symbol}} in your wallet to trade in this market.": "You need {{symbol}} in your wallet to trade in this market.",
   "You need a Vega wallet to start trading on this market": "You need a Vega wallet to start trading on this market",
   "You need to provide a expiry time/date": "You need to provide a expiry time/date",


### PR DESCRIPTION
# Related issues 🔗

Closes #6272 

# Description ℹ️

Include fee when calculating max size of spot order. Show low balance warning if order estimated size if greater then balance.