### PR TITLE
fix(trading): add 2 dp on 24h vol markets page

### DIFF
--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -234,10 +234,9 @@ export const useMarketsColumnDefs = () => {
 
           const volume =
             data && vol && vol !== '0'
-              ? addDecimalsFormatNumber(vol, data.positionDecimalPlaces)
+              ? addDecimalsFormatNumber(vol, data.positionDecimalPlaces, 2)
               : '0.00';
-          const volumePrice =
-            volPrice && formatNumber(volPrice, data?.decimalPlaces);
+          const volumePrice = volPrice && formatNumber(volPrice, 2);
 
           return volumePrice ? (
             <span className="font-mono">


### PR DESCRIPTION
# Related issues 🔗

Part of #6316 

# Description ℹ️

Format 2 dp on 24h vol markets page

# Demo 📺

<img width="1570" alt="Screenshot 2024-05-07 at 16 15 50 1" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/cf8cf3cc-717b-441a-837a-43110a732c49">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
