### PR TITLE
feat(explorer): improve batch proposal summary view

### DIFF
--- a/apps/explorer/src/app/components/txs/details/proposal/batch-item.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/batch-item.spec.tsx
@@ -29,7 +29,7 @@ describe('BatchItem', () => {
       newSpotMarket: {},
     };
     render(<BatchItem item={item} />);
-    expect(screen.getByText('New spot market')).toBeInTheDocument();
+    expect(screen.getByText('New spot market:')).toBeInTheDocument();
   });
 
   it('Renders "Cancel transfer"', () => {
@@ -68,7 +68,7 @@ describe('BatchItem', () => {
       newMarket: {},
     };
     render(<BatchItem item={item} />);
-    expect(screen.getByText('New market')).toBeInTheDocument();
+    expect(screen.getByText('New market:')).toBeInTheDocument();
   });
 
   it('Renders "New transfer"', () => {

--- a/apps/explorer/src/app/components/txs/details/proposal/batch-item.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/batch-item.tsx
@@ -2,6 +2,7 @@ import { t } from '@vegaprotocol/i18n';
 import { AssetLink, MarketLink, NetworkParameterLink } from '../../../links';
 import type { components } from '../../../../../types/explorer';
 import Hash from '../../../links/hash';
+import { MarketUpdateTypeMapping } from '@vegaprotocol/types';
 
 type Item = components['schemas']['vegaBatchProposalTermsChange'];
 
@@ -32,9 +33,17 @@ export const BatchItem = ({ item }: BatchItemProps) => {
   } else if (item.newFreeform) {
     return <span>{t('New freeform proposal')}</span>;
   } else if (item.newMarket) {
-    return <span>{t('New market')}</span>;
+    return (
+      <span>
+        {t('New market')}: {item.newMarket.changes?.instrument?.name}
+      </span>
+    );
   } else if (item.newSpotMarket) {
-    return <span>{t('New spot market')}</span>;
+    return (
+      <span>
+        {t('New spot market')}: {item.newSpotMarket.changes?.instrument?.name}
+      </span>
+    );
   } else if (item.newTransfer) {
     return <span>{t('New transfer')}</span>;
   } else if (item.updateAsset) {
@@ -57,7 +66,9 @@ export const BatchItem = ({ item }: BatchItemProps) => {
     const marketId = item?.updateMarketState?.changes?.marketId || false;
     return (
       <span>
-        {t('Update market state')}
+        {item.updateMarketState.changes?.updateType
+          ? MarketUpdateTypeMapping[item.updateMarketState.changes?.updateType]
+          : t('Update market state')}
         {marketId && <MarketLink className="ml-1" id={marketId} />}
       </span>
     );
@@ -82,7 +93,11 @@ export const BatchItem = ({ item }: BatchItemProps) => {
   } else if (item.updateVolumeDiscountProgram) {
     return <span>{t('Update volume discount program')}</span>;
   } else if (item.newAsset) {
-    return <span>{t('New asset')}</span>;
+    return (
+      <span>
+        {t('New asset')}: {item.newAsset.changes?.name}
+      </span>
+    );
   }
 
   return <span>{t('Unknown proposal type')}</span>;

--- a/apps/explorer/src/app/components/txs/details/proposal/proposal-date.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/proposal-date.spec.tsx
@@ -1,0 +1,92 @@
+import { format, getDate } from './proposal-date';
+import type { Proposal } from './proposal-date';
+
+describe('format', () => {
+  it('returns default value if date is undefined', () => {
+    const def = 'Default';
+    const result = format(undefined, def);
+    expect(result).toBe(def);
+  });
+
+  it('returns formatted date if date is valid', () => {
+    const date = '1631232000';
+    const def = 'Default';
+    const result = format(date, def);
+    expect(result).toContain('2021');
+    expect(result).toContain('10');
+  });
+
+  it('returns default value if date is invalid', () => {
+    const date = 'invalid';
+    const def = 'Default';
+    const result = format(date, def);
+    expect(result).toBe(def);
+  });
+});
+
+describe('getDate', () => {
+  const terms = {
+    closingTimestamp: '1631232000',
+    enactmentTimestamp: '1631232000',
+    validationTimestamp: '1631232000',
+  };
+
+  it('returns default value if proposal state is undefined', () => {
+    const proposal = undefined;
+    const result = getDate(proposal, terms);
+    expect(result).toBe('Unknown');
+  });
+
+  it('returns formatted date for STATE_DECLINED', () => {
+    const proposal = { state: 'STATE_DECLINED' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toContain('Rejected on:');
+    expect(result).toContain('2021');
+  });
+
+  it('returns formatted date for STATE_ENACTED', () => {
+    const proposal = { state: 'STATE_ENACTED' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toContain('Vote passed on:');
+    expect(result).toContain('2021');
+  });
+
+  it('returns formatted date for STATE_FAILED', () => {
+    const proposal = { state: 'STATE_FAILED' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toContain('Failed on:');
+    expect(result).toContain('2021');
+  });
+
+  it('returns formatted date for STATE_OPEN', () => {
+    const proposal = { state: 'STATE_OPEN' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toContain('Open until:');
+    expect(result).toContain('2021');
+  });
+
+  it('returns formatted date for STATE_PASSED', () => {
+    const proposal = { state: 'STATE_PASSED' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toContain('Passed on:');
+    expect(result).toContain('2021');
+  });
+
+  it('returns default value for STATE_REJECTED', () => {
+    const proposal = { state: 'STATE_REJECTED' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toBe('Rejected on submission');
+  });
+
+  it('returns default value for STATE_WAITING_FOR_NODE_VOTE', () => {
+    const proposal = { state: 'STATE_WAITING_FOR_NODE_VOTE' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toBe('Opening...');
+  });
+
+  it('returns default value for unknown state', () => {
+    const proposal = { state: 'UNKNOWN_STATE' };
+    const result = getDate(proposal as Proposal, terms);
+    expect(result).toBe('Unknown');
+  });
+});

--- a/apps/explorer/src/app/components/txs/details/proposal/proposal-date.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/proposal-date.tsx
@@ -3,18 +3,26 @@ import { Lozenge } from '@vegaprotocol/ui-toolkit';
 import type { components } from '../../../../../types/explorer';
 import type { ExplorerProposalStatusQuery } from './__generated__/Proposal';
 import { useExplorerProposalStatusQuery } from './__generated__/Proposal';
+import fromUnixTime from 'date-fns/fromUnixTime';
 
 type Terms = components['schemas']['vegaProposalTerms'];
 
 export function format(date: string | undefined, def: string) {
-  if (!date) {
+  let parsedDate;
+
+  try {
+    parsedDate = fromUnixTime(Number(date));
+    if (parsedDate.toString() === 'Invalid Date') {
+      throw new Error('Invalid Date');
+    }
+  } catch (e) {
     return def;
   }
 
-  return new Date().toLocaleDateString() || def;
+  return parsedDate.toLocaleDateString() || def;
 }
 
-type Proposal = Extract<
+export type Proposal = Extract<
   ExplorerProposalStatusQuery['proposal'],
   { __typename?: 'Proposal' }
 >;

--- a/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
@@ -65,7 +65,7 @@ export const ProposalSummary = ({
     <div className="w-auto max-w-lg border-2 border-solid border-vega-light-100 dark:border-vega-dark-200 p-5">
       {id && <ProposalStatusIcon id={id} />}
       {rationale?.title && (
-        <h1 className="text-xl pb-1 break-all">{rationale.title}</h1>
+        <h1 className="text-xl pb-1 break-word">{rationale.title}</h1>
       )}
       {rationale?.description && (
         <div className="pt-2 text-sm leading-tight">

--- a/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
@@ -84,7 +84,7 @@ export const ProposalSummary = ({
           <h2 className="text-lg pb-1">{t('Changes')}</h2>
           <ol>
             {batch.map((change, index) => (
-              <li className="ml-4 list-decimal" key={`batch-${index}`}>
+              <li className="ml-4 list-decimal my-2" key={`batch-${index}`}>
                 <BatchItem item={change} />
               </li>
             ))}

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -138,6 +138,8 @@ export function getLabelForProposal(
     return t('Proposal: Transfer');
   } else if (proposal.terms?.cancelTransfer) {
     return t('Proposal: Transfer cancel');
+  } else if (proposal.terms?.newSpotMarket) {
+    return t('Proposal: New spot market');
   } else {
     return t('Proposal');
   }


### PR DESCRIPTION
# Description ℹ️

Minor improvements to the batch proposal view:
- show title for new market view
- reorganise state updates to be 'verb' 'market name' (e.g. suspend USDT/ETH)
- improve spacing
- add type label for new spot markets (closes #6518)
- fix date parsing
- fix word breaks on batch proposal titles

# Demo 📺

# Added new market details, and action on market state update
<img width="489" alt="Screenshot 2024-06-12 at 17 19 56" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/769f3386-e312-412b-8af7-3c988c94811a">

## Fixed new sport market label
<img width="605" alt="Screenshot 2024-06-13 at 16 17 03" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/0a96974b-407b-437c-ad09-239f452064c7">

## Fixed date shown in lozenge
<img width="683" alt="Screenshot 2024-06-14 at 12 16 41" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/bdf6487a-773d-401f-b7ba-403333ae73f0">

## Fix line break
<img width="531" alt="Screenshot 2024-06-14 at 12 18 11" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/33529ee8-b325-4996-b09b-881631e4a25e">
