### PR TITLE
fix(trading): sort markets by 24h vol

### DIFF
--- a/apps/trading/client-pages/markets/open-markets.spec.tsx
+++ b/apps/trading/client-pages/markets/open-markets.spec.tsx
@@ -103,7 +103,11 @@ describe('Open', () => {
       'Open interest',
     ];
     expect(headers).toHaveLength(expectedHeaders.length);
-    expect(headers.map((h) => h.textContent?.trim())).toEqual(expectedHeaders);
+    headers
+      .map((h) => h.textContent?.trim())
+      .forEach((h, i) => {
+        expect(h).toContain(expectedHeaders[i]);
+      });
   });
 
   it('sort columns', async () => {

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -241,6 +241,7 @@ export const useMarketsColumnDefs = () => {
         headerName: t('24h Volume'),
         type: 'rightAligned',
         field: 'data.candles',
+        sort: 'desc',
         valueGetter: ({
           data,
         }: VegaValueGetterParams<MarketMaybeWithDataAndCandles>) => {


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

Sort by 24h vol markets active. 

# Demo 📺

<img width="1680" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/d3b3cdb9-6e18-4348-8a0c-1b8d8211f721">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
