### PR TITLE
ci(explorer,trading,governance): replace revoked token

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -108,5 +108,5 @@
       "!{projectRoot}/tsconfig.storybook.json"
     ]
   },
-  "nxCloudAccessToken": "OTY4ZjdlZTItNGIwNy00NDcyLTllZjctOWIzYTg1NWE0Yzg1fHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "ZDIzZTQ0YjAtZTRkMC00NDVlLTk2MjYtZjhlYjA4NzIzYzkyfHJlYWQ="
 }


### PR DESCRIPTION
`nx.json` contains a revoked read/write nx cloud token. This PR replaces it with a read only token

# Notes
Issue reported via https://vega.xyz/bug-bounties