### PR TITLE
fix(deposits): fix render loop after refetching balance

### DIFF
--- a/libs/deposits/src/lib/use-deposit-balances.ts
+++ b/libs/deposits/src/lib/use-deposit-balances.ts
@@ -31,6 +31,12 @@ export const useBalances = (asset?: AssetData) => {
     DepositBalances | 'loading' | undefined
   >(undefined);
 
+  const refetchBalances = useCallback(async () => {
+    setBalances(undefined);
+    const balances = await getBalances(asset);
+    setBalances(balances);
+  }, [asset, getBalances]);
+
   useEffect(() => {
     let ignore = false;
 
@@ -53,11 +59,7 @@ export const useBalances = (asset?: AssetData) => {
   return {
     balances,
     resetBalances: () => setBalances(undefined),
-    refetchBalances: async () => {
-      setBalances(undefined);
-      const balances = await getBalances(asset);
-      setBalances(balances);
-    },
+    refetchBalances,
   };
 };
 


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Wraps the refetch balances function in useCallback so as not to trigger a render loop