### PR TITLE
fix(ui-toolkit): ensure toast can be interacted with even when a dialog is open

### DIFF
--- a/libs/ui-toolkit/src/components/toast/toasts-container.tsx
+++ b/libs/ui-toolkit/src/components/toast/toasts-container.tsx
@@ -52,8 +52,7 @@ export const ToastsContainer = ({
     <Portal
       ref={ref as Ref<HTMLDivElement>}
       className={classNames(
-        'group',
-        'absolute z-30',
+        'group absolute z-30 pointer-events-auto',
         { 'bottom-0 right-0': position === ToastPosition.BottomRight },
         { 'bottom-0 left-0': position === ToastPosition.BottomLeft },
         { 'left-0 top-0': position === ToastPosition.TopLeft },


### PR DESCRIPTION
# Related issues 🔗

Closes #6432 

# Description ℹ️
 
Enables pointer events for toast container