### PR TITLE
chore(explorer): tidy up test output by improving mocks

### DIFF
--- a/apps/explorer/src/app/components/asset-balance/__mocks__/asset-balance.tsx
+++ b/apps/explorer/src/app/components/asset-balance/__mocks__/asset-balance.tsx
@@ -1,0 +1,5 @@
+import type { AssetBalanceProps } from '../asset-balance';
+
+export const AssetBalance = ({ price }: AssetBalanceProps) => (
+  <span>${price}</span>
+);

--- a/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
+++ b/apps/explorer/src/app/components/asset-balance/asset-balance.tsx
@@ -15,7 +15,7 @@ export type AssetBalanceProps = {
  * Given a market ID and a price it will fetch the market
  * and format the price in that market's decimal places.
  */
-const AssetBalance = ({
+export const AssetBalance = ({
   assetId,
   price,
   showAssetLink = true,

--- a/apps/explorer/src/app/components/emblem-with-chain/__mocks__/emblem-with-chain.tsx
+++ b/apps/explorer/src/app/components/emblem-with-chain/__mocks__/emblem-with-chain.tsx
@@ -1,0 +1,10 @@
+import type { EmblemProps } from '@vegaprotocol/emblem';
+
+export function EmblemWithChain(props: EmblemProps) {
+  return (
+    <img
+      src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD"
+      alt={props.alt || 'Emblem'}
+    />
+  );
+}

--- a/apps/explorer/src/app/components/emblem-with-chain/__mocks__/emblem-with-chain.tsx
+++ b/apps/explorer/src/app/components/emblem-with-chain/__mocks__/emblem-with-chain.tsx
@@ -3,7 +3,7 @@ import type { EmblemProps } from '@vegaprotocol/emblem';
 export function EmblemWithChain(props: EmblemProps) {
   return (
     <img
-      src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD"
+      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
       alt={props.alt || 'Emblem'}
     />
   );

--- a/apps/explorer/src/app/components/epoch-overview/__mocks__/epoch.tsx
+++ b/apps/explorer/src/app/components/epoch-overview/__mocks__/epoch.tsx
@@ -1,0 +1,9 @@
+export const EpochOverview = ({ id }: { id: string }) => (
+  <table>
+    <tbody>
+      <tr>
+        <td>{id}</td>
+      </tr>
+    </tbody>
+  </table>
+);

--- a/apps/explorer/src/app/components/epoch-overview/epoch-missing.spec.tsx
+++ b/apps/explorer/src/app/components/epoch-overview/epoch-missing.spec.tsx
@@ -1,9 +1,9 @@
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
 import EpochMissingOverview, { calculateEpochData } from './epoch-missing';
 import { getSecondsFromInterval } from '@vegaprotocol/utils';
+import { ExplorerFutureEpochDocument } from './__generated__/Epoch';
 const START_DATE_PAST = 'Monday, 17 February 2022 11:44:09';
-
 describe('getSecondsFromInterval', () => {
   it('returns 0 for bad data', () => {
     expect(getSecondsFromInterval(null as unknown as string)).toEqual(0);
@@ -110,8 +110,27 @@ describe('calculateEpochData', () => {
 
 describe('EpochMissingOverview', () => {
   function renderComponent(missingEpochId: string) {
+    const mock: MockedResponse = {
+      request: {
+        query: ExplorerFutureEpochDocument,
+      },
+      result: {
+        data: {
+          epoch: {
+            id: '10',
+            timestamps: {
+              start: START_DATE_PAST,
+            },
+          },
+          networkParameter: {
+            value: '1s',
+          },
+        },
+      },
+    };
+
     return render(
-      <MockedProvider>
+      <MockedProvider mocks={[mock]}>
         <EpochMissingOverview missingEpochId={missingEpochId} />
       </MockedProvider>
     );

--- a/apps/explorer/src/app/components/epoch-overview/epoch.tsx
+++ b/apps/explorer/src/app/components/epoch-overview/epoch.tsx
@@ -26,7 +26,7 @@ export type EpochOverviewProps = {
  *
  * The details are hidden in a tooltip, behind the epoch number
  */
-const EpochOverview = ({ id, icon = true }: EpochOverviewProps) => {
+export const EpochOverview = ({ id, icon = true }: EpochOverviewProps) => {
   const { data, error, loading } = useExplorerEpochQuery({
     variables: { id: id || '' },
   });

--- a/apps/explorer/src/app/components/links/__mocks__/index.ts
+++ b/apps/explorer/src/app/components/links/__mocks__/index.ts
@@ -2,3 +2,4 @@ export { AssetLink } from '../asset-link/__mocks__/asset-link';
 export { PartyLink } from '../party-link/__mocks__/party-link';
 export { BlockLink } from '../block-link/__mocks__/block-link';
 export { MarketLink } from '../market-link/__mocks__/market-link';
+export { NetworkParameterLink } from '../network-parameter-link/__mocks__/network-parameter-link';

--- a/apps/explorer/src/app/components/links/__mocks__/index.ts
+++ b/apps/explorer/src/app/components/links/__mocks__/index.ts
@@ -1,0 +1,2 @@
+export { AssetLink } from '../asset-link/__mocks__/asset-link';
+export { PartyLink } from '../party-link/__mocks__/party-link';

--- a/apps/explorer/src/app/components/links/__mocks__/index.ts
+++ b/apps/explorer/src/app/components/links/__mocks__/index.ts
@@ -1,2 +1,4 @@
 export { AssetLink } from '../asset-link/__mocks__/asset-link';
 export { PartyLink } from '../party-link/__mocks__/party-link';
+export { BlockLink } from '../block-link/__mocks__/block-link';
+export { MarketLink } from '../market-link/__mocks__/market-link';

--- a/apps/explorer/src/app/components/links/asset-link/__mocks__/asset-link.tsx
+++ b/apps/explorer/src/app/components/links/asset-link/__mocks__/asset-link.tsx
@@ -1,0 +1,3 @@
+export const AssetLink = ({ assetId }: { assetId: string }) => (
+  <a href={`/assets/${assetId}`}>{assetId}</a>
+);

--- a/apps/explorer/src/app/components/links/asset-link/asset-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/asset-link/asset-link.spec.tsx
@@ -15,9 +15,11 @@ function renderComponent(id: string, mock: MockedResponse[]) {
   );
 }
 
+jest.mock('../../emblem-with-chain/emblem-with-chain');
+
 describe('AssetLink', () => {
   it('renders the asset id when not found and makes the button disabled', async () => {
-    const res = render(renderComponent('123', []));
+    const res = render(renderComponent('123', [mockAssetA1]));
     expect(res.getByText('123')).toBeInTheDocument();
     expect(await res.findByTestId('asset-link')).toBeDisabled();
     await waitFor(async () => {

--- a/apps/explorer/src/app/components/links/block-link/__mocks__/block-link.tsx
+++ b/apps/explorer/src/app/components/links/block-link/__mocks__/block-link.tsx
@@ -1,0 +1,3 @@
+export const BlockLink = ({ height }: { height: string }) => (
+  <a href={`/blocks/${height}`}>{height}</a>
+);

--- a/apps/explorer/src/app/components/links/market-link/__mocks__/market-link.tsx
+++ b/apps/explorer/src/app/components/links/market-link/__mocks__/market-link.tsx
@@ -1,0 +1,3 @@
+export const MarketLink = ({ id }: { id: string }) => (
+  <a href={`/markets/${id}`}>{id}</a>
+);

--- a/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import MarketLink from './market-link';
 import { ExplorerMarketDocument } from './__generated__/Market';
 import { GraphQLError } from 'graphql';
+import { ExplorerMarket456 } from '../../../mocks/links';
 
 function renderComponent(id: string, mocks: MockedResponse[]) {
   return (
@@ -18,8 +19,8 @@ function renderComponent(id: string, mocks: MockedResponse[]) {
 
 describe('Market link component', () => {
   it('Renders the ID at first', () => {
-    const res = render(renderComponent('123', []));
-    expect(res.getByText('123')).toBeInTheDocument();
+    const res = render(renderComponent('456', [ExplorerMarket456]));
+    expect(res.getByText('456')).toBeInTheDocument();
   });
 
   it('Renders the ID with an emoji on error', async () => {
@@ -34,6 +35,7 @@ describe('Market link component', () => {
         errors: [new GraphQLError('No such market')],
       },
     };
+
     const res = render(renderComponent('456', [mock]));
     // The ID
     expect(res.getByText('456')).toBeInTheDocument();

--- a/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
@@ -41,10 +41,6 @@ describe('Market link component', () => {
     const res = render(renderComponent('456', [mock]));
     // The ID
     expect(res.getByText('456')).toBeInTheDocument();
-
-    const icons = await res.findAllByRole('img');
-    // Two market icons and a chain icon
-    expect(icons.length).toBe(3);
   });
 
   it('Renders the market name when the query returns a result', async () => {

--- a/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
@@ -17,6 +17,8 @@ function renderComponent(id: string, mocks: MockedResponse[]) {
   );
 }
 
+jest.mock('../../emblem-with-chain/emblem-with-chain');
+
 describe('Market link component', () => {
   it('Renders the ID at first', () => {
     const res = render(renderComponent('456', [ExplorerMarket456]));

--- a/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.spec.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import MarketLink from './market-link';
 import { ExplorerMarketDocument } from './__generated__/Market';
 import { GraphQLError } from 'graphql';
-import { ExplorerMarket456 } from '../../../mocks/links';
+import { MockExplorerMarket456 } from '../../../mocks/links';
 
 function renderComponent(id: string, mocks: MockedResponse[]) {
   return (
@@ -21,7 +21,7 @@ jest.mock('../../emblem-with-chain/emblem-with-chain');
 
 describe('Market link component', () => {
   it('Renders the ID at first', () => {
-    const res = render(renderComponent('456', [ExplorerMarket456]));
+    const res = render(renderComponent('456', [MockExplorerMarket456]));
     expect(res.getByText('456')).toBeInTheDocument();
   });
 

--- a/apps/explorer/src/app/components/links/network-parameter-link/__mocks__/network-parameter-link.tsx
+++ b/apps/explorer/src/app/components/links/network-parameter-link/__mocks__/network-parameter-link.tsx
@@ -1,0 +1,3 @@
+export const NetworkParameterLink = ({ parameter }: { parameter: string }) => (
+  <a href={`/network/#${parameter}`}>{parameter}</a>
+);

--- a/apps/explorer/src/app/components/links/network-parameter-link/network-parameter-link.tsx
+++ b/apps/explorer/src/app/components/links/network-parameter-link/network-parameter-link.tsx
@@ -12,7 +12,7 @@ export type NetworkParameterLinkProps = Partial<ComponentProps<typeof Link>> & {
 /**
  * Links a given network parameter to the relevant page and anchor on the page
  */
-const NetworkParameterLink = ({
+export const NetworkParameterLink = ({
   parameter,
   ...props
 }: NetworkParameterLinkProps) => {

--- a/apps/explorer/src/app/components/links/node-link/__mocks__/tendermint-node-link.tsx
+++ b/apps/explorer/src/app/components/links/node-link/__mocks__/tendermint-node-link.tsx
@@ -1,0 +1,3 @@
+export const TendermintNodeLink = ({ id }: { id: string }) => (
+  <a href={`/validators/${id}`}>{id}</a>
+);

--- a/apps/explorer/src/app/components/links/node-link/node-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/node-link/node-link.spec.tsx
@@ -16,30 +16,30 @@ function renderComponent(id: string, mock: MockedResponse[]) {
 }
 
 describe('Node link component', () => {
+  const mock = {
+    request: {
+      query: ExplorerNodeDocument,
+      variables: {
+        id: '123',
+      },
+    },
+    result: {
+      data: {
+        node: {
+          id: '123',
+          status: 'irrelevant-test-data',
+          name: 'test-label',
+        },
+      },
+    },
+  };
+
   it('Renders the ID at first', () => {
-    const res = render(renderComponent('123', []));
+    const res = render(renderComponent('123', [mock]));
     expect(res.getByText('123')).toBeInTheDocument();
   });
 
   it('Renders the node name when the query returns a result', async () => {
-    const mock = {
-      request: {
-        query: ExplorerNodeDocument,
-        variables: {
-          id: '123',
-        },
-      },
-      result: {
-        data: {
-          node: {
-            id: '123',
-            status: 'irrelevant-test-data',
-            name: 'test-label',
-          },
-        },
-      },
-    };
-
     const res = render(renderComponent('123', [mock]));
     expect(res.getByText('123')).toBeInTheDocument();
     expect(await res.findByText('test-label')).toBeInTheDocument();

--- a/apps/explorer/src/app/components/links/node-link/tendermint-node-link.tsx
+++ b/apps/explorer/src/app/components/links/node-link/tendermint-node-link.tsx
@@ -19,7 +19,10 @@ export type TendermintNodeLinkProps = Partial<ComponentProps<typeof Link>> & {
  * Both queries have forced caching on, which was quicker than adding a context just for this data
  * and works fine.
  */
-const TendermintNodeLink = ({ id, ...props }: TendermintNodeLinkProps) => {
+export const TendermintNodeLink = ({
+  id,
+  ...props
+}: TendermintNodeLinkProps) => {
   const { data: tmData } = useTendermintValidators(0, { cache: 'force-cache' });
   const { data: vegaData } = useExplorerNodesQuery({
     fetchPolicy: 'cache-first',

--- a/apps/explorer/src/app/components/links/party-link/__mocks__/party-link.tsx
+++ b/apps/explorer/src/app/components/links/party-link/__mocks__/party-link.tsx
@@ -1,0 +1,3 @@
+export const PartyLink = ({ id }: { id: string }) => (
+  <a href={`/parties/${id}`}>{id}</a>
+);

--- a/apps/explorer/src/app/components/links/party-link/party-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/party-link/party-link.spec.tsx
@@ -44,7 +44,7 @@ const mocks = [
 describe('PartyLink', () => {
   it('renders Network for 000.000 party', () => {
     const screen = render(
-      <MockedProvider>
+      <MockedProvider mocks={mocks}>
         <PartyLink id={zeroes} />
       </MockedProvider>
     );
@@ -53,7 +53,7 @@ describe('PartyLink', () => {
 
   it('renders Network for network party', () => {
     const screen = render(
-      <MockedProvider>
+      <MockedProvider mocks={mocks}>
         <PartyLink id="network" />
       </MockedProvider>
     );
@@ -62,7 +62,7 @@ describe('PartyLink', () => {
 
   it('renders ID with no link for invalid party', () => {
     const screen = render(
-      <MockedProvider>
+      <MockedProvider mocks={mocks}>
         <PartyLink id="this-party-is-not-valid" />
       </MockedProvider>
     );
@@ -88,7 +88,7 @@ describe('PartyLink', () => {
       '13464e35bcb8e8a2900ca0f87acaf252d50cf2ab2fc73694845a16b7c8a0dc6e';
 
     const screen = render(
-      <MockedProvider>
+      <MockedProvider mocks={mocks}>
         <MemoryRouter>
           <PartyLink id={aValidParty} />
         </MemoryRouter>

--- a/apps/explorer/src/app/components/links/party-link/party-link.tsx
+++ b/apps/explorer/src/app/components/links/party-link/party-link.tsx
@@ -36,7 +36,7 @@ export type PartyLinkProps = Partial<ComponentProps<typeof Link>> & {
   truncateLength?: number;
 };
 
-const PartyLink = ({
+export const PartyLink = ({
   id,
   truncate = false,
   truncateLength = 4,

--- a/apps/explorer/src/app/components/links/proposal-link/__mocks__/proposal-link.tsx
+++ b/apps/explorer/src/app/components/links/proposal-link/__mocks__/proposal-link.tsx
@@ -1,0 +1,3 @@
+export const ProposalLink = ({ id, text }: { id: string; text?: string }) => (
+  <a href={`https://governance.fairground.wtf/proposals/${id}`}>{text || id}</a>
+);

--- a/apps/explorer/src/app/components/links/proposal-link/proposal-link.spec.tsx
+++ b/apps/explorer/src/app/components/links/proposal-link/proposal-link.spec.tsx
@@ -20,9 +20,33 @@ function renderComponent(id: string, mocks: MockedResponse[]) {
   );
 }
 
+const successMock: MockedResponse<
+  ExplorerProposalQuery,
+  ExplorerProposalQueryVariables
+> = {
+  request: {
+    query: ExplorerProposalDocument,
+    variables: {
+      id: '123',
+    },
+  },
+  result: {
+    data: {
+      proposal: {
+        __typename: 'Proposal',
+        id: '123',
+        rationale: {
+          title: 'test-title',
+          description: 'test description',
+        },
+      },
+    },
+  },
+};
+
 describe('Proposal link component', () => {
   it('Renders the ID at first', () => {
-    const res = render(renderComponent('123', []));
+    const res = render(renderComponent('123', [successMock]));
     expect(res.getByText('123')).toBeInTheDocument();
   });
 
@@ -48,31 +72,8 @@ describe('Proposal link component', () => {
 
   it('Renders the proposal title when the query returns a result', async () => {
     const proposalId = '123';
-    const mock: MockedResponse<
-      ExplorerProposalQuery,
-      ExplorerProposalQueryVariables
-    > = {
-      request: {
-        query: ExplorerProposalDocument,
-        variables: {
-          id: proposalId,
-        },
-      },
-      result: {
-        data: {
-          proposal: {
-            __typename: 'Proposal',
-            id: proposalId,
-            rationale: {
-              title: 'test-title',
-              description: 'test description',
-            },
-          },
-        },
-      },
-    };
 
-    const res = render(renderComponent(proposalId, [mock]));
+    const res = render(renderComponent(proposalId, [successMock]));
     expect(res.getByText(proposalId)).toBeInTheDocument();
     expect(await res.findByText('test-title')).toBeInTheDocument();
   });

--- a/apps/explorer/src/app/components/links/proposal-link/proposal-link.tsx
+++ b/apps/explorer/src/app/components/links/proposal-link/proposal-link.tsx
@@ -15,7 +15,7 @@ export type ProposalLinkProps = {
  * Given a proposal ID, generates an external link over to
  * the Governance page for more information
  */
-const ProposalLink = ({ id, text }: ProposalLinkProps) => {
+export const ProposalLink = ({ id, text }: ProposalLinkProps) => {
   const { data } = useExplorerProposalQuery({
     variables: { id },
   });

--- a/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
+++ b/apps/explorer/src/app/components/order-details/amend-order-details.spec.tsx
@@ -162,6 +162,36 @@ function renderExistingAmend(
         },
       },
     },
+    {
+      request: {
+        query: ExplorerMarketDocument,
+        variables: {
+          id: '789',
+        },
+      },
+      result: {
+        data: {
+          market: {
+            id: '789',
+            decimalPlaces: 0,
+            positionDecimalPlaces: 2,
+            state: 'irrelevant-test-data',
+            tradableInstrument: {
+              instrument: {
+                name: 'test-label',
+                product: {
+                  __typename: 'Future',
+                  quoteName: 'dai',
+                  settlementAsset: {
+                    decimals: 8,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   ];
 
   return renderAmendOrderDetails(id, version, amend, mocks);

--- a/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
@@ -56,6 +56,7 @@ const mock = {
     },
   },
 };
+
 function renderComponent(
   id: string,
   mocks: MockedResponse[],
@@ -67,6 +68,9 @@ function renderComponent(
     </MockedProvider>
   );
 }
+
+jest.mock('../price-in-market/price-in-market');
+jest.mock('../size-in-market/size-in-market');
 
 describe('Order Summary component', () => {
   it('side, size are present', async () => {

--- a/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
@@ -68,7 +68,6 @@ function renderComponent(
     </MockedProvider>
   );
 }
-
 jest.mock('../price-in-market/price-in-market');
 jest.mock('../size-in-market/size-in-market');
 

--- a/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.spec.tsx
@@ -5,6 +5,7 @@ import OrderSummary from './order-summary';
 import type { OrderSummaryModifier } from './order-summary';
 import { render } from '@testing-library/react';
 import { ExplorerDeterministicOrderDocument } from '../order-details/__generated__/Order';
+import { commonLinkMocks } from '../../mocks/links';
 
 const mock = {
   request: {
@@ -57,11 +58,11 @@ const mock = {
 };
 function renderComponent(
   id: string,
-  mocks?: MockedResponse[],
+  mocks: MockedResponse[],
   modifier?: OrderSummaryModifier
 ) {
   return render(
-    <MockedProvider mocks={mocks}>
+    <MockedProvider mocks={[...mocks, ...commonLinkMocks]}>
       <OrderSummary id={id} modifier={modifier} />
     </MockedProvider>
   );

--- a/apps/explorer/src/app/components/order-summary/order-summary.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-summary.tsx
@@ -1,7 +1,7 @@
 import { useExplorerDeterministicOrderQuery } from '../order-details/__generated__/Order';
-import PriceInMarket from '../price-in-market/price-in-market';
+import { PriceInMarket } from '../price-in-market/price-in-market';
 import { sideText } from '../order-details/lib/order-labels';
-import SizeInMarket from '../size-in-market/size-in-market';
+import { SizeInMarket } from '../size-in-market/size-in-market';
 
 // Note: Edited has no style currently
 export type OrderSummaryModifier = 'cancelled' | 'edited';

--- a/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
+++ b/apps/explorer/src/app/components/order-summary/order-tx-summary.spec.tsx
@@ -39,6 +39,7 @@ const mock = {
     },
   },
 };
+
 function renderComponent(order: Order, mocks?: MockedResponse[]) {
   return render(
     <MockedProvider mocks={mocks}>

--- a/apps/explorer/src/app/components/price-in-market/__mocks__/price-in-market.tsx
+++ b/apps/explorer/src/app/components/price-in-market/__mocks__/price-in-market.tsx
@@ -1,0 +1,5 @@
+import type { PriceInMarketProps } from '../price-in-market';
+
+export const PriceInMarket = ({ price }: PriceInMarketProps) => {
+  return <span>{price}</span>;
+};

--- a/apps/explorer/src/app/components/price-in-market/price-in-market.spec.tsx
+++ b/apps/explorer/src/app/components/price-in-market/price-in-market.spec.tsx
@@ -56,9 +56,11 @@ const fullMock = {
   },
 };
 
+jest.mock('../emblem-with-chain/emblem-with-chain');
+
 describe('Price in Market component', () => {
-  it('Renders the raw price when there is no market data', () => {
-    const res = render(renderComponent('100', '123', []));
+  it('Renders the raw price before there is no market data', () => {
+    const res = render(renderComponent('100', '123', [fullMock]));
     expect(res.getByText('100')).toBeInTheDocument();
   });
 
@@ -92,19 +94,19 @@ describe('Price in Market component', () => {
   });
 
   it('Renders `Market` instead of a price for market orders: 0 price', () => {
-    const res = render(renderComponent('0', '123', []));
+    const res = render(renderComponent('0', '123', [fullMock]));
     expect(res.getByText('Market')).toBeInTheDocument();
   });
 
   it('Renders `Market` instead of a price for market orders: undefined price', () => {
     const res = render(
-      renderComponent(undefined as unknown as string, '123', [])
+      renderComponent(undefined as unknown as string, '123', [fullMock])
     );
     expect(res.getByText('Market')).toBeInTheDocument();
   });
 
   it('Renders `Market` instead of a price for market orders: empty price', () => {
-    const res = render(renderComponent('', '123', []));
+    const res = render(renderComponent('', '123', [fullMock]));
     expect(res.getByText('Market')).toBeInTheDocument();
   });
 });

--- a/apps/explorer/src/app/components/price-in-market/price-in-market.tsx
+++ b/apps/explorer/src/app/components/price-in-market/price-in-market.tsx
@@ -17,7 +17,7 @@ export type PriceInMarketProps = {
  * Given a market ID and a price it will fetch the market
  * and format the price in that market's decimal places.
  */
-const PriceInMarket = ({
+export const PriceInMarket = ({
   marketId,
   price,
   decimalSource = 'MARKET',

--- a/apps/explorer/src/app/components/size-in-asset/__mocks__/size-in-asset.tsx
+++ b/apps/explorer/src/app/components/size-in-asset/__mocks__/size-in-asset.tsx
@@ -1,0 +1,1 @@
+export const SizeInAsset = ({ size }: { size: string }) => <span>{size}</span>;

--- a/apps/explorer/src/app/components/size-in-asset/size-in-asset.tsx
+++ b/apps/explorer/src/app/components/size-in-asset/size-in-asset.tsx
@@ -14,7 +14,7 @@ export type SizeInAssetProps = {
  * Given a market ID and an order size it will fetch the market
  * order size, and format the size accordingly
  */
-const SizeInAsset = ({
+export const SizeInAsset = ({
   assetId,
   size,
   decimalSource = 'ASSET',

--- a/apps/explorer/src/app/components/size-in-market/__mocks__/size-in-market.tsx
+++ b/apps/explorer/src/app/components/size-in-market/__mocks__/size-in-market.tsx
@@ -1,0 +1,5 @@
+import type { SizeInMarketProps } from '../size-in-market';
+
+export const SizeInMarket = ({ size }: SizeInMarketProps) => {
+  return <span>{size}</span>;
+};

--- a/apps/explorer/src/app/components/size-in-market/size-in-market.spec.tsx
+++ b/apps/explorer/src/app/components/size-in-market/size-in-market.spec.tsx
@@ -58,12 +58,12 @@ const fullMock = {
 
 describe('Size in Market component', () => {
   it('Renders a dash size when there is no size', () => {
-    const res = render(renderComponent(undefined, '123', []));
+    const res = render(renderComponent(undefined, '123', [fullMock]));
     expect(res.getByText('-')).toBeInTheDocument();
   });
 
   it('Renders the raw size when there is no market data', () => {
-    const res = render(renderComponent('100', '123', []));
+    const res = render(renderComponent('100', '123', [fullMock]));
     expect(res.getByText('100')).toBeInTheDocument();
   });
 

--- a/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
+++ b/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
@@ -13,7 +13,7 @@ export type SizeInMarketProps = {
  * Given a market ID and an order size it will fetch the market
  * order size, and format the size accordingly
  */
-const SizeInMarket = ({
+export const SizeInMarket = ({
   marketId,
   size,
   decimalSource = 'MARKET',

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-builtin-deposit.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-builtin-deposit.spec.tsx
@@ -15,6 +15,8 @@ const fullMock: Deposit = {
   amount: 'amount123',
 };
 
+jest.mock('../../../links/');
+
 describe('Chain Event: Builtin asset deposit', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as Deposit;
@@ -66,8 +68,8 @@ describe('Chain Event: Builtin asset deposit', () => {
     if (!partyLink.parentElement) {
       throw new Error('Party link does not exist');
     }
-    expect(partyLink.parentElement.tagName).toEqual('A');
-    expect(partyLink.parentElement.getAttribute('href')).toEqual(
+    expect(partyLink.tagName).toEqual('A');
+    expect(partyLink.getAttribute('href')).toEqual(
       `/parties/${fullMock.partyId}`
     );
 
@@ -76,6 +78,6 @@ describe('Chain Event: Builtin asset deposit', () => {
     if (!assetLink.parentElement) {
       throw new Error('Asset link does not exist');
     }
-    expect(assetLink.parentElement.textContent).toEqual(fullMock.vegaAssetId);
+    expect(assetLink.textContent).toEqual(fullMock.vegaAssetId);
   });
 });

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-builtin-withdrawal.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-builtin-withdrawal.spec.tsx
@@ -15,6 +15,8 @@ const fullMock: Withdrawal = {
   amount: 'amount123',
 };
 
+jest.mock('../../../links/');
+
 describe('Chain Event: Builtin asset withdrawal', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as Withdrawal;
@@ -73,8 +75,8 @@ describe('Chain Event: Builtin asset withdrawal', () => {
       throw new Error('Party link does not exist');
     }
 
-    expect(partyLink.parentElement.tagName).toEqual('A');
-    expect(partyLink.parentElement.getAttribute('href')).toEqual(
+    expect(partyLink.tagName).toEqual('A');
+    expect(partyLink.getAttribute('href')).toEqual(
       `/parties/${fullMock.partyId}`
     );
 
@@ -83,6 +85,6 @@ describe('Chain Event: Builtin asset withdrawal', () => {
     if (!assetLink.parentElement) {
       throw new Error('Asset link does not exist');
     }
-    expect(assetLink.parentElement.textContent).toEqual(fullMock.vegaAssetId);
+    expect(assetLink.textContent).toEqual(fullMock.vegaAssetId);
   });
 });

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-delist.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-delist.spec.tsx
@@ -13,6 +13,8 @@ const fullMock: Delist = {
   vegaAssetId: 'asset123',
 };
 
+jest.mock('../../../links/asset-link/asset-link');
+
 describe('Chain Event: ERC20 Asset Delist', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as Delist;

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-limits-updated.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-limits-updated.spec.tsx
@@ -16,6 +16,8 @@ const fullMock: AssetLimitsUpdated = {
   withdrawThreshold: '60',
 };
 
+jest.mock('../../../links/asset-link/asset-link');
+
 describe('Chain Event: ERC20 Asset limits updated', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as AssetLimitsUpdated;

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-list.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-asset-list.spec.tsx
@@ -14,6 +14,8 @@ const fullMock: List = {
   assetSource: 'eth123',
 };
 
+jest.mock('../../../links/');
+
 describe('Chain Event: ERC20 Asset List', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as List;

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-deposit.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-deposit.spec.tsx
@@ -18,6 +18,8 @@ const fullMock: Deposit = {
     '0000000000000000000000000000000000000000000000000000000000000001',
 };
 
+jest.mock('../../../links');
+
 describe('Chain Event: ERC20 asset deposit', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as Deposit;
@@ -67,8 +69,8 @@ describe('Chain Event: ERC20 asset deposit', () => {
     if (!partyLink.parentElement) {
       throw new Error('Party link does not exist');
     }
-    expect(partyLink.parentElement.tagName).toEqual('A');
-    expect(partyLink.parentElement.getAttribute('href')).toEqual(
+    expect(partyLink.tagName).toEqual('A');
+    expect(partyLink.getAttribute('href')).toEqual(
       `/parties/${fullMock.targetPartyId}`
     );
 

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-withdrawal.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-withdrawal.tsx
@@ -7,6 +7,8 @@ import {
   EthExplorerLinkTypes,
 } from '../../../links/external-explorer-link/external-explorer-link';
 
+jest.mock('../../../links/asset-link/asset-link');
+
 interface TxDetailsChainEventWithdrawalProps {
   withdrawal: components['schemas']['vegaERC20Withdrawal'];
 }

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-withdrawal.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-erc20-withdrawal.tsx
@@ -7,8 +7,6 @@ import {
   EthExplorerLinkTypes,
 } from '../../../links/external-explorer-link/external-explorer-link';
 
-jest.mock('../../../links/asset-link/asset-link');
-
 interface TxDetailsChainEventWithdrawalProps {
   withdrawal: components['schemas']['vegaERC20Withdrawal'];
 }

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-deposit.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-deposit.spec.tsx
@@ -17,6 +17,8 @@ const fullMock: Deposit = {
     '0000000000000000000000000000000000000000000000000000000000000001',
 };
 
+jest.mock('../../../links/party-link/party-link');
+
 describe('Chain Event: Stake deposit', () => {
   it('Renders nothing if no good data is provided', () => {
     const mock = undefined as unknown as Deposit;
@@ -68,8 +70,8 @@ describe('Chain Event: Stake deposit', () => {
     if (!partyLink.parentElement) {
       throw new Error('Party link does not exist');
     }
-    expect(partyLink.parentElement.tagName).toEqual('A');
-    expect(partyLink.parentElement.getAttribute('href')).toEqual(
+    expect(partyLink.tagName).toEqual('A');
+    expect(partyLink.getAttribute('href')).toEqual(
       `/parties/${fullMock.vegaPublicKey}`
     );
 

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-deposit.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-deposit.tsx
@@ -1,7 +1,7 @@
 import { t } from '@vegaprotocol/i18n';
 import { TableRow, TableCell } from '../../../table';
 import type { components } from '../../../../../types/explorer';
-import { PartyLink } from '../../../links';
+import { PartyLink } from '../../../links/party-link/party-link';
 import {
   ExternalExplorerLink,
   EthExplorerLinkTypes,

--- a/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-remove.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-events/tx-stake-remove.spec.tsx
@@ -6,6 +6,7 @@ import omit from 'lodash/omit';
 import { MockedProvider } from '@apollo/client/testing';
 import { MemoryRouter } from 'react-router-dom';
 import { TxDetailsChainEventStakeRemove } from './tx-stake-remove';
+import { commonLinkMocks } from '../../../../mocks/links';
 
 type Remove = components['schemas']['vegaStakeRemoved'];
 
@@ -42,7 +43,7 @@ describe('Chain Event: Stake remove', () => {
 
   it('Renders TableRows if all data is provided', () => {
     const screen = render(
-      <MockedProvider>
+      <MockedProvider mocks={commonLinkMocks}>
         <MemoryRouter>
           <table>
             <tbody>

--- a/apps/explorer/src/app/components/txs/details/proposal/batch-item.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/batch-item.spec.tsx
@@ -5,6 +5,8 @@ import { MockedProvider } from '@apollo/client/testing';
 import type { components } from '../../../../../types/explorer';
 type Item = components['schemas']['vegaBatchProposalTermsChange'];
 
+jest.mock('../../../links');
+
 describe('BatchItem', () => {
   it('Renders "Unknown proposal type" by default', () => {
     const item = {};

--- a/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/__mocks__/bundle-signers.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/__mocks__/bundle-signers.tsx
@@ -1,0 +1,5 @@
+export const BundleSigners = ({ signatures }: { signatures: string[] }) => (
+  <ul>
+    <li>Signers</li>
+  </ul>
+);

--- a/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/bundle-exists.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/bundle-exists.spec.tsx
@@ -4,6 +4,9 @@ import { AssetStatus } from '@vegaprotocol/types';
 import { MemoryRouter } from 'react-router-dom';
 import { BundleExists } from './bundle-exists';
 
+jest.mock('../../../../links/proposal-link/proposal-link');
+jest.mock('./bundle-signers');
+
 describe('Bundle Exists', () => {
   const NON_ENABLED_STATUS: AssetStatus[] = [
     AssetStatus.STATUS_PENDING_LISTING,

--- a/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/bundle-exists.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/signature-bundle/bundle-exists.tsx
@@ -1,5 +1,5 @@
 import { t } from '@vegaprotocol/i18n';
-import ProposalLink from '../../../../links/proposal-link/proposal-link';
+import { ProposalLink } from '../../../../links/proposal-link/proposal-link';
 import { IconForBundleStatus } from './bundle-icon';
 import type { AssetStatus } from '@vegaprotocol/types';
 import type { ProposalTerms } from '../../tx-proposal';

--- a/apps/explorer/src/app/components/txs/details/referrals/referral-code-owner.test.tsx
+++ b/apps/explorer/src/app/components/txs/details/referrals/referral-code-owner.test.tsx
@@ -12,11 +12,19 @@ const renderComponent = (
   return render(
     <MockedProvider mocks={mocks}>
       <MemoryRouter>
-        <ReferralCodeOwner {...props} />
+        <table>
+          <tbody>
+            <tr>
+              <ReferralCodeOwner {...props} />
+            </tr>
+          </tbody>
+        </table>
       </MemoryRouter>
     </MockedProvider>
   );
 };
+
+jest.mock('../../../links/');
 
 describe('ReferralCodeOwner', () => {
   it('should render loading state', () => {

--- a/apps/explorer/src/app/components/txs/details/referrals/team.test.tsx
+++ b/apps/explorer/src/app/components/txs/details/referrals/team.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { ReferralTeam } from './team';
 import type { CreateReferralSet } from './team';
 import { MockedProvider } from '@apollo/client/testing';
+import { MockNodeNames } from '../../../../mocks/links';
 
 describe('ReferralTeam', () => {
   const team = {
@@ -18,9 +19,11 @@ describe('ReferralTeam', () => {
   const mockId = '123456';
   const mockCreator = 'JohnDoe';
 
+  jest.mock('../../../links');
+
   it('should render the team name', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -29,7 +32,7 @@ describe('ReferralTeam', () => {
 
   it('should render the team ID', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -39,7 +42,7 @@ describe('ReferralTeam', () => {
 
   it('should render the creator', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -49,7 +52,7 @@ describe('ReferralTeam', () => {
 
   it('should render the team URL', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -59,7 +62,7 @@ describe('ReferralTeam', () => {
 
   it('should render the avatar URL', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -69,7 +72,7 @@ describe('ReferralTeam', () => {
 
   it('should render the open status as a tick if closed is falsy', () => {
     const { getByTestId } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={mockTx} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );
@@ -84,7 +87,7 @@ describe('ReferralTeam', () => {
     };
 
     const { getByTestId } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockNodeNames]}>
         <ReferralTeam tx={m} id={mockId} creator={mockCreator} />
       </MockedProvider>
     );

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-participants.tsx
@@ -5,7 +5,7 @@ import {
   SPECIAL_CASE_NETWORK,
   SPECIAL_CASE_NETWORK_ID,
 } from '../../../../links/party-link/party-link';
-import SizeInAsset from '../../../../size-in-asset/size-in-asset';
+import { SizeInAsset } from '../../../../size-in-asset/size-in-asset';
 import { headerClasses, wrapperClasses } from '../transfer-details';
 import type { components } from '../../../../../../types/explorer';
 

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-repeat.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-repeat.tsx
@@ -1,6 +1,6 @@
 import { t } from '@vegaprotocol/i18n';
 import { Icon } from '@vegaprotocol/ui-toolkit';
-import EpochOverview from '../../../../epoch-overview/epoch';
+import { EpochOverview } from '../../../../epoch-overview/epoch';
 import { useExplorerFutureEpochQuery } from '../../../../epoch-overview/__generated__/Epoch';
 import { headerClasses, wrapperClasses } from '../transfer-details';
 import type { IconProps } from '@vegaprotocol/ui-toolkit';

--- a/apps/explorer/src/app/components/txs/details/transfer/transfer-rewards.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/transfer-rewards.spec.tsx
@@ -80,6 +80,8 @@ describe('getRewardTitle', () => {
   });
 });
 
+jest.mock('../../../links');
+
 describe('TransferRewards', () => {
   it('should render nothing if recurring dispatchStrategy is not provided', () => {
     const { container } = render(

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.test.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.test.tsx
@@ -4,6 +4,10 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import type { BlockExplorerTransactionResult } from '../../../routes/types/block-explorer-response';
 import { MockedProvider } from '@apollo/client/testing';
 import { MemoryRouter } from 'react-router-dom';
+import { MockExplorerEpochForBlockBlank } from '../../../mocks/links';
+
+jest.mock('../../../components/links/');
+jest.mock('../../../components/price-in-market/price-in-market');
 
 describe('TxDetailsLiquidityAmendment', () => {
   const mockTxData = {
@@ -29,7 +33,7 @@ describe('TxDetailsLiquidityAmendment', () => {
 
   it('should render the component with correct data', () => {
     const { getByText } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockExplorerEpochForBlockBlank]}>
         <MemoryRouter>
           <TxDetailsLiquidityAmendment
             txData={mockTxData as BlockExplorerTransactionResult}

--- a/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-liquidity-amend.tsx
@@ -5,7 +5,7 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
 import type { components } from '../../../../types/explorer';
-import PriceInMarket from '../../price-in-market/price-in-market';
+import { PriceInMarket } from '../../price-in-market/price-in-market';
 import BigNumber from 'bignumber.js';
 
 export type LiquidityAmendment =

--- a/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-transfer.tsx
@@ -6,7 +6,7 @@ import { TableRow, TableCell, TableWithTbody } from '../../table';
 
 import type { components } from '../../../../types/explorer';
 import { PartyLink } from '../../links';
-import SizeInAsset from '../../size-in-asset/size-in-asset';
+import { SizeInAsset } from '../../size-in-asset/size-in-asset';
 import { TransferDetails } from './transfer/transfer-details';
 import {
   SPECIAL_CASE_NETWORK,

--- a/apps/explorer/src/app/components/txs/tx-transfer.spec.tsx
+++ b/apps/explorer/src/app/components/txs/tx-transfer.spec.tsx
@@ -6,9 +6,11 @@ import {
   TxDetailsTransfer,
   getTypeLabelForTransfer,
 } from './details/tx-transfer';
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
+import { ExplorerTransferStatusDocument } from './details/transfer/__generated__/Transfer';
+import { ExplorerEpochForBlockDocument } from '../links/block-link/__generated__/EpochByBlock';
 
 type Transfer = components['schemas']['commandsv1Transfer'];
 
@@ -66,6 +68,55 @@ describe('TX: Transfer: getLabelForTransfer', () => {
   });
 });
 
+jest.mock('../links');
+jest.mock('../size-in-asset/size-in-asset');
+jest.mock('../epoch-overview/epoch');
+
+const MockTransferDetails: MockedResponse = {
+  request: {
+    query: ExplorerTransferStatusDocument,
+    variables: {
+      id: '51f3bab5eb2637651012507a64d497790a734248792c16e5cf36df8984074fbd',
+    },
+  },
+  result: {
+    data: {
+      transfer: {
+        transfer: {
+          status: 'STATUS_ACCEPTED',
+        },
+        fees: [
+          {
+            amount: '0',
+            epoch: 0,
+          },
+        ],
+      },
+    },
+  },
+};
+
+const MockExplorerEpochForBlock: MockedResponse = {
+  request: {
+    query: ExplorerEpochForBlockDocument,
+    variables: {
+      block: '100',
+    },
+  },
+  result: {
+    data: {
+      epoch: {
+        id: '100',
+        timestamps: {
+          start: '2022-03-24T11:03:40.014303953Z',
+          end: '2022-03-24T11:03:40.014303953Z',
+          lastBlock: '1',
+        },
+      },
+    },
+  },
+};
+
 describe('TxDetailsTransfer', () => {
   const mockBlockData = {
     result: {
@@ -108,7 +159,7 @@ describe('TxDetailsTransfer', () => {
 
   it('renders basic transfer details', () => {
     const { getByTestId } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockTransferDetails, MockExplorerEpochForBlock]}>
         <MemoryRouter>
           <TxDetailsTransfer
             txData={mockTxData as BlockExplorerTransactionResult}

--- a/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list-item.spec.tsx
@@ -3,6 +3,8 @@ import { TxsInfiniteListItem } from './txs-infinite-list-item';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
+jest.mock('../links');
+
 describe('Txs infinite list item', () => {
   it('should display "missing vital data" if "type" data missing', () => {
     render(

--- a/apps/explorer/src/app/components/txs/txs-infinite-list.spec.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list.spec.tsx
@@ -45,6 +45,8 @@ const generateTxs = (number: number): BlockExplorerTransactionResult[] => {
   }));
 };
 
+jest.mock('../links');
+
 describe('Txs infinite list', () => {
   it('should display a "no items" message when no items provided', () => {
     render(

--- a/apps/explorer/src/app/components/withdrawal/withdrawal-progress.spec.tsx
+++ b/apps/explorer/src/app/components/withdrawal/withdrawal-progress.spec.tsx
@@ -14,8 +14,34 @@ function renderComponent(id: string, status: number, mock: MockedResponse[]) {
 }
 
 describe('Withdrawal Progress component', () => {
+  const mock = {
+    request: {
+      query: ExplorerWithdrawalDocument,
+      variables: {
+        id: '123',
+      },
+    },
+    result: {
+      data: {
+        withdrawal: {
+          __typename: 'Withdrawal',
+          id: '123',
+          status: 'STATUS_OPEN',
+          createdTimestamp: '2022-03-24T11:03:40.026173466Z',
+          withdrawnTimestamp: null,
+          ref: 'irrelevant',
+          txHash: '0x123456890',
+          details: {
+            __typename: 'Erc20WithdrawalDetails',
+            receiverAddress: '0x5435345432342423',
+          },
+        },
+      },
+    },
+  };
+
   it('Renders success for the first indicator if txStatus is 0', () => {
-    const res = render(renderComponent('123', 0, []));
+    const res = render(renderComponent('123', 0, [mock]));
     expect(res.getByText('Requested')).toBeInTheDocument();
 
     // Steps 2 and three should not be complete also
@@ -24,7 +50,7 @@ describe('Withdrawal Progress component', () => {
   });
 
   it('Renders success for the first indicator if txStatus is anything except 0', () => {
-    const res = render(renderComponent('123', 20, []));
+    const res = render(renderComponent('123', 20, [mock]));
     expect(res.getByText('Rejected')).toBeInTheDocument();
 
     // Steps 2 and three should not be complete also
@@ -33,32 +59,6 @@ describe('Withdrawal Progress component', () => {
   });
 
   it('Renders success for the second indicator if a date can be fetched', async () => {
-    const mock = {
-      request: {
-        query: ExplorerWithdrawalDocument,
-        variables: {
-          id: '123',
-        },
-      },
-      result: {
-        data: {
-          withdrawal: {
-            __typename: 'Withdrawal',
-            id: '123',
-            status: 'STATUS_OPEN',
-            createdTimestamp: '2022-03-24T11:03:40.026173466Z',
-            withdrawnTimestamp: null,
-            ref: 'irrelevant',
-            txHash: '0x123456890',
-            details: {
-              __typename: 'Erc20WithdrawalDetails',
-              receiverAddress: '0x5435345432342423',
-            },
-          },
-        },
-      },
-    };
-
     const res = render(renderComponent('123', 0, [mock]));
     // Step 1 should be filled in
     expect(res.getByText('Requested')).toBeInTheDocument();

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -55,6 +55,27 @@ export const MockExplorerEpochForBlock: MockedResponse = {
   },
 };
 
+export const MockExplorerEpochForBlockBlank: MockedResponse = {
+  request: {
+    query: ExplorerEpochForBlockDocument,
+    variables: {
+      block: '',
+    },
+  },
+  result: {
+    data: {
+      epoch: {
+        id: '1',
+        timestamps: {
+          start: '2022-03-24T11:03:40.014303953Z',
+          end: '2022-03-24T11:03:40.014303953Z',
+          lastBlock: '1',
+        },
+      },
+    },
+  },
+};
+
 export const MockExplorerMarket123: MockedResponse = {
   request: {
     query: ExplorerMarketDocument,

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -1,0 +1,59 @@
+import { ExplorerEpochForBlockDocument } from '../components/links/block-link/__generated__/EpochByBlock';
+import { ExplorerNodeNamesDocument } from '../routes/validators/__generated__/NodeNames';
+import type { MockedResponse } from '@apollo/client/testing';
+import { ExplorerMarketDocument } from '../components/links/market-link/__generated__/Market';
+import { ExplorerNodeDocument } from '../components/links/node-link/__generated__/Node';
+
+export const NodeNamesMock: MockedResponse = {
+  request: {
+    query: ExplorerNodeNamesDocument,
+  },
+  result: { data: null },
+};
+
+export const ExplorerEpochForBlock: MockedResponse = {
+  request: {
+    query: ExplorerEpochForBlockDocument,
+    variables: {
+      block: '52987',
+    },
+  },
+  result: { data: null },
+};
+
+export const ExplorerMarket123: MockedResponse = {
+  request: {
+    query: ExplorerMarketDocument,
+    variables: {
+      id: '123',
+    },
+  },
+  result: { data: { market: { id: '123' } } },
+};
+
+export const ExplorerMarket456: MockedResponse = {
+  request: {
+    query: ExplorerMarketDocument,
+    variables: {
+      id: '456',
+    },
+  },
+  result: { data: { market: { id: '456' } } },
+};
+
+export const ExplorerNode: MockedResponse = {
+  request: {
+    query: ExplorerNodeDocument,
+    variables: {
+      id: '123',
+    },
+  },
+  result: { data: null },
+};
+
+export const commonLinkMocks: MockedResponse[] = [
+  NodeNamesMock,
+  ExplorerEpochForBlock,
+  ExplorerMarket123,
+  ExplorerNode,
+];

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -3,25 +3,26 @@ import { ExplorerNodeNamesDocument } from '../routes/validators/__generated__/No
 import type { MockedResponse } from '@apollo/client/testing';
 import { ExplorerMarketDocument } from '../components/links/market-link/__generated__/Market';
 import { ExplorerNodeDocument } from '../components/links/node-link/__generated__/Node';
+import { AssetMarketsDocument } from '../routes/assets/components/__generated__/Asset-Markets';
 
-export const NodeNamesMock: MockedResponse = {
+export const MockNodeNames: MockedResponse = {
   request: {
     query: ExplorerNodeNamesDocument,
   },
   result: { data: null },
 };
 
-export const ExplorerEpochForBlock: MockedResponse = {
+export const MockExplorerEpochForBlock: MockedResponse = {
   request: {
     query: ExplorerEpochForBlockDocument,
     variables: {
-      block: '52987',
+      block: '1',
     },
   },
   result: { data: null },
 };
 
-export const ExplorerMarket123: MockedResponse = {
+export const MockExplorerMarket123: MockedResponse = {
   request: {
     query: ExplorerMarketDocument,
     variables: {
@@ -31,7 +32,7 @@ export const ExplorerMarket123: MockedResponse = {
   result: { data: { market: { id: '123' } } },
 };
 
-export const ExplorerMarket456: MockedResponse = {
+export const MockExplorerMarket456: MockedResponse = {
   request: {
     query: ExplorerMarketDocument,
     variables: {
@@ -41,7 +42,7 @@ export const ExplorerMarket456: MockedResponse = {
   result: { data: { market: { id: '456' } } },
 };
 
-export const ExplorerNode: MockedResponse = {
+export const MockExplorerNode: MockedResponse = {
   request: {
     query: ExplorerNodeDocument,
     variables: {
@@ -51,9 +52,17 @@ export const ExplorerNode: MockedResponse = {
   result: { data: null },
 };
 
+export const MockAssetMarkets: MockedResponse = {
+  request: {
+    query: AssetMarketsDocument,
+  },
+  result: { data: null },
+};
+
 export const commonLinkMocks: MockedResponse[] = [
-  NodeNamesMock,
-  ExplorerEpochForBlock,
-  ExplorerMarket123,
-  ExplorerNode,
+  MockNodeNames,
+  MockExplorerEpochForBlock,
+  MockExplorerMarket123,
+  MockExplorerNode,
+  MockAssetMarkets,
 ];

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -5,12 +5,33 @@ import { ExplorerMarketDocument } from '../components/links/market-link/__genera
 import { ExplorerNodeDocument } from '../components/links/node-link/__generated__/Node';
 import { AssetMarketsDocument } from '../routes/assets/components/__generated__/Asset-Markets';
 import { AssetsDocument } from '@vegaprotocol/assets';
+import { ExplorerEpochDocument } from '../components/epoch-overview/__generated__/Epoch';
 
 export const MockNodeNames: MockedResponse = {
   request: {
     query: ExplorerNodeNamesDocument,
   },
   result: { data: null },
+};
+export const MockExplorerEpoch: MockedResponse = {
+  request: {
+    query: ExplorerEpochDocument,
+    variables: {
+      id: '1',
+    },
+  },
+  result: {
+    data: {
+      epoch: {
+        id: '1',
+        timestamps: {
+          start: '2022-03-24T11:03:40.014303953Z',
+          end: '2022-03-24T11:03:40.014303953Z',
+          lastBlock: '1',
+        },
+      },
+    },
+  },
 };
 
 export const MockExplorerEpochForBlock: MockedResponse = {
@@ -20,7 +41,18 @@ export const MockExplorerEpochForBlock: MockedResponse = {
       block: '1',
     },
   },
-  result: { data: null },
+  result: {
+    data: {
+      epoch: {
+        id: '1',
+        timestamps: {
+          start: '2022-03-24T11:03:40.014303953Z',
+          end: '2022-03-24T11:03:40.014303953Z',
+          lastBlock: '1',
+        },
+      },
+    },
+  },
 };
 
 export const MockExplorerMarket123: MockedResponse = {
@@ -98,4 +130,5 @@ export const commonLinkMocks: MockedResponse[] = [
   MockExplorerNode,
   MockAssetMarkets,
   MockAsset,
+  MockExplorerEpoch,
 ];

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -75,7 +75,6 @@ export const MockExplorerEpochForBlockBlank: MockedResponse = {
     },
   },
 };
-
 export const MockExplorerMarket123: MockedResponse = {
   request: {
     query: ExplorerMarketDocument,

--- a/apps/explorer/src/app/mocks/links.ts
+++ b/apps/explorer/src/app/mocks/links.ts
@@ -4,6 +4,7 @@ import type { MockedResponse } from '@apollo/client/testing';
 import { ExplorerMarketDocument } from '../components/links/market-link/__generated__/Market';
 import { ExplorerNodeDocument } from '../components/links/node-link/__generated__/Node';
 import { AssetMarketsDocument } from '../routes/assets/components/__generated__/Asset-Markets';
+import { AssetsDocument } from '@vegaprotocol/assets';
 
 export const MockNodeNames: MockedResponse = {
   request: {
@@ -39,7 +40,28 @@ export const MockExplorerMarket456: MockedResponse = {
       id: '456',
     },
   },
-  result: { data: { market: { id: '456' } } },
+  result: {
+    data: {
+      market: {
+        id: '456',
+        decimalPlaces: 5,
+        positionDecimalPlaces: 2,
+        state: 'irrelevant-test-data',
+        tradableInstrument: {
+          instrument: {
+            name: 'test-label',
+            product: {
+              __typename: 'Future',
+              quoteName: 'dai',
+              settlementAsset: {
+                decimals: 8,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
 export const MockExplorerNode: MockedResponse = {
@@ -59,10 +81,21 @@ export const MockAssetMarkets: MockedResponse = {
   result: { data: null },
 };
 
+export const MockAsset: MockedResponse = {
+  request: {
+    query: AssetsDocument,
+    variables: {
+      assetId: 'asset1',
+    },
+  },
+  result: { data: null },
+};
+
 export const commonLinkMocks: MockedResponse[] = [
   MockNodeNames,
   MockExplorerEpochForBlock,
   MockExplorerMarket123,
   MockExplorerNode,
   MockAssetMarkets,
+  MockAsset,
 ];

--- a/apps/explorer/src/app/routes/assets/components/asset-markets.spec.tsx
+++ b/apps/explorer/src/app/routes/assets/components/asset-markets.spec.tsx
@@ -5,6 +5,9 @@ import { MemoryRouter } from 'react-router-dom';
 import type { AssetMarketsQuery } from './__generated__/Asset-Markets';
 import { AccountType } from '@vegaprotocol/types';
 
+jest.mock('../../../components/links');
+jest.mock('../../../components/price-in-market/price-in-market');
+
 describe('transformAssetMarketsQuery', () => {
   it('should return an empty array if data is undefined', () => {
     const result = transformAssetMarketsQuery(undefined, 'assetId');

--- a/apps/explorer/src/app/routes/assets/components/asset-markets.spec.tsx
+++ b/apps/explorer/src/app/routes/assets/components/asset-markets.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { AssetMarketsQuery } from './__generated__/Asset-Markets';
 import { AccountType } from '@vegaprotocol/types';
+import { MockAssetMarkets } from '../../../mocks/links';
 
 jest.mock('../../../components/links');
 jest.mock('../../../components/price-in-market/price-in-market');
@@ -148,7 +149,7 @@ describe('transformAssetMarketsQuery', () => {
 describe('AssetMarkets', () => {
   it('should render the component', () => {
     render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockAssetMarkets]}>
         <MemoryRouter>
           <AssetMarkets asset="assetId" />
         </MemoryRouter>
@@ -160,7 +161,7 @@ describe('AssetMarkets', () => {
 
   it('should display a message when there are no markets with an insurance account balance in the asset', () => {
     render(
-      <MockedProvider>
+      <MockedProvider mocks={[MockAssetMarkets]}>
         <MemoryRouter>
           <AssetMarkets asset="assetId" />
         </MemoryRouter>

--- a/apps/explorer/src/app/routes/assets/components/asset-markets.tsx
+++ b/apps/explorer/src/app/routes/assets/components/asset-markets.tsx
@@ -1,6 +1,6 @@
 import { KeyValueTable, KeyValueTableRow } from '@vegaprotocol/ui-toolkit';
 import { MarketLink } from '../../../components/links';
-import PriceInMarket from '../../../components/price-in-market/price-in-market';
+import { PriceInMarket } from '../../../components/price-in-market/price-in-market';
 import type { AssetMarketsQuery } from './__generated__/Asset-Markets';
 import { useAssetMarketsQuery } from './__generated__/Asset-Markets';
 import { t } from '@vegaprotocol/i18n';

--- a/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Routes as RouteNames } from '../../route-names';
 import { useFetch } from '@vegaprotocol/react-helpers';
 import { MockedProvider } from '@apollo/client/testing';
+import { MockExplorerEpochForBlock } from '../../../mocks/links';
 
 jest.mock('@vegaprotocol/react-helpers', () => {
   const original = jest.requireActual('@vegaprotocol/react-helpers');
@@ -12,6 +13,14 @@ jest.mock('@vegaprotocol/react-helpers', () => {
     useFetch: jest.fn(),
   };
 });
+
+jest.mock('../../../components/links/node-link/tendermint-node-link', () => ({
+  ...jest.requireActual(
+    '../../../components/links/node-link/tendermint-node-link'
+  ),
+  __esModule: true,
+  default: (props: { id: string }) => <div>{props.id}</div>,
+}));
 
 const blockId = 1085890;
 
@@ -122,7 +131,7 @@ const createBlockResponse = (id: number = blockId) => {
 
 const renderComponent = (id: number = blockId) => {
   return (
-    <MockedProvider>
+    <MockedProvider mocks={[MockExplorerEpochForBlock]}>
       <MemoryRouter initialEntries={[`/${RouteNames.BLOCKS}/${id}`]}>
         <Routes>
           <Route path={`/${RouteNames.BLOCKS}/:block`} element={<Block />} />

--- a/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.spec.tsx
@@ -4,7 +4,10 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Routes as RouteNames } from '../../route-names';
 import { useFetch } from '@vegaprotocol/react-helpers';
 import { MockedProvider } from '@apollo/client/testing';
-import { MockExplorerEpochForBlock } from '../../../mocks/links';
+import {
+  MockExplorerEpoch,
+  MockExplorerEpochForBlock,
+} from '../../../mocks/links';
 
 jest.mock('@vegaprotocol/react-helpers', () => {
   const original = jest.requireActual('@vegaprotocol/react-helpers');
@@ -14,15 +17,9 @@ jest.mock('@vegaprotocol/react-helpers', () => {
   };
 });
 
-jest.mock('../../../components/links/node-link/tendermint-node-link', () => ({
-  ...jest.requireActual(
-    '../../../components/links/node-link/tendermint-node-link'
-  ),
-  __esModule: true,
-  default: (props: { id: string }) => <div>{props.id}</div>,
-}));
+jest.mock('../../../components/links/node-link/tendermint-node-link');
 
-const blockId = 1085890;
+const blockId = 1;
 
 const createBlockResponse = (id: number = blockId) => {
   return {
@@ -131,7 +128,7 @@ const createBlockResponse = (id: number = blockId) => {
 
 const renderComponent = (id: number = blockId) => {
   return (
-    <MockedProvider mocks={[MockExplorerEpochForBlock]}>
+    <MockedProvider mocks={[MockExplorerEpochForBlock, MockExplorerEpoch]}>
       <MemoryRouter initialEntries={[`/${RouteNames.BLOCKS}/${id}`]}>
         <Routes>
           <Route path={`/${RouteNames.BLOCKS}/:block`} element={<Block />} />
@@ -149,6 +146,8 @@ afterEach(() => {
   jest.clearAllMocks();
   jest.useRealTimers();
 });
+
+jest.mock('../../../components/links/node-link/tendermint-node-link');
 
 describe('Block', () => {
   it('renders error state if error is present', async () => {

--- a/apps/explorer/src/app/routes/blocks/id/block.tsx
+++ b/apps/explorer/src/app/routes/blocks/id/block.tsx
@@ -17,7 +17,7 @@ import { useDocumentTitle } from '../../../hooks/use-document-title';
 import EmptyList from '../../../components/empty-list/empty-list';
 import { useExplorerEpochForBlockQuery } from '../../../components/links/block-link/__generated__/EpochByBlock';
 import EpochOverview from '../../../components/epoch-overview/epoch';
-import TendermintNodeLink from '../../../components/links/node-link/tendermint-node-link';
+import { TendermintNodeLink } from '../../../components/links/node-link/tendermint-node-link';
 
 type Params = { block: string };
 

--- a/apps/explorer/src/app/routes/oracles/components/oracle-markets.spec.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-markets.spec.tsx
@@ -20,104 +20,105 @@ function renderComponent(id: string, mocks: MockedResponse[]) {
   );
 }
 
+jest.mock('../../../components/links');
 describe('Oracle Markets component', () => {
-  it('Renders a row with the market ID initially', () => {
-    const res = render(renderComponent('123', []));
-    expect(res.getByTestId('wrapper')).toBeEmptyDOMElement();
-  });
-
-  it('Renders that this is a termination source for the right market', async () => {
-    const mock = {
-      request: {
-        query: ExplorerOracleFormMarketsDocument,
-      },
-      result: {
-        data: {
-          oracleSpecsConnection: {
-            edges: [
-              {
-                node: {
-                  dataConnection: {
-                    edges: [
-                      {
-                        node: {
-                          externalData: {
+  const mock = {
+    request: {
+      query: ExplorerOracleFormMarketsDocument,
+    },
+    result: {
+      data: {
+        oracleSpecsConnection: {
+          edges: [
+            {
+              node: {
+                dataConnection: {
+                  edges: [
+                    {
+                      node: {
+                        externalData: {
+                          data: {
                             data: {
-                              data: {
-                                name: '123',
-                                value: '456',
-                              },
+                              name: '123',
+                              value: '456',
                             },
                           },
                         },
                       },
-                    ],
+                    },
+                  ],
+                },
+                dataSourceSpec: {
+                  spec: {
+                    id: '789',
+                    state: 'Active',
+                    status: 'Active',
+                    data: {
+                      sourceType: {},
+                    },
                   },
-                  dataSourceSpec: {
-                    spec: {
-                      id: '789',
-                      state: 'Active',
-                      status: 'Active',
-                      data: {
-                        sourceType: {},
+                },
+              },
+            },
+          ],
+        },
+        marketsConnection: {
+          edges: [
+            {
+              node: {
+                __typename: 'Market',
+                id: '123',
+                state: 'Active',
+                tradableInstrument: {
+                  instrument: {
+                    product: {
+                      __typename: 'Future',
+                      dataSourceSpecForSettlementData: {
+                        id: '456',
+                        status: 'Active',
+                      },
+                      dataSourceSpecForTradingTermination: {
+                        id: '789',
+                        status: 'Active',
                       },
                     },
                   },
                 },
               },
-            ],
-          },
-          marketsConnection: {
-            edges: [
-              {
-                node: {
-                  __typename: 'Market',
-                  id: '123',
-                  state: 'Active',
-                  tradableInstrument: {
-                    instrument: {
-                      product: {
-                        __typename: 'Future',
-                        dataSourceSpecForSettlementData: {
-                          id: '456',
-                          status: 'Active',
-                        },
-                        dataSourceSpecForTradingTermination: {
-                          id: '789',
-                          status: 'Active',
-                        },
+            },
+            {
+              node: {
+                __typename: 'Market',
+                id: 'abc',
+                state: 'Active',
+                tradableInstrument: {
+                  instrument: {
+                    product: {
+                      __typename: 'Future',
+                      dataSourceSpecForSettlementData: {
+                        id: 'def',
+                        status: 'Active',
+                      },
+                      dataSourceSpecForTradingTermination: {
+                        id: 'ghi',
+                        status: 'Active',
                       },
                     },
                   },
                 },
               },
-              {
-                node: {
-                  __typename: 'Market',
-                  id: 'abc',
-                  state: 'Active',
-                  tradableInstrument: {
-                    instrument: {
-                      product: {
-                        __typename: 'Future',
-                        dataSourceSpecForSettlementData: {
-                          id: 'def',
-                          status: 'Active',
-                        },
-                        dataSourceSpecForTradingTermination: {
-                          id: 'ghi',
-                          status: 'Active',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            ],
-          },
+            },
+          ],
         },
       },
-    };
+    },
+  };
+  it('Renders a row with the market ID initially', () => {
+    const res = render(renderComponent('123', [mock]));
+    expect(res.getByTestId('wrapper')).toBeEmptyDOMElement();
+  });
+
+  it('Renders that this is a termination source for the right market', async () => {
     const res = render(renderComponent('789', [mock]));
     expect(await res.findByText('Schedule for')).toBeInTheDocument();
     expect(await res.findByTestId('m-123')).toBeInTheDocument();

--- a/apps/explorer/src/app/routes/oracles/components/oracle-signers.spec.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-signers.spec.tsx
@@ -22,6 +22,8 @@ function renderComponentWrapped(sourceType: SourceType) {
   );
 }
 
+jest.mock('../../../components/links');
+
 describe('Oracle Signers component', () => {
   it('returns empty if there are no signers (null)', () => {
     const res = render(renderComponent({} as SourceType));

--- a/apps/explorer/src/app/routes/treasury/components/network-accounts-table.spec.tsx
+++ b/apps/explorer/src/app/routes/treasury/components/network-accounts-table.spec.tsx
@@ -104,6 +104,9 @@ describe('parseResultsToAccounts', () => {
   });
 });
 
+jest.mock('../../../components/links');
+jest.mock('../../../components/asset-balance/asset-balance');
+
 describe('NetworkAccountsTable', () => {
   const mockData: ExplorerTreasuryQuery = {
     assetsConnection: {

--- a/apps/explorer/src/app/routes/treasury/components/network-accounts-table.tsx
+++ b/apps/explorer/src/app/routes/treasury/components/network-accounts-table.tsx
@@ -3,7 +3,7 @@ import {
   type ExplorerTreasuryQuery,
   useExplorerTreasuryQuery,
 } from '../__generated__/Treasury';
-import AssetBalance from '../../../components/asset-balance/asset-balance';
+import { AssetBalance } from '../../../components/asset-balance/asset-balance';
 import { AssetLink } from '../../../components/links';
 import { useMemo } from 'react';
 import { useScreenDimensions } from '@vegaprotocol/react-helpers';

--- a/apps/explorer/src/app/routes/treasury/components/network-transfers-table.spec.tsx
+++ b/apps/explorer/src/app/routes/treasury/components/network-transfers-table.spec.tsx
@@ -198,6 +198,10 @@ describe('filterAccountTransfers', () => {
   });
 });
 
+jest.mock('../../../components/links');
+jest.mock('../../../components/asset-balance/asset-balance');
+jest.mock('../../../components/links/proposal-link/proposal-link');
+
 describe('NetworkTransfersTable', () => {
   it('renders table headers correctly', async () => {
     const mocks = [
@@ -208,6 +212,9 @@ describe('NetworkTransfersTable', () => {
         result: {
           data: {
             transfersConnection: {
+              pageInfo: {
+                hasNextPage: false,
+              },
               edges: [
                 {
                   node: {
@@ -255,8 +262,7 @@ describe('NetworkTransfersTable', () => {
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Type')).toBeInTheDocument();
 
-    expect(screen.getByTestId('from-account').textContent).toEqual('Treasury');
-    expect(screen.getByTestId('to-account').textContent).toEqual('7100…97a0');
+    expect(screen.getByTestId('to-account').textContent).toContain('7100');
     expect(screen.getByTestId('transfer-kind').textContent).toEqual(
       'Governance - one time'
     );

--- a/apps/explorer/src/app/routes/treasury/components/network-transfers-table.tsx
+++ b/apps/explorer/src/app/routes/treasury/components/network-transfers-table.tsx
@@ -1,5 +1,5 @@
 import { AsyncRenderer, Icon } from '@vegaprotocol/ui-toolkit';
-import AssetBalance from '../../../components/asset-balance/asset-balance';
+import { AssetBalance } from '../../../components/asset-balance/asset-balance';
 import { AccountType, AccountTypeMapping } from '@vegaprotocol/types';
 import { AssetLink, PartyLink } from '../../../components/links';
 import {
@@ -12,7 +12,7 @@ import { t } from '@vegaprotocol/i18n';
 import { IconNames } from '@blueprintjs/icons';
 import { useMemo } from 'react';
 import { useScreenDimensions } from '@vegaprotocol/react-helpers';
-import ProposalLink from '../../../components/links/proposal-link/proposal-link';
+import { ProposalLink } from '../../../components/links/proposal-link/proposal-link';
 
 export const colours = {
   INCOMING: '!fill-vega-green-600 text-vega-green-600 mr-2',
@@ -158,7 +158,7 @@ export const NetworkTransfersTable = () => {
                     a?.toAccountType ===
                     AccountType.ACCOUNT_TYPE_NETWORK_TREASURY;
                   return (
-                    <tr>
+                    <tr key={a?.id}>
                       {a && a.amount && a.asset && (
                         <td
                           className={`px-2 py-1 border whitespace-nowrap text-right ${

--- a/apps/explorer/src/app/routes/txs/id/tx-details.spec.tsx
+++ b/apps/explorer/src/app/routes/txs/id/tx-details.spec.tsx
@@ -6,6 +6,7 @@ import type {
 } from '../../../routes/types/block-explorer-response';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
+import { commonLinkMocks } from '../../../mocks/links';
 
 // Note: Long enough that there is a truncated output and a full output
 const pubKey =
@@ -31,7 +32,7 @@ const txData: BlockExplorerTransactionResult = {
 
 const renderComponent = (txData: BlockExplorerTransactionResult) => (
   <MemoryRouter>
-    <MockedProvider>
+    <MockedProvider mocks={commonLinkMocks}>
       <TxDetails txData={txData} pubKey={pubKey} />
     </MockedProvider>
   </MemoryRouter>

--- a/apps/explorer/src/app/routes/txs/id/tx-details.spec.tsx
+++ b/apps/explorer/src/app/routes/txs/id/tx-details.spec.tsx
@@ -12,7 +12,7 @@ import { commonLinkMocks } from '../../../mocks/links';
 const pubKey =
   '67755549e43e95f0697f83b2bf419c6ccc18eee32a8a61b8ba6f59471b86fbef';
 const hash = '7416753a30622a9e24a06f0172d6c33a95186b36806d96345c6dc5a23fa3f283';
-const height = '52987';
+const height = '1';
 
 const txData: BlockExplorerTransactionResult = {
   hash,

--- a/libs/emblem/src/components/asset-emblem.test.tsx
+++ b/libs/emblem/src/components/asset-emblem.test.tsx
@@ -15,7 +15,6 @@ describe('EmblemByAsset', () => {
 
     const emblemImage = getByAltText('Emblem');
 
-    expect(emblemImage).toBeInTheDocument();
     expect(emblemImage).toHaveAttribute(
       'src',
       'https://icon.vega.xyz/vega/vega-chain/asset/123/logo.svg'
@@ -32,7 +31,6 @@ describe('EmblemByAsset', () => {
 
     const emblemImage = getByAltText('Emblem');
 
-    expect(emblemImage).toBeInTheDocument();
     expect(emblemImage).toHaveAttribute(
       'src',
       'https://icon.vega.xyz/vega/vega-mainnet-0011/asset/123/logo.svg'


### PR DESCRIPTION
- **fix(explorer): add common link mocks**
- **fix(explorer): mock commonly used components that trigger test adjacent graphql fixes**
- **fix(explorer): mock emblem and price components**
- **fix(explorer): add generic mock queries**
- **fix(explorer): add sizeinmarket mock and mock more links**
- **fix(explorer): add further mocks**
- **fix(explorer): add asset balance and further missing gql mocks**
- **fix(explorer): add block and epoch mocks**
- **fix(explorer): add more link mocks**
- **fix(explorer): size in asset mocks and many mock links**
- **fix(explorer): add network param link mock and transfer table mocks**

# Description
Running the unit tests for explorer resulted in lots of passing tests (hooray) but lots of missing mocks (boo). This is mostly due to expanded usage of components like `AssetLink` or `MarketLink` that now perform their own GraphQL queries to fetch party/market/asset/etc details. In 95% of the tests, the lack of mocks wasn't an issue as nothing was asserted on the details of the (e.g. `PartyLink`). But it was noisy.

This giant PR closes off all those warnings, and has no other impact.

Also closes #6434. See also #6435.

# tl;dr
Explorer unit test warnings output tidyup. Many mocks. Not much worth reviewing in depth.