### PR TITLE
fix(emblem): fix incorrect base asset chain logo for spot markets

### DIFF
--- a/libs/emblem/src/components/market-emblem.tsx
+++ b/libs/emblem/src/components/market-emblem.tsx
@@ -103,7 +103,7 @@ export function getLogoPaths(
     base: baseLogo ? `${URL_BASE}${baseLogo}` : missing,
     quote: quoteLogo ? `${URL_BASE}${quoteLogo}` : missing,
     quoteChain: quoteChainLogo ? `${URL_BASE}${quoteChainLogo}` : undefined,
-    baseChain: quoteChainLogo ? `${URL_BASE}${quoteChainLogo}` : undefined,
+    baseChain: baseChainLogo ? `${URL_BASE}${baseChainLogo}` : undefined,
     settlementChain: settlementChainLogo
       ? `${URL_BASE}${settlementChainLogo}`
       : undefined,


### PR DESCRIPTION
# Related issues 🔗

Closes #6497

# Description ℹ️

The Enbken component for markets, specifically for spot markets, where the chain logos were shown, would use the chain of the quote asset for both chain icons. After this fix, it uses the correct chain for each asset.

- Fix base asset chain logo

# Demo 📺

## After
<img width="88" alt="Screenshot 2024-06-03 at 14 16 25" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/538899b5-32f3-4403-b9b4-5efdc67e510c">

## Before
<img width="96" alt="Screenshot 2024-06-03 at 14 05 41" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/3418b0b8-7c0d-4e4d-b8e5-5c55757bde94">


