### PR TITLE
feat(deal-ticket): allow toggle of size between base and quote asset

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
@@ -642,16 +642,12 @@ const NotEnoughBalanceWarning = ({
       />
     );
   }
-  const margin = removeDecimal(
-    size || '0',
-    asset.decimals - market.decimalPlaces
-  );
-  if (BigInt(balance) < BigInt(margin)) {
+  if (size && size !== '0' && BigInt(balance) < BigInt(size)) {
     return (
       <MarginWarning
         isSpotMarket={true}
         balance={balance}
-        margin={margin}
+        margin={size}
         asset={asset}
         onDeposit={onDeposit}
       />

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
@@ -901,8 +901,12 @@ const NotionalAndFees = ({
     <div className="mb-4 flex w-full flex-col gap-2">
       <KeyValue
         label={t('Notional')}
-        value={formatValue(notionalSize, market.decimalPlaces)}
-        formattedValue={formatValue(notionalSize, market.decimalPlaces)}
+        value={formatValue(notionalSize, asset.decimals)}
+        formattedValue={formatValue(
+          notionalSize,
+          asset.decimals,
+          asset.quantum
+        )}
         symbol={quoteName}
         labelDescription={t(
           'NOTIONAL_SIZE_TOOLTIP_TEXT',
@@ -1175,6 +1179,7 @@ const getDerivedPriceAndNotional = ({
   price,
   positionDecimalPlaces,
   decimalPlaces,
+  decimals,
   triggerType,
   triggerPrice,
   marketPrice,
@@ -1184,6 +1189,7 @@ const getDerivedPriceAndNotional = ({
   price?: string;
   positionDecimalPlaces: number;
   decimalPlaces: number;
+  decimals: number;
   triggerType: StopOrderFormValues['triggerType'];
   type: StopOrderFormValues['type'];
   marketPrice?: string | null;
@@ -1204,7 +1210,8 @@ const getDerivedPriceAndNotional = ({
     derivedPrice,
     size,
     decimalPlaces,
-    positionDecimalPlaces
+    positionDecimalPlaces,
+    decimals
   );
   return { notionalSize, derivedPrice };
 };
@@ -1340,6 +1347,7 @@ export const StopOrder = ({
     return () => subscription.unsubscribe();
   }, [watch, market.id, updateStoredFormValues]);
 
+  const asset = getAsset(market);
   const quoteName = getQuoteName(market);
   const assetUnit = getBaseQuoteUnit(
     market.tradableInstrument.instrument.metadata.tags
@@ -1366,6 +1374,7 @@ export const StopOrder = ({
     decimalPlaces: market.decimalPlaces,
     marketPrice,
     positionDecimalPlaces: market.positionDecimalPlaces,
+    decimals: asset.decimals,
     size: normalizedSize,
     triggerPrice,
     triggerType,
@@ -1386,6 +1395,7 @@ export const StopOrder = ({
       decimalPlaces: market.decimalPlaces,
       marketPrice,
       positionDecimalPlaces: market.positionDecimalPlaces,
+      decimals: asset.decimals,
       size: ocoNormalizedSize,
       triggerPrice: ocoTriggerPrice,
       triggerType: ocoTriggerType,

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.spec.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.spec.tsx
@@ -943,4 +943,39 @@ describe('DealTicket', () => {
       );
     });
   });
+
+  it('toggle of size between base and quote asset', async () => {
+    // Render component
+    render(generateJsx());
+
+    let orderSizeField = screen.getByTestId('order-size');
+    await userEvent.type(orderSizeField, '1');
+    await userEvent.click(screen.getByTestId('useNotional'));
+    let orderNotionalField = screen.getByTestId('order-notional');
+    // market price is 2 order size is 1 => notional is 2
+    expect(orderNotionalField).toHaveDisplayValue('2.0');
+
+    await userEvent.clear(orderNotionalField);
+    await userEvent.type(orderNotionalField, '4');
+    await userEvent.click(screen.getByTestId('useSize'));
+    orderSizeField = screen.getByTestId('order-size');
+    // market price is 2 notional is 4  => size is 2
+    expect(orderSizeField).toHaveDisplayValue('2.0');
+
+    userEvent.click(screen.getByTestId('order-type-Limit'));
+    const orderPriceField = screen.getByTestId('order-price');
+    await userEvent.clear(orderPriceField);
+    await userEvent.type(orderPriceField, '4');
+    await userEvent.click(screen.getByTestId('useNotional'));
+    // limit price is 4 size is 2 => notional 8
+    orderNotionalField = screen.getByTestId('order-notional');
+    expect(screen.getByTestId('order-notional')).toHaveDisplayValue('8.0');
+
+    await userEvent.clear(orderNotionalField);
+    await userEvent.type(orderNotionalField, '16');
+    await userEvent.click(screen.getByTestId('useSize'));
+    orderSizeField = screen.getByTestId('order-size');
+    // market price is 4 notional is 16  => size is 4
+    expect(orderSizeField).toHaveDisplayValue('4.0');
+  });
 });

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -35,6 +35,7 @@ import {
   useValidateAmount,
   formatForInput,
   formatValue,
+  toDecimal,
 } from '@vegaprotocol/utils';
 import { useActiveOrders } from '@vegaprotocol/orders';
 import {
@@ -89,6 +90,8 @@ import {
   useDealTicketFormValues,
 } from '@vegaprotocol/react-helpers';
 import { useSlippage } from '../../hooks/use-slippage';
+import BigNumber from 'bignumber.js';
+import classNames from 'classnames';
 
 export const REDUCE_ONLY_TOOLTIP =
   '"Reduce only" will ensure that this order will not increase the size of an open position. When the order is matched, it will only trade enough volume to bring your open volume towards 0 but never change the direction of your position. If applied to a limit order that is not instantly filled, the order will be stopped.';
@@ -137,6 +140,8 @@ const getDefaultValues = (
       ? Schema.OrderTimeInForce.TIME_IN_FORCE_GTC
       : Schema.OrderTimeInForce.TIME_IN_FORCE_IOC,
   size: '0',
+  notional: '0',
+  useNotional: false,
   price: '0',
   expiresAt: undefined,
   postOnly: false,
@@ -224,6 +229,7 @@ export const DealTicket = ({
   const peakSize = watch('peakSize');
   const expiresAt = watch('expiresAt');
   const postOnly = watch('postOnly');
+  const useNotional = watch('useNotional');
 
   useEffect(() => {
     const size = storedFormValues?.[dealTicketType]?.size;
@@ -412,6 +418,12 @@ export const DealTicket = ({
   const disableIcebergCheckbox = nonPersistentOrder;
   const featureFlags = useFeatureFlags((state) => state.flags);
   const sizeStep = determineSizeStep(market);
+  const minNotional = toBigNum(price || '0', market.decimalPlaces).multipliedBy(
+    sizeStep
+  );
+  const notionalStep = toDecimal(
+    Math.floor(Math.log10(minNotional.toNumber())) * -1
+  );
   const marketIsInAuction = isMarketInAuction(marketData.marketTradingMode);
 
   const maxSize = useMaxSize({
@@ -522,49 +534,148 @@ export const DealTicket = ({
           />
         )}
       />
-
-      <Controller
-        name="size"
-        control={control}
-        rules={{
-          required: t('You need to provide a size'),
-          min: {
-            value: sizeStep,
-            message: t('Size cannot be lower than {{sizeStep}}', { sizeStep }),
-          },
-          validate: validateAmount(sizeStep, 'Size'),
-          deps: ['peakSize', 'minimumVisibleSize'],
-        }}
-        render={({ field, fieldState }) => (
-          <div className={isLimitType ? 'mb-4' : 'mb-2'}>
-            <FormGroup label={t('Size')} labelFor="order-size" compact>
-              <Input
-                id="order-size"
-                className="w-full"
-                type="number"
-                appendElement={baseQuote && <Pill size="xs">{baseQuote}</Pill>}
-                step={sizeStep}
-                min={sizeStep}
-                data-testid="order-size"
-                onWheel={(e) => e.currentTarget.blur()}
-                {...field}
-              />
-            </FormGroup>
-            <Slider
-              min={0}
-              max={maxSize}
-              step={Number(sizeStep)}
-              value={[Number(field.value)]}
-              onValueChange={([value]) => field.onChange(value)}
-            />
-            {fieldState.error && (
-              <InputError testId="deal-ticket-error-message-size">
-                {fieldState.error.message}
-              </InputError>
-            )}
-          </div>
+      <div className={isLimitType ? 'mb-4' : 'mb-2'}>
+        {useNotional && (
+          <Controller
+            key="notional"
+            name="notional"
+            control={control}
+            rules={{
+              required: t('You need to provide a size'),
+              min: {
+                value: minNotional.toString(),
+                message: t('Notional cannot be lower than {{minNotional}}', {
+                  minNotional: minNotional.toString(),
+                }),
+              },
+              validate: validateAmount(sizeStep, 'Size'),
+              deps: ['peakSize', 'minimumVisibleSize'],
+            }}
+            render={({ field: { onChange, ...field }, fieldState }) => {
+              const onNotionalChange = (value: string) => {
+                onChange(value);
+                if (!price || !value) {
+                  return;
+                }
+                const size =
+                  value === '0'
+                    ? '0'
+                    : BigNumber(value)
+                        .dividedBy(toBigNum(price, market.decimalPlaces))
+                        .toFixed(market.positionDecimalPlaces);
+                setValue('size', size);
+              };
+              return (
+                <FormGroup
+                  label={t('Notional')}
+                  labelFor="order-notional"
+                  compact
+                >
+                  <Input
+                    id="order-notional"
+                    className="w-full"
+                    type="number"
+                    appendElement={
+                      quoteName && (
+                        <button
+                          type="button"
+                          onClick={() => setValue('useNotional', false)}
+                        >
+                          <Pill size="xs">{quoteName}</Pill>
+                        </button>
+                      )
+                    }
+                    step={notionalStep}
+                    min={notionalStep}
+                    data-testid="order-notional"
+                    onWheel={(e) => e.currentTarget.blur()}
+                    {...field}
+                    onChange={(event) => onNotionalChange(event.target.value)}
+                  />
+                </FormGroup>
+              );
+            }}
+          />
         )}
-      />
+        <Controller
+          key="size"
+          name="size"
+          control={control}
+          rules={{
+            required: t('You need to provide a size'),
+            min: {
+              value: sizeStep,
+              message: t('Size cannot be lower than {{sizeStep}}', {
+                sizeStep,
+              }),
+            },
+            validate: validateAmount(sizeStep, 'Size'),
+            deps: ['peakSize', 'minimumVisibleSize'],
+          }}
+          render={({ field: { onChange, ...field }, fieldState }) => {
+            const onSizeChange = (value: string) => {
+              onChange(value);
+              if (!price || !value) {
+                return;
+              }
+              setValue(
+                'notional',
+                value === '0'
+                  ? '0'
+                  : BigNumber(value)
+                      .multipliedBy(toBigNum(price, market.decimalPlaces))
+                      .toFixed(market.positionDecimalPlaces)
+              );
+            };
+            return (
+              <>
+                <FormGroup
+                  label={t('Size')}
+                  labelFor="order-size"
+                  compact
+                  className={classNames({ hidden: useNotional })}
+                >
+                  <Input
+                    id="order-size"
+                    className="w-full"
+                    type="number"
+                    appendElement={
+                      baseQuote && (
+                        <button
+                          type="button"
+                          onClick={() => setValue('useNotional', true)}
+                        >
+                          <Pill size="xs">{baseQuote}</Pill>
+                        </button>
+                      )
+                    }
+                    step={sizeStep}
+                    min={sizeStep}
+                    data-testid="order-size"
+                    onWheel={(e) => e.currentTarget.blur()}
+                    {...field}
+                    onChange={(event) => {
+                      onSizeChange(event.target.value);
+                    }}
+                  />
+                </FormGroup>
+                <Slider
+                  min={0}
+                  max={maxSize}
+                  step={Number(sizeStep)}
+                  value={[Number(field.value)]}
+                  onValueChange={([value]) => onSizeChange(value.toString())}
+                />
+                {fieldState.error && (
+                  <InputError testId="deal-ticket-error-message-size">
+                    {fieldState.error.message}
+                  </InputError>
+                )}
+              </>
+            );
+          }}
+        />
+      </div>
       {isLimitType && (
         <Controller
           name="price"
@@ -607,17 +718,27 @@ export const DealTicket = ({
         />
       )}
       <div className="mb-4 flex w-full flex-col gap-2">
-        <KeyValue
-          label={t('Notional')}
-          value={formatValue(notionalSize, market.decimalPlaces)}
-          formattedValue={formatValue(notionalSize, market.decimalPlaces)}
-          symbol={quoteName}
-          labelDescription={t(
-            'NOTIONAL_SIZE_TOOLTIP_TEXT',
-            NOTIONAL_SIZE_TOOLTIP_TEXT,
-            { quoteName }
-          )}
-        />
+        {useNotional ? (
+          <KeyValue
+            label={t('Size')}
+            formattedValue={formatValue(
+              normalizedOrder?.size || '0',
+              market.positionDecimalPlaces
+            )}
+            symbol={baseQuote}
+          />
+        ) : (
+          <KeyValue
+            label={t('Notional')}
+            value={formatValue(notionalSize, market.decimalPlaces)}
+            symbol={quoteName}
+            labelDescription={t(
+              'NOTIONAL_SIZE_TOOLTIP_TEXT',
+              NOTIONAL_SIZE_TOOLTIP_TEXT,
+              { quoteName }
+            )}
+          />
+        )}
         <DealTicketFeeDetails
           order={
             normalizedOrder && { ...normalizedOrder, price: price || undefined }

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -422,15 +422,21 @@ export const DealTicket = ({
   const disableIcebergCheckbox = nonPersistentOrder;
   const featureFlags = useFeatureFlags((state) => state.flags);
   const sizeStep = determineSizeStep(market);
-  const notionalPrice = (!price || price === '0' ? markPrice : price) || '0';
-  const minNotional = toBigNum(notionalPrice, market.decimalPlaces)
-    .multipliedBy(sizeStep)
-    .toNumber();
+  const notionalPrice = !price || price === '0' ? markPrice : price;
+  const minNotional = notionalPrice
+    ? toBigNum(notionalPrice, market.decimalPlaces)
+        .multipliedBy(sizeStep)
+        .toNumber()
+    : undefined;
 
-  const notionalDecimals = Math.floor(Math.log10(minNotional)) * -1;
-  const notionalStep = toDecimal(notionalDecimals);
+  const notionalDecimals =
+    minNotional && Math.floor(Math.log10(minNotional)) * -1;
+  const notionalStep = notionalDecimals ? toDecimal(notionalDecimals) : '1';
 
   useEffect(() => {
+    if (!notionalPrice || typeof notionalDecimals !== 'number') {
+      return;
+    }
     if (useNotional) {
       const size =
         !notional || notional === '0'

--- a/libs/deal-ticket/src/test-helpers.ts
+++ b/libs/deal-ticket/src/test-helpers.ts
@@ -33,7 +33,7 @@ export function generateMarket(override?: PartialDeep<Market>): Market {
         name: 'ACTIVE MARKET',
         metadata: {
           __typename: 'InstrumentMetadata',
-          tags: [],
+          tags: ['base:tDAI'],
         },
         product: {
           __typename: 'Future',

--- a/libs/react-helpers/src/hooks/use-form-values.ts
+++ b/libs/react-helpers/src/hooks/use-form-values.ts
@@ -53,6 +53,8 @@ export type OrderFormValues = {
   type: OrderType;
   side: Side;
   size: string;
+  notional?: string;
+  useNotional?: boolean;
   timeInForce: OrderTimeInForce;
   price?: string;
   expiresAt?: string | undefined;

--- a/libs/ui-toolkit/src/components/slider/percentage-slider.tsx
+++ b/libs/ui-toolkit/src/components/slider/percentage-slider.tsx
@@ -25,6 +25,7 @@ export const PercentageSlider = ({
         {...props}
         min={disabled ? 0 : min}
         max={disabled ? 1 : max}
+        value={disabled ? [0] : props.value}
         className="relative flex items-center select-none touch-none h-10 pb-5 w-full"
       >
         <SliderPrimitive.Track className=" relative grow h-[4px]">


### PR DESCRIPTION
# Related issues 🔗

Closes #6187

# Description ℹ️

Allow toggle of size between base and quote asset.
There are no changes in order submission. If quote asset is used size is calculated base on price and notional.

# Demo 📺

<img width="142" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/1754247/e8e00c9f-9ded-4f32-a299-f47465251e99">