### PR TITLE
chore(trading): fix shallow fetch release workflow

### DIFF
--- a/.github/workflows/release-console.yml
+++ b/.github/workflows/release-console.yml
@@ -40,8 +40,6 @@ jobs:
         run: |
           BRANCH_NAME="release/${{ github.event.inputs.environment }}/${{ github.event.inputs.releaseVersion }}"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
-          git fetch --all
-          git checkout $BRANCH_NAME || git checkout -b $BRANCH_NAME origin/${{ github.event.inputs.environment }}
           echo "::set-output name=branch_name::$BRANCH_NAME"
           git fetch --all
           git checkout -b $BRANCH_NAME origin/${{ github.event.inputs.environment }}

--- a/.github/workflows/release-console.yml
+++ b/.github/workflows/release-console.yml
@@ -27,7 +27,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commitHash }}
+          fetch-depth: 50
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+
+      - name: Ensure commit is available
+        run: |
+          if ! git cat-file -e ${{ github.event.inputs.commitHash }}^{commit}; then
+            echo "Commit not found, deepening fetch..."
+            git fetch --deepen=100
+          fi
 
       - name: Create Tag
         run: git tag ${{ github.event.inputs.releaseVersion }} ${{ github.event.inputs.commitHash }}
@@ -42,7 +50,7 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
           echo "::set-output name=branch_name::$BRANCH_NAME"
           git fetch --all
-          git checkout -b $BRANCH_NAME origin/${{ github.event.inputs.environment }}
+          git checkout $BRANCH_NAME || git checkout -b $BRANCH_NAME ${{ github.event.inputs.commitHash }}
           git push --set-upstream origin $BRANCH_NAME
 
   run_e2e_tests:
@@ -70,8 +78,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.setup_release_branch.outputs.branch_name }}
-          fetch-depth: 0
+          fetch-depth: 50
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
+
+      - name: Ensure commit is available
+        run: |
+          if ! git cat-file -e ${{ github.event.inputs.commitHash }}^{commit}; then
+            echo "Commit not found, deepening fetch..."
+            git fetch --deepen=100
+          fi
 
       - name: Reset and push release branch
         run: |

--- a/.github/workflows/release-console.yml
+++ b/.github/workflows/release-console.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           BRANCH_NAME="release/${{ github.event.inputs.environment }}/${{ github.event.inputs.releaseVersion }}"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+          git fetch --all
+          git checkout $BRANCH_NAME || git checkout -b $BRANCH_NAME origin/${{ github.event.inputs.environment }}
           echo "::set-output name=branch_name::$BRANCH_NAME"
           git fetch --all
           git checkout -b $BRANCH_NAME origin/${{ github.event.inputs.environment }}
@@ -70,6 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.setup_release_branch.outputs.branch_name }}
+          fetch-depth: 0
           token: ${{ secrets.VEGA_CI_BOT_GITHUB_TOKEN }}
 
       - name: Reset and push release branch


### PR DESCRIPTION
Currently the release workflow fails with

> Run BRANCH_NAME="release/main/v0.25.25"
  BRANCH_NAME="release/main/v0.25.25"
  git reset --hard c19eb034b14a9239ee39c28c3d980618cf3ea97f
  git push --force --set-upstream origin $BRANCH_NAME
  shell: /usr/bin/bash -e {0}
  env:
    E2E_TEST_WORKFLOW: ./.github/workflows/trading-e2e-test-run.yml
fatal: Could not parse object 'c19eb034b14a9239ee39c28c3d980618cf3ea97f'.
Error: Process completed with exit code 128.

This change should fix the shallow fetch