### PR TITLE
fix(trading): translation for epochs ends in count

### DIFF
--- a/apps/trading/components/rewards-container/reward-card.tsx
+++ b/apps/trading/components/rewards-container/reward-card.tsx
@@ -352,20 +352,18 @@ const RewardCard = ({
                     })}
                   </span>
                 </span>
-              ) : (
-                endsIn && (
-                  <span className="flex flex-col">
-                    <span className="text-muted text-xs">{t('Ends in')} </span>
-                    <span data-testid="ends-in" data-endsin={endsIn}>
-                      {endsIn >= 0
-                        ? t('numberEpochs', '{{count}} epochs', {
-                            count: endsIn,
-                          })
-                        : t('Ended')}
-                    </span>
+              ) : endsIn !== undefined ? (
+                <span className="flex flex-col">
+                  <span className="text-muted text-xs">{t('Ends in')} </span>
+                  <span data-testid="ends-in" data-endsin={endsIn}>
+                    {endsIn > 0
+                      ? t('numberEpochs', '{{count}} epochs', {
+                          count: endsIn,
+                        })
+                      : t('Ended')}
                   </span>
-                )
-              )}
+                </span>
+              ) : null}
               {/** WINDOW LENGTH */}
               <span className="flex flex-col">
                 <span className="text-muted text-xs">{t('Assessed over')}</span>


### PR DESCRIPTION
# Related issues 🔗

Closes #6407 

# Description ℹ️

Games that are ending have a weird 0 on the cards. 

# Demo 📺

Fixes this: 
![image](https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/ad325fab-ffb8-499e-b7f7-c324c6c0bb04)


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
