### PR TITLE
chore(explorer,trading,governance): update browserlist

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10115,9 +10115,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001561"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
-  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
+  version "1.0.30001620"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz"
+  integrity sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -21149,7 +21149,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21232,7 +21241,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21245,6 +21254,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -23056,7 +23072,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -23078,6 +23094,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Description ℹ️
```
❯ npx update-browserslist-db@latest                                                                                                                       ─╯
Need to install the following packages:
update-browserslist-db@1.0.16
Ok to proceed? (y) y

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Latest version:     1.0.30001620
Installed version:  1.0.30001561
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
warning Resolution field "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.cd77847.0" is incompatible with requested version "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0"
warning Pattern ["@apollo/client@latest"] is trying to unpack in the same destination "/Users/edd/Library/Caches/Yarn/v6/npm-@apollo-client-3.8.7-090b1518f513503b9a6a690ee3eaec49529822e1-integrity/node_modules/@apollo/client" as pattern ["@apollo/client@^3.5.8"]. This could result in non-deterministic behavior, skipping.
warning " > @sentry/nextjs@6.19.7" has incorrect peer dependency "next@^10.0.8 || ^11.0 || ^12.0".
warning " > recharts@2.9.3" has unmet peer dependency "prop-types@^15.6.0".
warning "recharts > react-smooth@2.0.5" has unmet peer dependency "prop-types@^15.6.0".
warning " > @graphql-codegen/typescript-react-apollo@3.3.7" has unmet peer dependency "graphql-tag@^2.0.0".
warning " > @rollup/plugin-url@7.0.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning " > @testing-library/user-event@14.5.1" has unmet peer dependency "@testing-library/dom@>=7.21.4".
warning "cypress-mochawesome-reporter > mochawesome@7.1.3" has unmet peer dependency "mocha@>=7".
warning "verdaccio > clipanion@3.2.1" has unmet peer dependency "typanion@*".
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
warning Resolution field "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.cd77847.0" is incompatible with requested version "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0"
warning Pattern ["@apollo/client@latest"] is trying to unpack in the same destination "/Users/edd/Library/Caches/Yarn/v6/npm-@apollo-client-3.8.7-090b1518f513503b9a6a690ee3eaec49529822e1-integrity/node_modules/@apollo/client" as pattern ["@apollo/client@^3.5.8"]. This could result in non-deterministic behavior, skipping.
warning " > @sentry/nextjs@6.19.7" has incorrect peer dependency "next@^10.0.8 || ^11.0 || ^12.0".
warning " > recharts@2.9.3" has unmet peer dependency "prop-types@^15.6.0".
warning "recharts > react-smooth@2.0.5" has unmet peer dependency "prop-types@^15.6.0".
warning " > @graphql-codegen/typescript-react-apollo@3.3.7" has unmet peer dependency "graphql-tag@^2.0.0".
warning " > @rollup/plugin-url@7.0.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning " > @testing-library/user-event@14.5.1" has unmet peer dependency "@testing-library/dom@>=7.21.4".
warning "cypress-mochawesome-reporter > mochawesome@7.1.3" has unmet peer dependency "mocha@>=7".
warning "verdaccio > clipanion@3.2.1" has unmet peer dependency "typanion@*".
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
caniuse-lite has been successfully updated
```
