### PR TITLE
chore(trading): bring toast to the front so it appears on top of dialogs

### DIFF
--- a/libs/ui-toolkit/src/components/toast/toasts-container.tsx
+++ b/libs/ui-toolkit/src/components/toast/toasts-container.tsx
@@ -53,7 +53,7 @@ export const ToastsContainer = ({
       ref={ref as Ref<HTMLDivElement>}
       className={classNames(
         'group',
-        'absolute z-20',
+        'absolute z-30',
         { 'bottom-0 right-0': position === ToastPosition.BottomRight },
         { 'bottom-0 left-0': position === ToastPosition.BottomLeft },
         { 'left-0 top-0': position === ToastPosition.TopLeft },


### PR DESCRIPTION
# Related issues 🔗

Closes #6432 

# Description ℹ️

Increases toast container z-index so that toasts appear over the top of dialog overlays