### PR TITLE
fix(explorer,assets,trading): chage how assets dialog gets vega chain id

### DIFF
--- a/apps/explorer/src/app/routes/layout.tsx
+++ b/apps/explorer/src/app/routes/layout.tsx
@@ -27,6 +27,7 @@ import {
   ProtocolUpgradeInProgressNotification,
   ProtocolUpgradeProposalNotification,
 } from '@vegaprotocol/proposals';
+import { ENV } from '../config/env';
 
 const DialogsContainer = () => {
   const { isOpen, id, trigger, asJson, setOpen } = useAssetDetailsDialogStore();
@@ -37,6 +38,7 @@ const DialogsContainer = () => {
       asJson={asJson}
       open={isOpen}
       onChange={setOpen}
+      vegaChain={ENV.vegaChainId}
     />
   );
 };

--- a/apps/trading/pages/dialogs-container.tsx
+++ b/apps/trading/pages/dialogs-container.tsx
@@ -9,9 +9,11 @@ import {
 import { WelcomeDialog } from '../components/welcome-dialog';
 import { VegaWalletConnectDialog } from '../components/vega-wallet-connect-dialog';
 import { ProfileDialog } from '../components/profile-dialog';
+import { useChainId } from '@vegaprotocol/wallet-react';
 
 const DialogsContainer = () => {
   const { isOpen, id, trigger, setOpen } = useAssetDetailsDialogStore();
+  const { chainId } = useChainId();
 
   return (
     <>
@@ -21,6 +23,7 @@ const DialogsContainer = () => {
         trigger={trigger || null}
         open={isOpen}
         onChange={setOpen}
+        vegaChain={chainId}
       />
       <WelcomeDialog />
       <Web3ConnectUncontrolledDialog />

--- a/libs/assets/src/lib/asset-details-dialog.spec.tsx
+++ b/libs/assets/src/lib/asset-details-dialog.spec.tsx
@@ -60,6 +60,7 @@ const WrappedAssetDetailsDialog = ({ assetId }: { assetId: string }) => (
         assetId={assetId}
         open={true}
         onChange={() => false}
+        vegaChain="vega-mainnet-0011"
       ></AssetDetailsDialog>
     </MockedWalletProvider>
   </MockedProvider>

--- a/libs/assets/src/lib/asset-details-dialog.tsx
+++ b/libs/assets/src/lib/asset-details-dialog.tsx
@@ -5,7 +5,6 @@ import { AssetDetailsTable } from './asset-details-table';
 import { AssetProposalNotification } from '@vegaprotocol/proposals';
 import { useAssetDataProvider } from './asset-data-provider';
 import { Emblem } from '@vegaprotocol/emblem';
-import { useChainId } from '@vegaprotocol/wallet-react';
 
 export type AssetDetailsDialogStore = {
   isOpen: boolean;
@@ -42,6 +41,8 @@ export interface AssetDetailsDialogProps {
   open: boolean;
   onChange: (open: boolean) => void;
   asJson?: boolean;
+  // Used to fetch the correct asset icon for the current chain
+  vegaChain: string;
 }
 
 export const AssetDetailsDialog = ({
@@ -50,6 +51,7 @@ export const AssetDetailsDialog = ({
   open,
   onChange,
   asJson = false,
+  vegaChain,
 }: AssetDetailsDialogProps) => {
   const t = useT();
   const { data: asset } = useAssetDataProvider(assetId);
@@ -76,12 +78,10 @@ export const AssetDetailsDialog = ({
     ? t('Asset details - {{symbol}}', asset)
     : t('Asset not found');
 
-  const { chainId } = useChainId();
-
   return (
     <Dialog
       title={title}
-      icon={<Emblem asset={assetId} vegaChain={chainId} />}
+      icon={<Emblem asset={assetId} vegaChain={vegaChain} />}
       open={open}
       onChange={(isOpen) => onChange(isOpen)}
       onCloseAutoFocus={(e) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #6493

# Description ℹ️

#6483 added an Emblem to the asset dialog, but used the wallet provider to get the chain Id, which explorer doesn't have. This PR changes it to be a prop, so each app can customise how it gets the chain id. trading still uses the wallet provider. Explorer uses env.

# How to test this
The error was most obvious in dev mode, so testing this is a local thing.

1. Running:

```bash
yarn env-cmd -f ./apps/explorer/.env.testnet yarn nx run explorer:serve 
```

should launch a browser with Explorer in it, without a full screen error.

2. Running :

```bash
yarn env-cmd -f apps/trading/.env.testnet yarn nx run trading:serve
```

should launch a browser with Trading in it, and clicking on an asset should launch the assets modal with the correct icon for the asset in the header