### PR TITLE
fix(trading): cropping of sidebar elements

### DIFF
--- a/apps/trading/components/sidebar/sidebar.tsx
+++ b/apps/trading/components/sidebar/sidebar.tsx
@@ -283,9 +283,9 @@ const ContentWrapper = ({
   title?: string;
 }) => {
   return (
-    <TinyScroll className="py-4 px-3" data-testid="sidebar-content">
-      {title && <h2 className="mb-4">{title}</h2>}
-      {children}
+    <TinyScroll className="py-4" data-testid="sidebar-content">
+      {title && <h2 className="mb-4 px-3">{title}</h2>}
+      <div className="px-3">{children}</div>
     </TinyScroll>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #6484  

# Description ℹ️

Fix the slider scale being trimmed on the left and right sides. 

# Demo 📺

<img width="323" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/5bf415d4-df3b-46e8-b37d-afdd3857f27f">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
