### PR TITLE
chore(trading,explorer,governance): remove deprecated nx configuration

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -103,7 +103,11 @@ jobs:
           fi
 
           if [ "${{ matrix.app }}" = "trading" ]; then
-            $envCmd yarn nx export trading || (yarn install && $envCmd yarn nx export trading)
+            # expost implicitly runs build, but nx:cloud is incorrectly giving us a cached
+            # build when only a nested dependency is changed, so running build separately
+            # *may* help, or at least provide output that will help
+            $envCmd yarn nx build trading || (yarn install && $envCmd yarn nx build trading)
+            $envCmd yarn nx export trading
             DIST_LOCATION=dist/apps/trading/exported
           elif [ "${{ matrix.app }}" = "ui-toolkit" ]; then
             NODE_ENV=production yarn nx run ui-toolkit:build-storybook

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -103,7 +103,11 @@ jobs:
           fi
 
           if [ "${{ matrix.app }}" = "trading" ]; then
-            $envCmd yarn nx export trading || (yarn install && $envCmd yarn nx export trading)
+            # expost implicitly runs build, but nx:cloud is incorrectly giving us a cached
+            # build when only a nested dependency is changed, so running build separately
+            # *may* help, or at least provide output that will help
+            $envCmd yarn nx build trading --skip-nx-cache || (yarn install && $envCmd yarn nx build trading --skip-nx-cache)
+            $envCmd yarn nx export trading
             DIST_LOCATION=dist/apps/trading/exported
           elif [ "${{ matrix.app }}" = "ui-toolkit" ]; then
             NODE_ENV=production yarn nx run ui-toolkit:build-storybook

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -103,11 +103,7 @@ jobs:
           fi
 
           if [ "${{ matrix.app }}" = "trading" ]; then
-            # expost implicitly runs build, but nx:cloud is incorrectly giving us a cached
-            # build when only a nested dependency is changed, so running build separately
-            # *may* help, or at least provide output that will help
-            $envCmd yarn nx build trading || (yarn install && $envCmd yarn nx build trading)
-            $envCmd yarn nx export trading
+            $envCmd yarn nx export trading || (yarn install && $envCmd yarn nx export trading)
             DIST_LOCATION=dist/apps/trading/exported
           elif [ "${{ matrix.app }}" = "ui-toolkit" ]; then
             NODE_ENV=production yarn nx run ui-toolkit:build-storybook

--- a/apps/trading/project.json
+++ b/apps/trading/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {
       "executor": "@nx/next:build",
+      "inputs": ["default", "^production"],
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
@@ -33,6 +34,7 @@
     },
     "export": {
       "executor": "@nx/next:export",
+      "inputs": ["default", "^production"],
       "options": {
         "buildTarget": "trading:build:production"
       }

--- a/apps/trading/project.json
+++ b/apps/trading/project.json
@@ -5,6 +5,7 @@
   "projectType": "application",
   "targets": {
     "build": {
+      "inputs": ["default", { "runtime": "git rev-parse HEAD" }],
       "executor": "@nx/next:build",
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",

--- a/apps/trading/project.json
+++ b/apps/trading/project.json
@@ -5,7 +5,6 @@
   "projectType": "application",
   "targets": {
     "build": {
-      "inputs": ["default", { "runtime": "git rev-parse HEAD" }],
       "executor": "@nx/next:build",
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",

--- a/nx.json
+++ b/nx.json
@@ -2,23 +2,6 @@
   "affected": {
     "defaultBase": "develop"
   },
-  "tasksRunnerOptions": {
-    "default": {
-      "options": {
-        "runtimeCacheInputs": [
-          "echo $NX_VEGA_NETWORKS",
-          "echo $NX_VEGA_ENV",
-          "echo $NX_VEGA_URL",
-          "echo $NX_TENDERMINT_URL",
-          "echo $NX_TENDERMINT_WEBSOCKET_URL",
-          "echo $NX_ETHEREUM_PROVIDER_URL",
-          "echo $NX_CHARTING_LIBRARY_PATH",
-          "echo $NX_CHARTING_LIBRARY_HASH",
-          "echo $GIT_COMMIT_HASH"
-        ]
-      }
-    }
-  },
   "generators": {
     "@nx/web:application": {
       "style": "scss",


### PR DESCRIPTION
We previously used https://nx.dev/deprecated/runtime-cache-inputs to ensure we didn't cache config between environments. Since upgrading NX, this config has not been doing anything and is distracting.

- remove cache inputs