### PR TITLE
chore(trading): limit swap assets to only arbitrum ones

### DIFF
--- a/apps/trading/lib/hooks/use-squid-router-config.ts
+++ b/apps/trading/lib/hooks/use-squid-router-config.ts
@@ -67,6 +67,7 @@ const isSquidFriendlyAsset = (
   Boolean(
     asset.source.__typename === 'ERC20' &&
       asset.source.chainId &&
+      Number(asset.source.chainId) === ARBITRUM_CHAIN_ID &&
       asset.source.contractAddress
   );
 


### PR DESCRIPTION
# Related issues 🔗

Closes #6507 

# Description ℹ️

Filters assets provided to the squid router config. Only arbitrum assets are kept, this locks the 'swap to' asset

# Demo 📺

![Screenshot 2024-06-10 at 15 44 29](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/5370709b-9c1f-4adf-b3a1-83f0b45c7e2d)
