### PR TITLE
fix(ui-toolkit): unnecessary scroll bars appearing due to large padding

### DIFF
--- a/libs/ui-toolkit/src/components/dialog/dialog.tsx
+++ b/libs/ui-toolkit/src/components/dialog/dialog.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import * as DialogPrimitives from '@radix-ui/react-dialog';
 import classNames from 'classnames';
 
@@ -49,14 +48,6 @@ export function Dialog({
     }
   );
 
-  useEffect(() => {
-    if (open) {
-      document.body.classList.add('overflow-hidden');
-    } else {
-      document.body.classList.remove('overflow-hidden');
-    }
-  }, [open]);
-
   return (
     <DialogPrimitives.Root open={open} onOpenChange={(x) => onChange?.(x)}>
       <DialogPrimitives.Portal>
@@ -73,7 +64,7 @@ export function Dialog({
           <div
             className={classNames(
               // Positions the modal in the center of screen
-              'z-20 relative rounded top-[5vw] pb-[5vw] lg:top-[10vh] lg:pb-[10vh]'
+              'z-20 relative rounded top-[5vw] lg:top-[10vw] pb-3'
             )}
           >
             <div className={wrapperClasses}>

--- a/libs/ui-toolkit/src/components/dialog/dialog.tsx
+++ b/libs/ui-toolkit/src/components/dialog/dialog.tsx
@@ -64,7 +64,7 @@ export function Dialog({
           <div
             className={classNames(
               // Positions the modal in the center of screen
-              'z-20 relative rounded top-[5vw] lg:top-[10vw] pb-3'
+              'z-20 relative rounded top-[5vw] pb-3'
             )}
           >
             <div className={wrapperClasses}>


### PR DESCRIPTION
# Related issues 🔗

Closes #6430

# Description ℹ️

- Reduce amount of padding below the dialog content. This was there to ensure you could scroll beneath the dialog but ultimately if the viewport was a specific size (wide but not tall) would cause scroll bars to appear when they weren't necessary
- Remove a useEffect/className toggle that had no effect on functionality