### PR TITLE
fix(trading): market dropdown on mobile in market selector

### DIFF
--- a/apps/trading/components/market-selector/market-selector-item.tsx
+++ b/apps/trading/components/market-selector/market-selector-item.tsx
@@ -129,7 +129,7 @@ const MarketData = ({
         {price} {symbol}
       </div>
       <div
-        className="hidden sm:w-1/6 overflow-hidden text-xs lg:text-sm whitespace-nowrap text-ellipsis text-right"
+        className="hidden sm:w-1/6 sm:flex justify-end overflow-hidden text-xs lg:text-sm whitespace-nowrap text-ellipsis text-right"
         title={t('24h vol')}
         data-testid="market-selector-volume"
         role="gridcell"

--- a/apps/trading/components/market-selector/market-selector-item.tsx
+++ b/apps/trading/components/market-selector/market-selector-item.tsx
@@ -100,7 +100,7 @@ const MarketData = ({
 
   return (
     <>
-      <div className="w-2/6" role="gridcell">
+      <div className="w-4/6 sm:w-2/6" role="gridcell">
         <h3 className="flex items-baseline">
           <span className="overflow-hidden text-xs md:text-sm lg:text-base text-ellipsis whitespace-nowrap">
             {
@@ -129,7 +129,7 @@ const MarketData = ({
         {price} {symbol}
       </div>
       <div
-        className="w-2/6 sm:w-1/6 overflow-hidden text-xs lg:text-sm whitespace-nowrap text-ellipsis text-right"
+        className="hidden sm:w-1/6 overflow-hidden text-xs lg:text-sm whitespace-nowrap text-ellipsis text-right"
         title={t('24h vol')}
         data-testid="market-selector-volume"
         role="gridcell"

--- a/apps/trading/components/market-selector/market-selector.tsx
+++ b/apps/trading/components/market-selector/market-selector.tsx
@@ -188,7 +188,10 @@ const MarketList = ({
         <div className="w-2/6 text-right pr-4" role="columnheader">
           {t('Price')}
         </div>
-        <div className="hidden sm:w-1/6 text-right" role="columnheader">
+        <div
+          className="hidden sm:w-1/6 sm:flex justify-end text-right"
+          role="columnheader"
+        >
           {t('24h volume')}
         </div>
         <div className="sm:w-1/6" role="columnheader" />

--- a/apps/trading/components/market-selector/market-selector.tsx
+++ b/apps/trading/components/market-selector/market-selector.tsx
@@ -182,13 +182,13 @@ const MarketList = ({
           'p-2 mx-2 border-b border-default text-xs text-secondary'
         )}
       >
-        <div className="w-2/6" role="columnheader">
+        <div className="w-4/6 sm:w-2/6" role="columnheader">
           {t('Name')}
         </div>
         <div className="w-2/6 text-right pr-4" role="columnheader">
           {t('Price')}
         </div>
-        <div className="w-2/6 sm:w-1/6 text-right" role="columnheader">
+        <div className="hidden sm:w-1/6 text-right" role="columnheader">
           {t('24h volume')}
         </div>
         <div className="sm:w-1/6" role="columnheader" />


### PR DESCRIPTION
# Related issues 🔗

Closes #6346 

# Description ℹ️

Hide 24h vol on mobile in market selector

# Demo 📺

<img width="472" alt="Screenshot 2024-05-07 at 15 35 25" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/0566d739-8c21-4155-9268-b265213e2c9a">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
