### PR TITLE
fix(explorer): update types and add label for new asset in batch

### DIFF
--- a/apps/explorer/project.json
+++ b/apps/explorer/project.json
@@ -70,7 +70,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "npx openapi-typescript https://raw.githubusercontent.com/vegaprotocol/documentation/main/specs/v0.73.1/blockexplorer.openapi.json --output apps/explorer/src/types/explorer.d.ts --immutable-types"
+          "npx openapi-typescript https://raw.githubusercontent.com/vegaprotocol/documentation/main/specs/v0.76.0/blockexplorer.openapi.json --output apps/explorer/src/types/explorer.d.ts --immutable-types"
         ]
       }
     },

--- a/apps/explorer/src/app/components/txs/details/proposal/batch-item.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/batch-item.tsx
@@ -81,6 +81,8 @@ export const BatchItem = ({ item }: BatchItemProps) => {
     );
   } else if (item.updateVolumeDiscountProgram) {
     return <span>{t('Update volume discount program')}</span>;
+  } else if (item.newAsset) {
+    return <span>{t('New asset')}</span>;
   }
 
   return <span>{t('Unknown proposal type')}</span>;

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
@@ -42,6 +42,7 @@ const AccountType: Record<AccountTypes, string> = {
   ACCOUNT_TYPE_REWARD_VALIDATOR_RANKING: 'Reward Validator Ranking',
   ACCOUNT_TYPE_PENDING_FEE_REFERRAL_REWARD: 'Pending Fee Referral Reward',
   ACCOUNT_TYPE_ORDER_MARGIN: 'Order Margin',
+  ACCOUNT_TYPE_REWARD_REALISED_RETURN: 'Reward Realised Return',
 };
 
 export type TransferFee = {

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-rewards.tsx
@@ -17,6 +17,7 @@ export const headerClasses =
 
 const metricLabels: Record<Metric, string> = {
   DISPATCH_METRIC_UNSPECIFIED: 'Unknown metric',
+  DISPATCH_METRIC_REALISED_RETURN: 'Realised return',
   ...DispatchMetricLabels,
 };
 


### PR DESCRIPTION
# Related issues 🔗

Closes #6301

# Description ℹ️

Adds a label for a batch proposal type that was added in 0.76

Note this won't be visible until https://github.com/vegaprotocol/vega/pull/11199 is merged

# Demo 📺

## Before fix is applied
<img width="563" alt="Screenshot 2024-04-26 at 11 35 04" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/fb41a5f6-437d-4b27-984d-162c55bae658">

## After fix is applied
Note this won't be visible until https://github.com/vegaprotocol/vega/pull/11199 is merged. But then it'll work, and it'll be great.