### PR TITLE
fix(trading): decimal places tooltips

### DIFF
--- a/libs/i18n/src/locales/en/markets.json
+++ b/libs/i18n/src/locales/en/markets.json
@@ -135,6 +135,7 @@
   "The scaling between the liquidity demand estimate, based on open interest and target stake.": "The scaling between the liquidity demand estimate, based on open interest and target stake.",
   "The second currency in a pair for a currency-based derivatives market.": "The second currency in a pair for a currency-based derivatives market.",
   "The smallest price increment on the book.": "The smallest price increment on the book.",
+  "The smallest order / position size on this market is 10^(-pdp).": "The smallest order / position size on this market is 10^(-pdp).",
   "The total number of contracts traded in the last 24 hours.": "The total number of contracts traded in the last 24 hours.",
   "The trading mode the market is currently running.": "The trading mode the market is currently running.",
   "The triggering ratio for entering liquidity auction.": "The triggering ratio for entering liquidity auction.",

--- a/libs/markets/src/lib/components/market-info/tooltip-mapping.tsx
+++ b/libs/markets/src/lib/components/market-info/tooltip-mapping.tsx
@@ -40,10 +40,15 @@ export const useTooltipMapping: () => Record<string, ReactNode> = () => {
     bestStaticOfferVolume: t(
       'The aggregated volume being offered at the best static offer price on the market.'
     ),
-    marketDecimalPlaces: t('The smallest price increment on the book.'),
-    decimalPlaces: t('The smallest price increment on the book.'),
+    decimalPlaces: t(
+      'The number of decimal places supported by the market price.'
+    ),
+    marketDecimalPlaces: t(
+      'The number of decimal places supported by the market price.'
+    ),
+    tickSize: t('The smallest price increment on the book.'),
     positionDecimalPlaces: t(
-      'How big the smallest order / position on the market can be.'
+      'The smallest order / position size on this market is 10^(-pdp).'
     ),
     tradingMode: t('The trading mode the market is currently running.'),
     state: t('The current state of the market'),


### PR DESCRIPTION
# Related issues 🔗

Closes #6304 

# Description ℹ️

- [x]  Tooltip for market decimals: "The number of decimal places supported by the market price"
- [x]  Tooltip for tick size: "The smallest price increment on the book"

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
