### PR TITLE
feat(emblem,trading): add url builder for emblem

### DIFF
--- a/apps/trading/lib/hooks/use-squid-router-config.ts
+++ b/apps/trading/lib/hooks/use-squid-router-config.ts
@@ -370,10 +370,7 @@ const mapAssetToDestinationTokenConfig = (
   const tokenContractAddress = asset.source.contractAddress;
 
   // FIXME: Could use some better icon getting
-  let assetLogo = `https://icon.vega.xyz/vega/${vegaChainId}/asset/${asset.id}/logo.svg`;
-  if (asset.chainId === String(ARBITRUM_CHAIN_ID)) {
-    assetLogo = 'https://icon.vega.xyz/missing.svg';
-  }
+  const assetLogo = `https://icon.vega.xyz/vega/${vegaChainId}/asset/${asset.id}/logo.svg`;
 
   const route: DestinationTokenConfig['customContractCalls'] = [
     // 0: SWAP

--- a/apps/trading/lib/hooks/use-squid-router-config.ts
+++ b/apps/trading/lib/hooks/use-squid-router-config.ts
@@ -32,6 +32,7 @@ import {
   prepend0x,
 } from '@vegaprotocol/smart-contracts';
 import { AssetStatus } from '@vegaprotocol/types';
+import { getVegaAssetLogoUrl } from '@vegaprotocol/emblem';
 
 /**
  * A flag determining whether the final deposit via SquidRouter should be done
@@ -370,7 +371,7 @@ const mapAssetToDestinationTokenConfig = (
   const tokenContractAddress = asset.source.contractAddress;
 
   // FIXME: Could use some better icon getting
-  const assetLogo = `https://icon.vega.xyz/vega/${vegaChainId}/asset/${asset.id}/logo.svg`;
+  const assetLogo = getVegaAssetLogoUrl(vegaChainId, asset.id);
 
   const route: DestinationTokenConfig['customContractCalls'] = [
     // 0: SWAP

--- a/libs/emblem/src/components/asset-emblem.tsx
+++ b/libs/emblem/src/components/asset-emblem.tsx
@@ -1,7 +1,8 @@
 import { t } from '@vegaprotocol/i18n';
-import { URL_BASE, FILENAME, CHAIN_FILENAME } from '../config';
+import { CHAIN_FILENAME } from '../config';
 import { EmblemBase } from './emblem-base';
 import { getVegaChain } from './lib/get-chain';
+import { getVegaAssetLogoUrl } from './lib/url-builder';
 
 export type EmblemByAssetProps = {
   asset: string;
@@ -18,14 +19,13 @@ export type EmblemByAssetProps = {
  */
 export function EmblemByAsset(p: EmblemByAssetProps) {
   const chain = getVegaChain(p.vegaChain);
-  const baseUrl = `${URL_BASE}/vega/${chain}/asset/${p.asset}/`;
 
   return (
     <div className="relative inline-block">
-      <EmblemBase src={`${baseUrl}${FILENAME}`} {...p} />
+      <EmblemBase src={getVegaAssetLogoUrl(chain, p.asset)} {...p} />
       {p.showSourceChain !== false && (
         <EmblemBase
-          src={`${baseUrl}${CHAIN_FILENAME}`}
+          src={getVegaAssetLogoUrl(chain, p.asset, CHAIN_FILENAME)}
           width={12}
           height={12}
           alt={t('Chain logo')}

--- a/libs/emblem/src/components/contract-emblem.tsx
+++ b/libs/emblem/src/components/contract-emblem.tsx
@@ -1,6 +1,6 @@
-import { URL_BASE, FILENAME } from '../config';
 import { EmblemBase } from './emblem-base';
 import { getVegaChain } from './lib/get-chain';
+import { getChainAssetLogoUrl } from './lib/url-builder';
 
 export type EmblemByContractProps = {
   contract: string;
@@ -16,7 +16,7 @@ export type EmblemByContractProps = {
  */
 export function EmblemByContract(p: EmblemByContractProps) {
   const chain = getVegaChain(p.vegaChain);
-  const url = `${URL_BASE}/chain/${chain}/asset/${p.contract}/${FILENAME}`;
+  const url = getChainAssetLogoUrl(chain, p.contract);
 
   return <EmblemBase src={url} {...p} />;
 }

--- a/libs/emblem/src/components/lib/url-builder.test.ts
+++ b/libs/emblem/src/components/lib/url-builder.test.ts
@@ -1,0 +1,31 @@
+import { getChainAssetLogoUrl, getVegaAssetLogoUrl } from './url-builder';
+import { URL_BASE, FILENAME } from '../../config';
+
+describe('getChainAssetLogoUrl', () => {
+  it('should generate the correct URL for an asset', () => {
+    const chain = '1';
+    const contract = '0x1234567890abcdef';
+    const expectedUrl = `${URL_BASE}/chain/${chain}/asset/${contract}/${FILENAME}`;
+    const result = getChainAssetLogoUrl(chain, contract);
+    expect(result).toBe(expectedUrl);
+  });
+});
+
+describe('getVegaAssetLogoUrl', () => {
+  it('should generate the correct URL for an asset', () => {
+    const chain = 'vega-chain';
+    const asset = 'asset-id';
+    const expectedUrl = `${URL_BASE}/vega/${chain}/asset/${asset}/${FILENAME}`;
+    const result = getVegaAssetLogoUrl(chain, asset);
+    expect(result).toBe(expectedUrl);
+  });
+
+  it('should generate the correct URL for an asset with a custom filename', () => {
+    const chain = 'vega-chain';
+    const asset = 'asset-id';
+    const filename = 'custom-filename.png';
+    const expectedUrl = `${URL_BASE}/vega/${chain}/asset/${asset}/${filename}`;
+    const result = getVegaAssetLogoUrl(chain, asset, filename);
+    expect(result).toBe(expectedUrl);
+  });
+});

--- a/libs/emblem/src/components/lib/url-builder.ts
+++ b/libs/emblem/src/components/lib/url-builder.ts
@@ -1,0 +1,29 @@
+import { URL_BASE, FILENAME } from '../../config';
+
+/**
+ * Generates the full URL for an asset given its contract address
+ *
+ * @param chain string ID of the chain (e.g. 1 for Ethereum)
+ * @param contract string Full contract address
+ * @returns string full path to the asset logo
+ */
+export function getChainAssetLogoUrl(chain: string, contract: string): string {
+  return `${URL_BASE}/chain/${chain}/asset/${contract}/${FILENAME}`;
+}
+
+/**
+ * Generates the full URL for an asset on Vega. An optional third parameter
+ * can be used to
+ *
+ * @param chain Vega Chain ID for the asset
+ * @param asset The asset ID
+ * @param filename Optional parameter that can be used to fetch the origin chain logo instead of the asset logo
+ * @returns string full path to the asset logo
+ */
+export function getVegaAssetLogoUrl(
+  chain: string,
+  asset: string,
+  filename: string = FILENAME
+): string {
+  return `${URL_BASE}/vega/${chain}/asset/${asset}/${filename}`;
+}

--- a/libs/emblem/src/index.ts
+++ b/libs/emblem/src/index.ts
@@ -4,3 +4,7 @@ export type { EmblemProps } from './components/emblem';
 export { EmblemByContract } from './components/contract-emblem';
 export { EmblemByAsset } from './components/asset-emblem';
 export { EmblemByMarket } from './components/market-emblem';
+export {
+  getChainAssetLogoUrl,
+  getVegaAssetLogoUrl,
+} from './components/lib/url-builder';


### PR DESCRIPTION
- **fix(trading): allow arbitrum assets to have icons in squid**
- **feat(emblem,trading): add url builder for emblem and use it in squid config**

# Related issues 🔗

Closes #6509

# Description ℹ️

The experimental Squid cross-chain deposit widget was incorrectly rendering a blank logo for Arbitrum USDT. This was down to a leftover bit of logic that was easy to remove, but also gave us a chance to standardise the logo generation. Now Emblem and squid config use the same function to build image URLs

- Add url-builder to emblem
- Update squid config to use url-builder
- Remove flag that hardcodes arbitrum logos to be blank

# Demo 📺
<img width="493" alt="Screenshot 2024-06-04 at 16 34 19" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/c0202b61-2ef1-4bfd-b9dc-adda7d2096f1">

