### PR TITLE
feat(trading): add transfer interval on reward cards

### DIFF
--- a/apps/trading/components/rewards-container/active-rewards.spec.tsx
+++ b/apps/trading/components/rewards-container/active-rewards.spec.tsx
@@ -96,9 +96,11 @@ describe('ActiveRewards', () => {
     expect(screen.getByText('Individual scope')).toBeInTheDocument();
     expect(screen.getByText('Average position')).toBeInTheDocument();
     expect(screen.getByText('Ends in')).toBeInTheDocument();
-    expect(screen.getByText('1 epoch')).toBeInTheDocument();
+    expect(screen.getByText('Pays every')).toBeInTheDocument();
     expect(screen.getByText('Assessed over')).toBeInTheDocument();
-    expect(screen.getByText('1 epoch')).toBeInTheDocument();
+    expect(screen.getByTestId('assessed-over')).toHaveTextContent('1 epoch');
+    expect(screen.getByTestId('pays-every')).toHaveTextContent('1 epoch');
+    expect(screen.getByTestId('ends-in')).toHaveTextContent('Ended');
   });
 
   describe('applyFilter', () => {

--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -375,6 +375,17 @@ const RewardCard = ({
                   })}
                 </span>
               </span>
+              {/** PAYS EVERY */}
+              {dispatchStrategy.transferInterval && (
+                <span className="flex flex-col">
+                  <span className="text-muted text-xs">{t('Pays every')}</span>
+                  <span data-testid="assessed-over">
+                    {t('numberEpochs', '{{count}} epochs', {
+                      count: dispatchStrategy.transferInterval,
+                    })}
+                  </span>
+                </span>
+              )}
               {/** CAPPED AT */}
               {dispatchStrategy.capRewardFeeMultiple && (
                 <span className="flex flex-col">

--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -379,7 +379,7 @@ const RewardCard = ({
               {dispatchStrategy.transferInterval && (
                 <span className="flex flex-col">
                   <span className="text-muted text-xs">{t('Pays every')}</span>
-                  <span data-testid="assessed-over">
+                  <span data-testid="pays-every">
                     {t('numberEpochs', '{{count}} epochs', {
                       count: dispatchStrategy.transferInterval,
                     })}


### PR DESCRIPTION
# Related issues 🔗

Closes #6312 

# Description ℹ️

Add a new label to the card for "Pays every" and use the value from transferInterval + "epochs"

# Demo 📺
 
<img width="1680" alt="Screenshot 2024-05-09 at 17 49 04" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/fea76071-1b1b-4542-a658-a3847dc11831">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
