### PR TITLE
feat(trading): market trading mode icons

### DIFF
--- a/apps/trading/client-pages/markets/market-icon.tsx
+++ b/apps/trading/client-pages/markets/market-icon.tsx
@@ -4,53 +4,52 @@ import { VegaIconNames, VegaIcon, Tooltip } from '@vegaprotocol/ui-toolkit';
 import { useT } from '../../lib/use-t';
 
 export const getTradingModeIcon = (
-  tradingMode: MarketTradingMode,
   state?: MarketState
 ): VegaIconNames | null => {
-  switch (tradingMode) {
-    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
-    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
-    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
+  switch (state) {
+    case MarketState.STATE_PENDING:
+    case MarketState.STATE_PROPOSED:
+      return VegaIconNames.MONITOR;
+    case MarketState.STATE_SUSPENDED: // market in auction
       return VegaIconNames.HAMMER;
-    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
+    case MarketState.STATE_SUSPENDED_VIA_GOVERNANCE:
       return VegaIconNames.PAUSE;
-    case MarketTradingMode.TRADING_MODE_NO_TRADING:
-      switch (state) {
-        case MarketState.STATE_PENDING:
-        case MarketState.STATE_PROPOSED:
-          return VegaIconNames.MONITOR;
-        default:
-          return VegaIconNames.CLOSED;
-      }
+
+    case MarketState.STATE_SETTLED:
+    case MarketState.STATE_CLOSED:
+    case MarketState.STATE_TRADING_TERMINATED:
+    case MarketState.STATE_REJECTED:
+      return VegaIconNames.CLOSED;
     default:
       return null;
   }
 };
 
 export const getTradingModeTooltip = (
-  tradingMode?: MarketTradingMode,
-  state?: MarketState
+  state?: MarketState,
+  tradingMode?: MarketTradingMode
 ): string => {
-  switch (tradingMode) {
-    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
-      return 'In protective auction due to large price movement, crossed orders are required to set price and restart trading';
-    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
-      return 'In opening auction, liquidity and crossed orders are required to set an opening price and start trading';
-    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
+  switch (state) {
+    case MarketState.STATE_SETTLED:
+      return 'Market is settled and all positions are closed';
+    case MarketState.STATE_PENDING:
+    case MarketState.STATE_PROPOSED:
+      return 'Voting is in progress on this proposed market';
+    case MarketState.STATE_TRADING_TERMINATED:
+      return 'Market is terminated and awaiting settlement data';
+    case MarketState.STATE_SUSPENDED_VIA_GOVERNANCE:
       return 'Trading is suspended due to governance';
-    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
-      return 'Market is in batch auction';
-    case MarketTradingMode.TRADING_MODE_NO_TRADING:
-      switch (state) {
-        case MarketState.STATE_SETTLED:
-          return 'Market is settled and all positions are closed';
-        case MarketState.STATE_PENDING:
-        case MarketState.STATE_PROPOSED:
-          return 'Voting is in progress on this proposed market';
+    case MarketState.STATE_SUSPENDED:
+      switch (tradingMode) {
+        case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
+          return 'In protective auction due to large price movement, crossed orders are required to set price and restart trading';
+        case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
+          return 'In opening auction, liquidity and crossed orders are required to set an opening price and start trading';
+        case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
+          return 'Market is in batch auction';
         default:
-          return 'Market is terminated and awaiting settlement data';
+          return '';
       }
-    case MarketTradingMode.TRADING_MODE_CONTINUOUS:
     default:
       return '';
   }
@@ -60,13 +59,13 @@ export const MarketIcon = ({ data }: { data?: MarketMaybeWithData | null }) => {
   const t = useT();
   const tradingMode = data?.data?.marketTradingMode;
   const state = data?.data?.marketState;
-  const icon = tradingMode && getTradingModeIcon(tradingMode, state);
-  const tooltip = getTradingModeTooltip(tradingMode, state);
+  const icon = getTradingModeIcon(state);
+  const tooltip = getTradingModeTooltip(state, tradingMode);
 
   if (!icon) return null;
   return (
     <Tooltip description={t(tooltip)}>
-      <VegaIcon name={icon} size={14} className="ml-1" />
+      <VegaIcon name={icon} size={16} className="ml-1" />
     </Tooltip>
   );
 };

--- a/apps/trading/client-pages/markets/market-icon.tsx
+++ b/apps/trading/client-pages/markets/market-icon.tsx
@@ -1,0 +1,72 @@
+import { type MarketMaybeWithData } from '@vegaprotocol/markets';
+import { MarketTradingMode, MarketState } from '@vegaprotocol/types';
+import { VegaIconNames, VegaIcon, Tooltip } from '@vegaprotocol/ui-toolkit';
+import { useT } from '../../lib/use-t';
+
+export const getTradingModeIcon = (
+  tradingMode: MarketTradingMode,
+  state?: MarketState
+): VegaIconNames | null => {
+  switch (tradingMode) {
+    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
+    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
+    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
+      return VegaIconNames.HAMMER;
+    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
+      return VegaIconNames.PAUSE;
+    case MarketTradingMode.TRADING_MODE_NO_TRADING:
+      switch (state) {
+        case MarketState.STATE_PENDING:
+        case MarketState.STATE_PROPOSED:
+          return VegaIconNames.MONITOR;
+        default:
+          return VegaIconNames.CLOSED;
+      }
+    default:
+      return null;
+  }
+};
+
+export const getTradingModeTooltip = (
+  tradingMode?: MarketTradingMode,
+  state?: MarketState
+): string => {
+  switch (tradingMode) {
+    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
+      return 'In protective auction due to large price movement, crossed orders are required to set price and restart trading';
+    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
+      return 'In opening auction, liquidity and crossed orders are required to set an opening price and start trading';
+    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
+      return 'Trading is suspended due to governance';
+    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
+      return 'Market is in batch auction';
+    case MarketTradingMode.TRADING_MODE_NO_TRADING:
+      switch (state) {
+        case MarketState.STATE_SETTLED:
+          return 'Market is settled and all positions are closed';
+        case MarketState.STATE_PENDING:
+        case MarketState.STATE_PROPOSED:
+          return 'Voting is in progress on this proposed market';
+        default:
+          return 'Market is terminated and awaiting settlement data';
+      }
+    case MarketTradingMode.TRADING_MODE_CONTINUOUS:
+    default:
+      return '';
+  }
+};
+
+export const MarketIcon = ({ data }: { data?: MarketMaybeWithData | null }) => {
+  const t = useT();
+  const tradingMode = data?.data?.marketTradingMode;
+  const state = data?.data?.marketState;
+  const icon = tradingMode && getTradingModeIcon(tradingMode, state);
+  const tooltip = getTradingModeTooltip(tradingMode, state);
+
+  if (!icon) return null;
+  return (
+    <Tooltip description={t(tooltip)}>
+      <VegaIcon name={icon} size={14} className="ml-1" />
+    </Tooltip>
+  );
+};

--- a/apps/trading/client-pages/markets/market-icon.tsx
+++ b/apps/trading/client-pages/markets/market-icon.tsx
@@ -18,8 +18,10 @@ export const getTradingModeIcon = (
     case MarketState.STATE_SETTLED:
     case MarketState.STATE_CLOSED:
     case MarketState.STATE_TRADING_TERMINATED:
+    case MarketState.STATE_CANCELLED:
     case MarketState.STATE_REJECTED:
       return VegaIconNames.CLOSED;
+    case MarketState.STATE_ACTIVE:
     default:
       return null;
   }
@@ -33,12 +35,19 @@ export const getTradingModeTooltip = (
     case MarketState.STATE_SETTLED:
       return 'Market is settled and all positions are closed';
     case MarketState.STATE_PENDING:
+      return 'Governance vote passed, market is pending trading';
     case MarketState.STATE_PROPOSED:
       return 'Voting is in progress on this proposed market';
     case MarketState.STATE_TRADING_TERMINATED:
       return 'Market is terminated and awaiting settlement data';
     case MarketState.STATE_SUSPENDED_VIA_GOVERNANCE:
       return 'Trading is suspended due to governance';
+    case MarketState.STATE_CANCELLED:
+      return 'Market is cancelled';
+    case MarketState.STATE_REJECTED:
+      return 'Market is rejected';
+    case MarketState.STATE_CLOSED:
+      return 'Market is closed';
     case MarketState.STATE_SUSPENDED:
       switch (tradingMode) {
         case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
@@ -50,6 +59,7 @@ export const getTradingModeTooltip = (
         default:
           return '';
       }
+    case MarketState.STATE_ACTIVE:
     default:
       return '';
   }

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -12,12 +12,7 @@ import {
   priceChange,
   toBigNum,
 } from '@vegaprotocol/utils';
-import {
-  Sparkline,
-  TooltipCellComponent,
-  VegaIcon,
-  VegaIconNames,
-} from '@vegaprotocol/ui-toolkit';
+import { Sparkline, TooltipCellComponent } from '@vegaprotocol/ui-toolkit';
 import type {
   MarketMaybeWithData,
   MarketMaybeWithDataAndCandles,
@@ -32,60 +27,7 @@ import {
 import { useT } from '../../lib/use-t';
 import { EmblemByMarket } from '@vegaprotocol/emblem';
 import { useChainId } from '@vegaprotocol/wallet-react';
-import { MarketState, MarketTradingMode } from '@vegaprotocol/types';
-
-const getTradingModeIcon = (
-  tradingMode: MarketTradingMode,
-  state?: MarketState
-): VegaIconNames | null => {
-  switch (tradingMode) {
-    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
-    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
-    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
-      return VegaIconNames.HAMMER;
-    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
-      return VegaIconNames.PAUSE;
-    case MarketTradingMode.TRADING_MODE_NO_TRADING:
-      switch (state) {
-        case MarketState.STATE_PENDING:
-        case MarketState.STATE_PROPOSED:
-          return VegaIconNames.MONITOR;
-        default:
-          return VegaIconNames.CLOSED;
-      }
-    default:
-      return null;
-  }
-};
-
-const getTradingModeTooltip = (
-  tradingMode?: MarketTradingMode,
-  state?: MarketState
-): string => {
-  switch (tradingMode) {
-    case MarketTradingMode.TRADING_MODE_MONITORING_AUCTION:
-      return 'In protective auction due to large price movement, crossed orders are required to set price and restart trading';
-    case MarketTradingMode.TRADING_MODE_OPENING_AUCTION:
-      return 'In opening auction, liquidity and crossed orders are required to set an opening price and start trading';
-    case MarketTradingMode.TRADING_MODE_SUSPENDED_VIA_GOVERNANCE:
-      return 'Trading is suspended due to governance';
-    case MarketTradingMode.TRADING_MODE_BATCH_AUCTION:
-      return 'Market is in batch auction';
-    case MarketTradingMode.TRADING_MODE_NO_TRADING:
-      switch (state) {
-        case MarketState.STATE_SETTLED:
-          return 'Market is settled and all positions are closed';
-        case MarketState.STATE_PENDING:
-        case MarketState.STATE_PROPOSED:
-          return 'Voting is in progress on this proposed market';
-        default:
-          return 'Market is terminated and awaiting settlement data';
-      }
-    case MarketTradingMode.TRADING_MODE_CONTINUOUS:
-    default:
-      return '';
-  }
-};
+import { MarketIcon, getTradingModeTooltip } from './market-icon';
 
 const openInterestRenderer = (data: MarketMaybeWithData | undefined) => {
   if (!data) return '-';
@@ -209,9 +151,6 @@ export const useMarketsColumnDefs = () => {
           MarketMaybeWithData,
           'tradableInstrument.instrument.code'
         >) => {
-          const tradingMode = data?.data?.marketTradingMode;
-          const state = data?.data?.marketState;
-          const icon = tradingMode && getTradingModeIcon(tradingMode, state);
           return (
             <span className="flex items-center gap-2 cursor-pointer">
               <span className="mr-2">
@@ -220,9 +159,7 @@ export const useMarketsColumnDefs = () => {
               <StackedCell
                 primary={value}
                 secondary={data?.tradableInstrument.instrument.name}
-                primaryIcon={
-                  icon && <VegaIcon name={icon} size={14} className="ml-1" />
-                }
+                primaryIcon={<MarketIcon data={data} />}
               />
             </span>
           );

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -14,7 +14,7 @@ import {
 } from '@vegaprotocol/utils';
 import {
   Sparkline,
-  Tooltip,
+  TooltipCellComponent,
   VegaIcon,
   VegaIconNames,
 } from '@vegaprotocol/ui-toolkit';
@@ -194,6 +194,14 @@ export const useMarketsColumnDefs = () => {
         headerName: t('Market'),
         field: 'tradableInstrument.instrument.code',
         minWidth: 150,
+        pinned: true,
+        tooltipComponent: TooltipCellComponent,
+        tooltipValueGetter: ({ value, data }) => {
+          const tradingMode = data?.data?.marketTradingMode;
+          const state = data?.data?.marketState;
+          const tooltip = getTradingModeTooltip(tradingMode, state);
+          return t(tooltip);
+        },
         cellRenderer: ({
           value,
           data,
@@ -204,7 +212,6 @@ export const useMarketsColumnDefs = () => {
           const tradingMode = data?.data?.marketTradingMode;
           const state = data?.data?.marketState;
           const icon = tradingMode && getTradingModeIcon(tradingMode, state);
-          const tooltip = getTradingModeTooltip(tradingMode, state);
           return (
             <span className="flex items-center gap-2 cursor-pointer">
               <span className="mr-2">
@@ -214,11 +221,7 @@ export const useMarketsColumnDefs = () => {
                 primary={value}
                 secondary={data?.tradableInstrument.instrument.name}
                 primaryIcon={
-                  icon ? (
-                    <Tooltip description={t(tooltip)}>
-                      <VegaIcon name={icon} size={14} className="ml-1" />
-                    </Tooltip>
-                  ) : undefined
+                  icon && <VegaIcon name={icon} size={14} className="ml-1" />
                 }
               />
             </span>

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -234,6 +234,7 @@ export const useMarketsColumnDefs = () => {
         type: 'rightAligned',
         cellRenderer: 'PriceFlashCell',
         filter: 'agNumberColumnFilter',
+        maxWidth: 150,
         valueGetter: ({ data }: VegaValueGetterParams<MarketMaybeWithData>) => {
           if (
             data?.tradableInstrument.instrument.product.__typename === 'Spot'

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -5,14 +5,14 @@ import type {
   VegaValueFormatterParams,
   VegaValueGetterParams,
 } from '@vegaprotocol/datagrid';
-import { StackedCell } from '@vegaprotocol/datagrid';
+import { MarketProductPill, StackedCell } from '@vegaprotocol/datagrid';
 import {
   addDecimalsFormatNumber,
   formatNumber,
   priceChange,
   toBigNum,
 } from '@vegaprotocol/utils';
-import { Sparkline, TooltipCellComponent } from '@vegaprotocol/ui-toolkit';
+import { Sparkline, Tooltip } from '@vegaprotocol/ui-toolkit';
 import type {
   MarketMaybeWithData,
   MarketMaybeWithDataAndCandles,
@@ -137,13 +137,6 @@ export const useMarketsColumnDefs = () => {
         field: 'tradableInstrument.instrument.code',
         minWidth: 150,
         pinned: true,
-        tooltipComponent: TooltipCellComponent,
-        tooltipValueGetter: ({ value, data }) => {
-          const tradingMode = data?.data?.marketTradingMode;
-          const state = data?.data?.marketState;
-          const tooltip = getTradingModeTooltip(tradingMode, state);
-          return t(tooltip);
-        },
         cellRenderer: ({
           value,
           data,
@@ -151,17 +144,33 @@ export const useMarketsColumnDefs = () => {
           MarketMaybeWithData,
           'tradableInstrument.instrument.code'
         >) => {
+          const tradingMode = data?.data?.marketTradingMode;
+          const state = data?.data?.marketState;
+          const tooltip = getTradingModeTooltip(state, tradingMode);
+          const productType =
+            data?.tradableInstrument.instrument.product.__typename;
           return (
-            <span className="flex items-center gap-2 cursor-pointer">
-              <span className="mr-2">
-                <EmblemByMarket market={data?.id || ''} vegaChain={chainId} />
+            <Tooltip description={t(tooltip)}>
+              <span className="flex items-center gap-2 cursor-pointer">
+                <span className="mr-2">
+                  <EmblemByMarket market={data?.id || ''} vegaChain={chainId} />
+                </span>
+                <StackedCell
+                  primary={value}
+                  secondary={data?.tradableInstrument.instrument.name}
+                  primaryIcon={
+                    <>
+                      <span>
+                        <MarketIcon data={data} />
+                      </span>
+                      <span className="ml-0.5">
+                        <MarketProductPill productType={productType} />
+                      </span>
+                    </>
+                  }
+                />
               </span>
-              <StackedCell
-                primary={value}
-                secondary={data?.tradableInstrument.instrument.name}
-                primaryIcon={<MarketIcon data={data} />}
-              />
-            </span>
+            </Tooltip>
           );
         },
       },

--- a/apps/trading/components/market-selector/market-selector-item.tsx
+++ b/apps/trading/components/market-selector/market-selector-item.tsx
@@ -15,7 +15,6 @@ import { MarketProductPill } from '@vegaprotocol/datagrid';
 import { useT } from '../../lib/use-t';
 import { EmblemByMarket } from '@vegaprotocol/emblem';
 import { useChainId } from '@vegaprotocol/wallet-react';
-import { MarketIcon } from '../../client-pages/markets/market-icon';
 
 export const MarketSelectorItem = ({
   market,
@@ -112,12 +111,7 @@ const MarketData = ({
             {market.tradableInstrument.instrument.code}
           </span>
           {allProducts && productType && (
-            <>
-              <MarketProductPill productType={productType} />{' '}
-              <span className="pt-1">
-                <MarketIcon data={market} />
-              </span>
-            </>
+            <MarketProductPill productType={productType} />
           )}
         </h3>
         {mode && (

--- a/apps/trading/components/market-selector/market-selector-item.tsx
+++ b/apps/trading/components/market-selector/market-selector-item.tsx
@@ -112,9 +112,13 @@ const MarketData = ({
             {market.tradableInstrument.instrument.code}
           </span>
           {allProducts && productType && (
-            <MarketProductPill productType={productType} />
+            <>
+              <MarketProductPill productType={productType} />{' '}
+              <span className="pt-1">
+                <MarketIcon data={market} />
+              </span>
+            </>
           )}
-          <MarketIcon data={market} />
         </h3>
         {mode && (
           <p className="text-xs text-vega-orange-500 dark:text-vega-orange-550 whitespace-nowrap">

--- a/apps/trading/components/market-selector/market-selector-item.tsx
+++ b/apps/trading/components/market-selector/market-selector-item.tsx
@@ -15,6 +15,7 @@ import { MarketProductPill } from '@vegaprotocol/datagrid';
 import { useT } from '../../lib/use-t';
 import { EmblemByMarket } from '@vegaprotocol/emblem';
 import { useChainId } from '@vegaprotocol/wallet-react';
+import { MarketIcon } from '../../client-pages/markets/market-icon';
 
 export const MarketSelectorItem = ({
   market,
@@ -113,6 +114,7 @@ const MarketData = ({
           {allProducts && productType && (
             <MarketProductPill productType={productType} />
           )}
+          <MarketIcon data={market} />
         </h3>
         {mode && (
           <p className="text-xs text-vega-orange-500 dark:text-vega-orange-550 whitespace-nowrap">

--- a/libs/datagrid/src/lib/cells/market-name-cell.tsx
+++ b/libs/datagrid/src/lib/cells/market-name-cell.tsx
@@ -19,7 +19,7 @@ export const MarketProductPill = ({
   }
   return (
     <Pill
-      size="xxs"
+      size="xs"
       className="uppercase ml-0.5"
       title={ProductTypeMapping[productType]}
     >

--- a/libs/datagrid/src/lib/cells/stacked-cell.tsx
+++ b/libs/datagrid/src/lib/cells/stacked-cell.tsx
@@ -3,9 +3,11 @@ import type { ReactNode } from 'react';
 export const StackedCell = ({
   primary,
   secondary,
+  primaryIcon,
 }: {
   primary: ReactNode;
   secondary: ReactNode;
+  primaryIcon?: ReactNode;
 }) => {
   return (
     <div className="leading-4">
@@ -13,7 +15,8 @@ export const StackedCell = ({
         className="text-ellipsis whitespace-nowrap overflow-hidden"
         data-testid="stack-cell-primary"
       >
-        {primary}
+        <span>{primary}</span>
+        {primaryIcon && <span>{primaryIcon}</span>}
       </div>
       <div
         data-testid="stack-cell-secondary"

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
@@ -3,11 +3,19 @@ export const IconClosed = ({ size = 16 }: { size: number }) => {
     <svg
       width={size}
       height={size}
-      viewBox="0 0 22 22"
+      viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <circle cx="11" cy="11" r="10" stroke="white" />
+      <circle cx="12" cy="12" r="10" stroke="currentColor" />
+      <line
+        x1="4.92896"
+        y1="18.364"
+        x2="18.364"
+        y2="4.92892"
+        stroke="currentColor"
+        stroke-linecap="round"
+      />
     </svg>
   );
 };

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
@@ -1,0 +1,13 @@
+export const IconClosed = ({ size = 16 }: { size: number }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 22 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="11" cy="11" r="10" stroke="white" />
+    </svg>
+  );
+};

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-closed.tsx
@@ -1,4 +1,35 @@
-export const IconClosed = ({ size = 16 }: { size: number }) => {
+export const IconClosed = ({
+  size = 16,
+  background = true,
+}: {
+  size?: number;
+  background?: boolean;
+}) => {
+  if (background) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10Z"
+          fill="#323339"
+        />
+        <circle cx="10" cy="9.99998" r="6" stroke="white" />
+        <line
+          x1="5.75732"
+          y1="13.5355"
+          x2="13.5355"
+          y2="5.75736"
+          stroke="white"
+          stroke-linecap="round"
+        />
+      </svg>
+    );
+  }
   return (
     <svg
       width={size}

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
@@ -1,0 +1,30 @@
+export const IconHammer = ({ size = 16 }: { size: number }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 23 23"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="12.6606"
+        y="13.3119"
+        width="12"
+        height="4.49049"
+        transform="rotate(135 12.6606 13.3119)"
+        stroke="white"
+        stroke-linejoin="round"
+      />
+      <rect
+        x="11.6919"
+        y="1"
+        width="14"
+        height="8"
+        transform="rotate(45 11.6919 1)"
+        stroke="white"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
@@ -13,7 +13,7 @@ export const IconHammer = ({ size = 16 }: { size: number }) => {
         width="12"
         height="4.49049"
         transform="rotate(135 12.6606 13.3119)"
-        stroke="white"
+        stroke="currentColor"
         stroke-linejoin="round"
       />
       <rect
@@ -22,7 +22,7 @@ export const IconHammer = ({ size = 16 }: { size: number }) => {
         width="14"
         height="8"
         transform="rotate(45 11.6919 1)"
-        stroke="white"
+        stroke="currentColor"
         stroke-linejoin="round"
       />
     </svg>

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-hammer.tsx
@@ -1,4 +1,44 @@
-export const IconHammer = ({ size = 16 }: { size: number }) => {
+export const IconHammer = ({
+  size = 16,
+  background = true,
+}: {
+  size?: number;
+  background?: boolean;
+}) => {
+  if (background) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10Z"
+          fill="#323339"
+        />
+        <rect
+          x="8.59424"
+          y="8.65686"
+          width="3"
+          height="6.4974"
+          transform="rotate(45 8.59424 8.65686)"
+          stroke="white"
+          stroke-linejoin="round"
+        />
+        <rect
+          x="10.0942"
+          y="3"
+          width="9.07233"
+          height="5"
+          transform="rotate(45 10.0942 3)"
+          stroke="white"
+          stroke-linejoin="round"
+        />
+      </svg>
+    );
+  }
   return (
     <svg
       width={size}

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
@@ -1,4 +1,47 @@
-export const IconMonitor = ({ size = 16 }: { size: number }) => {
+export const IconMonitor = ({
+  size = 16,
+  background = true,
+}: {
+  size?: number;
+  background?: boolean;
+}) => {
+  if (background) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10Z"
+          fill="#323339"
+        />
+        <rect
+          x="6"
+          y="5"
+          width="8"
+          height="6.66667"
+          stroke="white"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M4 12V14H16V12"
+          stroke="white"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M8 8.33333L9.33333 9.66667L12 7"
+          stroke="white"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    );
+  }
   return (
     <svg
       width={size}

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
@@ -12,19 +12,19 @@ export const IconMonitor = ({ size = 16 }: { size: number }) => {
         y="5"
         width="12"
         height="10"
-        stroke="white"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
       />
       <path
         d="M3 15V18H21V15"
-        stroke="white"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
       />
       <path
         d="M9 10L11 12L15 8"
-        stroke="white"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
       />

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-monitor.tsx
@@ -1,0 +1,33 @@
+export const IconMonitor = ({ size = 16 }: { size: number }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="6"
+        y="5"
+        width="12"
+        height="10"
+        stroke="white"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M3 15V18H21V15"
+        stroke="white"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 10L11 12L15 8"
+        stroke="white"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
@@ -1,4 +1,43 @@
-export const IconPause = ({ size = 16 }: { size: number }) => {
+export const IconPause = ({
+  size = 16,
+  background = true,
+}: {
+  size?: number;
+  background?: boolean;
+}) => {
+  if (background) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10Z"
+          fill="#65676b"
+        />
+        <circle cx="10" cy="9.99998" r="6" stroke="white" />
+        <line
+          x1="8.5"
+          y1="7.83333"
+          x2="8.5"
+          y2="11.8333"
+          stroke="white"
+          stroke-linecap="round"
+        />
+        <line
+          x1="11.8333"
+          y1="7.83333"
+          x2="11.8333"
+          y2="11.8333"
+          stroke="white"
+          stroke-linecap="round"
+        />
+      </svg>
+    );
+  }
   return (
     <svg
       width={size}

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
@@ -7,13 +7,13 @@ export const IconPause = ({ size = 16 }: { size: number }) => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <circle cx="12" cy="12" r="10" stroke="white" />
+      <circle cx="12" cy="12" r="10" stroke="currentColor" />
       <line
         x1="9.5"
         y1="8.5"
         x2="9.5"
         y2="15.5"
-        stroke="white"
+        stroke="currentColor"
         stroke-linecap="round"
       />
       <line
@@ -21,7 +21,7 @@ export const IconPause = ({ size = 16 }: { size: number }) => {
         y1="8.5"
         x2="14.5"
         y2="15.5"
-        stroke="white"
+        stroke="currentColor"
         stroke-linecap="round"
       />
     </svg>

--- a/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/svg-icons/icon-pause.tsx
@@ -1,0 +1,29 @@
+export const IconPause = ({ size = 16 }: { size: number }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="10" stroke="white" />
+      <line
+        x1="9.5"
+        y1="8.5"
+        x2="9.5"
+        y2="15.5"
+        stroke="white"
+        stroke-linecap="round"
+      />
+      <line
+        x1="14.5"
+        y1="8.5"
+        x2="14.5"
+        y2="15.5"
+        stroke="white"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+};

--- a/libs/ui-toolkit/src/components/icon/vega-icons/vega-icon-record.ts
+++ b/libs/ui-toolkit/src/components/icon/vega-icons/vega-icon-record.ts
@@ -44,6 +44,10 @@ import { IconWithdraw } from './svg-icons/icon-withdraw';
 import { IconMan } from './svg-icons/icon-man';
 import { IconTeam } from './svg-icons/icon-team';
 import { IconStreak } from './svg-icons/icon-streak';
+import { IconHammer } from './svg-icons/icon-hammer';
+import { IconMonitor } from './svg-icons/icon-monitor';
+import { IconPause } from './svg-icons/icon-pause';
+import { IconClosed } from './svg-icons/icon-closed';
 
 export enum VegaIconNames {
   ARROW_DOWN = 'arrow-down',
@@ -92,6 +96,10 @@ export enum VegaIconNames {
   WARNING = 'warning',
   MAN = 'man',
   TEAM = 'team',
+  MONITOR = 'monitor',
+  HAMMER = 'hammer',
+  PAUSE = 'pause',
+  CLOSED = 'closed',
 }
 
 export const VegaIconNameMap: Record<
@@ -144,4 +152,8 @@ export const VegaIconNameMap: Record<
   man: IconMan,
   team: IconTeam,
   streak: IconStreak,
+  hammer: IconHammer,
+  monitor: IconMonitor,
+  pause: IconPause,
+  closed: IconClosed,
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #6344 

# Description ℹ️

Add market trading mode icons and tooltips to market page

# Demo 📺

<img width="1618" alt="Screenshot 2024-05-02 at 14 42 21" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/2ac1416c-ae45-4110-bb37-ddefbae21c99">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
