### PR TITLE
fix(trading): trading button break word

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/key-value.tsx
@@ -28,11 +28,17 @@ export const KeyValue = ({
   );
 
   const valueElement = onClick ? (
-    <button type="button" onClick={onClick} className="font-mono ml-auto">
+    <button
+      type="button"
+      onClick={onClick}
+      className="font-mono ml-auto [word-break:break-word]"
+    >
       {displayValue}
     </button>
   ) : (
-    <div className="font-mono ml-auto">{displayValue}</div>
+    <div className="font-mono ml-auto [word-break:break-word]">
+      {displayValue}
+    </div>
   );
 
   return (

--- a/libs/ui-toolkit/src/components/trading-button/trading-button.tsx
+++ b/libs/ui-toolkit/src/components/trading-button/trading-button.tsx
@@ -97,7 +97,7 @@ const Content = ({
     {subLabel && (
       <span
         data-sub-label
-        className="mt-0.5 font-mono text-xs leading-tight"
+        className="mt-0.5 font-mono text-xs leading-tight [word-break:break-word]"
         key="trading-button-sub-label"
       >
         {subLabel}


### PR DESCRIPTION
# Related issues 🔗

Closes #6332 

# Description ℹ️

Fixes size overflow on the deal ticket by adding break word on trading button.

# Demo 📺

Fixes: 
<img width="379" alt="Screenshot 2024-05-14 at 15 53 07" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/e6dbc11e-ef64-440c-8043-f85561e723dd">

To be:

<img width="374" alt="Screenshot 2024-05-14 at 15 52 09" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/d3eeca0c-a7eb-41e5-be94-1a25978ec074">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
