### PR TITLE
feat(trading): add error type for not enough collateral for spot orders

### DIFF
--- a/libs/deal-ticket/src/components/deal-ticket-validation/margin-warning.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-validation/margin-warning.tsx
@@ -17,16 +17,9 @@ interface Props {
     decimals: number;
   };
   onDeposit: (assetId: string) => void;
-  isSpotMarket?: boolean;
 }
 
-export const MarginWarning = ({
-  margin,
-  balance,
-  asset,
-  onDeposit,
-  isSpotMarket,
-}: Props) => {
+export const MarginWarning = ({ margin, balance, asset, onDeposit }: Props) => {
   const t = useT();
   const description = (
     <div className="flex flex-col items-start gap-2 p-2">
@@ -63,11 +56,7 @@ export const MarginWarning = ({
         <span className="text-yellow-500 mr-2">
           <VegaIcon name={VegaIconNames.WARNING} />
         </span>
-        {isSpotMarket
-          ? t('You may not have enough balance to make this trade.')
-          : t(
-              'You may not have enough margin available to open this position.'
-            )}
+        {t('You may not have enough margin available to open this position.')}
       </div>
     </Tooltip>
   );

--- a/libs/deal-ticket/src/components/deal-ticket-validation/not-enough-error.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-validation/not-enough-error.tsx
@@ -1,0 +1,34 @@
+import { Intent, Notification } from '@vegaprotocol/ui-toolkit';
+import { useT } from '../../use-t';
+import { getAssetSymbol, type AssetFieldsFragment } from '@vegaprotocol/assets';
+
+interface NotEnoughErrorProps {
+  asset: AssetFieldsFragment;
+  onDeposit: (assetId: string) => void;
+}
+
+export const NotEnoughError = ({ asset, onDeposit }: NotEnoughErrorProps) => {
+  const t = useT();
+
+  return (
+    <Notification
+      intent={Intent.Warning}
+      testId="deal-ticket-error-message-not-enough-balance"
+      message={
+        <>
+          {t('You may not have enough {{symbol}} to make this trade.', {
+            symbol: getAssetSymbol(asset),
+          })}
+        </>
+      }
+      buttonProps={{
+        text: t(`Make a deposit`),
+        action: () => {
+          onDeposit(asset.id);
+        },
+        dataTestId: 'deal-ticket-deposit-dialog-button',
+        size: 'small',
+      }}
+    />
+  );
+};

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
@@ -645,7 +645,6 @@ const NotEnoughBalanceWarning = ({
   if (size && size !== '0' && BigInt(balance) < BigInt(size)) {
     return (
       <MarginWarning
-        isSpotMarket={true}
         balance={balance}
         margin={size}
         asset={asset}

--- a/libs/deal-ticket/src/constants.ts
+++ b/libs/deal-ticket/src/constants.ts
@@ -37,6 +37,7 @@ export enum MarketModeValidationType {
 export enum SummaryValidationType {
   NoPubKey = 'NoPubKey',
   NoCollateral = 'NoCollateral',
+  NotEnoughCollateral = 'NotEnoughCollateral',
   TradingMode = 'MarketTradingMode',
   MarketState = 'MarketState',
 }

--- a/libs/i18n/src/locales/en/deal-ticket.json
+++ b/libs/i18n/src/locales/en/deal-ticket.json
@@ -168,7 +168,7 @@
   "You have only {{amount}}.": "You have only {{amount}}.",
   "You have an existing position and open orders on this market": "You have an existing position and open orders on this market",
   "You may not have enough margin available to open this position.": "You may not have enough margin available to open this position.",
-  "You may not have enough balance to make this trade.": "You may not have enough balance to make this trade.",
+  "You may not have enough {{symbol}} to make this trade.": "You may not have enough {{symbol}} to make this trade.",
   "You need {{symbol}} in your wallet to trade in this market.": "You need {{symbol}} in your wallet to trade in this market.",
   "You need a Vega wallet to start trading on this market": "You need a Vega wallet to start trading on this market",
   "You need to provide a expiry time/date": "You need to provide a expiry time/date",


### PR DESCRIPTION
# Related issues 🔗

Closes #6554

# Description ℹ️

Removes use of margin account balances when calculating if there is enough collateral for a spot trade