### PR TITLE
chore(trading): rename external block explorer link

### DIFF
--- a/apps/explorer/src/app/routes/validators/validators-page.tsx
+++ b/apps/explorer/src/app/routes/validators/validators-page.tsx
@@ -21,7 +21,7 @@ import { JsonViewerDialog } from '../../components/dialogs/json-viewer-dialog';
 import { PageTitle } from '../../components/page-helpers/page-title';
 import BigNumber from 'bignumber.js';
 import {
-  EtherscanLink,
+  BlockExplorerLink,
   DApp,
   TOKEN_VALIDATOR,
   useLinks,
@@ -238,7 +238,7 @@ export const ValidatorsPage = () => {
                         <KeyValueTableRow>
                           <div>{t('Ethereum address')}</div>
                           <div className="break-all text-xs font-mono">
-                            <EtherscanLink address={v.ethereumAddress} />{' '}
+                            <BlockExplorerLink address={v.ethereumAddress} />{' '}
                             <CopyWithTooltip text={v.ethereumAddress}>
                               <button title={t('Copy address to clipboard')}>
                                 <Icon size={3} name="duplicate" />

--- a/apps/governance/src/routes/tranches/tranche.tsx
+++ b/apps/governance/src/routes/tranches/tranche.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router';
 import { Navigate } from 'react-router-dom';
 import { formatNumber } from '@vegaprotocol/utils';
 
-import { EtherscanLink } from '@vegaprotocol/environment';
+import { BlockExplorerLink } from '@vegaprotocol/environment';
 import { TrancheItem } from '../redemption/tranche-item';
 import Routes from '../routes';
 import { TrancheLabel } from './tranche-label';
@@ -59,7 +59,7 @@ export const Tranche = () => {
             </KeyValueTableRow>
             {tranche.users.map((user) => (
               <KeyValueTableRow key={user}>
-                <EtherscanLink address={user} data-testid="link" />
+                <BlockExplorerLink address={user} data-testid="link" />
                 <RouterLink
                   className="underline"
                   title={t('View vesting information')}

--- a/libs/accounts/src/lib/accounts-actions-dropdown.tsx
+++ b/libs/accounts/src/lib/accounts-actions-dropdown.tsx
@@ -22,7 +22,7 @@ export const AccountsActionsDropdown = ({
   assetContractAddress?: string;
   onClickBreakdown: () => void;
 }) => {
-  const etherscanLink = useExternalExplorerLink();
+  const blockExplorerLink = useExternalExplorerLink();
   const openAssetDialog = useAssetDetailsDialogStore((store) => store.open);
   const t = useT();
   return (
@@ -47,7 +47,7 @@ export const AccountsActionsDropdown = ({
       {assetContractAddress && (
         <TradingDropdownItem>
           <Link
-            href={etherscanLink(
+            href={blockExplorerLink(
               ETHERSCAN_ADDRESS.replace(':hash', assetContractAddress)
             )}
             target="_blank"

--- a/libs/accounts/src/lib/accounts-actions-dropdown.tsx
+++ b/libs/accounts/src/lib/accounts-actions-dropdown.tsx
@@ -1,4 +1,7 @@
-import { ETHERSCAN_ADDRESS, useEtherscanLink } from '@vegaprotocol/environment';
+import {
+  ETHERSCAN_ADDRESS,
+  useExternalExplorerLink,
+} from '@vegaprotocol/environment';
 import { useT } from './use-t';
 import {
   ActionsDropdown,
@@ -19,7 +22,7 @@ export const AccountsActionsDropdown = ({
   assetContractAddress?: string;
   onClickBreakdown: () => void;
 }) => {
-  const etherscanLink = useEtherscanLink();
+  const etherscanLink = useExternalExplorerLink();
   const openAssetDialog = useAssetDetailsDialogStore((store) => store.open);
   const t = useT();
   return (

--- a/libs/assets/src/lib/asset-details-table.tsx
+++ b/libs/assets/src/lib/asset-details-table.tsx
@@ -1,5 +1,5 @@
 import {
-  EtherscanLink,
+  BlockExplorerLink,
   getExternalChainLabel,
 } from '@vegaprotocol/environment';
 import { addDecimalsFormatNumber } from '@vegaprotocol/utils';
@@ -163,12 +163,12 @@ export const useRows = () => {
 
           return (
             <>
-              <EtherscanLink
+              <BlockExplorerLink
                 address={asset.source.contractAddress}
                 sourceChainId={Number(asset.source.chainId)}
               >
                 {truncateMiddle(asset.source.contractAddress)}
-              </EtherscanLink>{' '}
+              </BlockExplorerLink>{' '}
               <CopyWithTooltip text={asset.source.contractAddress}>
                 <button title={t('Copy address to clipboard')}>
                   <VegaIcon size={14} name={VegaIconNames.COPY} />

--- a/libs/deposits/src/lib/approve-notification.tsx
+++ b/libs/deposits/src/lib/approve-notification.tsx
@@ -1,7 +1,8 @@
 import { USDT_ID, type Asset } from '@vegaprotocol/assets';
 import {
-  EtherscanLink,
+  BlockExplorerLink,
   Networks,
+  getExternalChainLabel,
   useEnvironment,
 } from '@vegaprotocol/environment';
 import { Intent, Notification } from '@vegaprotocol/ui-toolkit';
@@ -167,9 +168,13 @@ const ApprovalTxFeedback = ({
       : undefined;
 
   const txLink = tx.txHash && (
-    <EtherscanLink sourceChainId={chainId} tx={tx.txHash}>
-      {t('View on Etherscan')}
-    </EtherscanLink>
+    <BlockExplorerLink sourceChainId={chainId} tx={tx.txHash}>
+      {t('View on {{chainLabel}}', {
+        chainLabel: chainId
+          ? getExternalChainLabel(chainId.toString())
+          : 'block explorer',
+      })}
+    </BlockExplorerLink>
   );
 
   if (tx.status === EthTxStatus.Error) {

--- a/libs/deposits/src/lib/deposits-table.tsx
+++ b/libs/deposits/src/lib/deposits-table.tsx
@@ -13,7 +13,7 @@ import {
   type TypedDataAgGrid,
 } from '@vegaprotocol/datagrid';
 import { type DepositFieldsFragment } from './__generated__/Deposit';
-import { EtherscanLink } from '@vegaprotocol/environment';
+import { BlockExplorerLink } from '@vegaprotocol/environment';
 import { DepositStatusMapping } from '@vegaprotocol/types';
 import { getAssetSymbol, type AssetFieldsFragment } from '@vegaprotocol/assets';
 
@@ -78,13 +78,13 @@ export const DepositsTable = (
               : 1;
 
           return (
-            <EtherscanLink
+            <BlockExplorerLink
               tx={value}
               sourceChainId={chainId}
-              data-testid="etherscan-link"
+              data-testid="block-explorer-link"
             >
               {truncateByChars(value)}
-            </EtherscanLink>
+            </BlockExplorerLink>
           );
         },
       },

--- a/libs/deposits/src/lib/faucet-notification.tsx
+++ b/libs/deposits/src/lib/faucet-notification.tsx
@@ -1,5 +1,5 @@
 import type { Asset } from '@vegaprotocol/assets';
-import { EtherscanLink } from '@vegaprotocol/environment';
+import { BlockExplorerLink } from '@vegaprotocol/environment';
 import { Intent, Notification } from '@vegaprotocol/ui-toolkit';
 import { EthTxStatus, useEthTransactionStore } from '@vegaprotocol/web3';
 import { useGetFaucetError } from './get-faucet-error';
@@ -82,9 +82,9 @@ export const FaucetNotification = ({
               </p>
               {tx.txHash && (
                 <p>
-                  <EtherscanLink tx={tx.txHash}>
-                    {t('View on Etherscan')}
-                  </EtherscanLink>
+                  <BlockExplorerLink tx={tx.txHash}>
+                    {t('View on block explorer')}
+                  </BlockExplorerLink>
                 </p>
               )}
             </>
@@ -112,9 +112,9 @@ export const FaucetNotification = ({
               </p>
               {tx.txHash && (
                 <p>
-                  <EtherscanLink tx={tx.txHash}>
-                    {t('View on Etherscan')}
-                  </EtherscanLink>
+                  <BlockExplorerLink tx={tx.txHash}>
+                    {t('View on block explorer')}
+                  </BlockExplorerLink>
                 </p>
               )}
             </>

--- a/libs/environment/src/components/block-explorer-link.tsx
+++ b/libs/environment/src/components/block-explorer-link.tsx
@@ -1,10 +1,15 @@
 import { ExternalLink } from '@vegaprotocol/ui-toolkit';
 import type { ComponentProps } from 'react';
-import { ETHERSCAN_ADDRESS, ETHERSCAN_TX, useEtherscanLink } from '../hooks';
+import {
+  ETHERSCAN_ADDRESS,
+  ETHERSCAN_TX,
+  useExternalExplorerLink,
+} from '../hooks';
 import { useT } from '../use-t';
 import { getExternalChainLabel } from '../external-chain';
 
-export const EtherscanLink = ({
+/** BlockExplorerLink (external) directs to any external block explorer links (e.g. etherscan.io or arbiscan.io)  */
+export const BlockExplorerLink = ({
   address,
   tx,
   sourceChainId,
@@ -16,7 +21,7 @@ export const EtherscanLink = ({
   sourceChainId?: number;
 } & ComponentProps<typeof ExternalLink>) => {
   const t = useT();
-  const etherscanLink = useEtherscanLink(sourceChainId);
+  const externalLink = useExternalExplorerLink(sourceChainId);
   let href = '';
 
   if ((!address && !tx) || (address && tx)) {
@@ -24,10 +29,10 @@ export const EtherscanLink = ({
   }
 
   if (address) {
-    href = etherscanLink(ETHERSCAN_ADDRESS.replace(':hash', address));
+    href = externalLink(ETHERSCAN_ADDRESS.replace(':hash', address));
   }
   if (tx) {
-    href = etherscanLink(ETHERSCAN_TX.replace(':hash', tx));
+    href = externalLink(ETHERSCAN_TX.replace(':hash', tx));
   }
 
   return (

--- a/libs/environment/src/components/index.ts
+++ b/libs/environment/src/components/index.ts
@@ -4,4 +4,4 @@ export * from './network-switcher';
 export * from './node-guard';
 export * from './node-switcher';
 export * from './node-failure';
-export * from './etherscan-link';
+export * from './block-explorer-link';

--- a/libs/environment/src/hooks/use-links.ts
+++ b/libs/environment/src/hooks/use-links.ts
@@ -121,7 +121,7 @@ export const useLinks = (dapp: DApp, network?: Net) => {
   return link;
 };
 
-export const useEtherscanLink = (sourceChainId?: number) => {
+export const useExternalExplorerLink = (sourceChainId?: number) => {
   const { ETHERSCAN_URL } = useEnvironment();
 
   const otherScanUrl = sourceChainId

--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -58,7 +58,7 @@ import {
 } from '@vegaprotocol/types';
 import {
   DApp,
-  EtherscanLink,
+  BlockExplorerLink,
   useFeatureFlags,
   TOKEN_PROPOSAL,
   useEnvironment,
@@ -1167,7 +1167,7 @@ export const EthOraclePanel = ({ sourceType }: { sourceType: EthCallSpec }) => {
           </KeyValueTable>
 
           <div className="my-2">
-            <EtherscanLink
+            <BlockExplorerLink
               address={sourceType.address}
               sourceChainId={sourceType.sourceChainId}
             >
@@ -1176,7 +1176,7 @@ export const EthOraclePanel = ({ sourceType }: { sourceType: EthCallSpec }) => {
                   (sourceType.sourceChainId || 1).toString()
                 ),
               })}
-            </EtherscanLink>
+            </BlockExplorerLink>
           </div>
         </>
       )}

--- a/libs/web3/src/lib/ethereum-transaction-dialog/dialog-rows.tsx
+++ b/libs/web3/src/lib/ethereum-transaction-dialog/dialog-rows.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@vegaprotocol/ui-toolkit';
-import { EtherscanLink, useEnvironment } from '@vegaprotocol/environment';
+import { BlockExplorerLink, useEnvironment } from '@vegaprotocol/environment';
 import { EthTxStatus } from '../use-ethereum-transaction';
 import { useT } from '../use-t';
 
@@ -66,12 +66,12 @@ export const TxRow = ({
       >
         <span>{t('Ethereum transaction complete')}</span>
         {txHash && (
-          <EtherscanLink
+          <BlockExplorerLink
             tx={txHash}
             className="text-vega-pink dark:text-vega-yellow"
           >
             {t('View transaction on Etherscan')}
-          </EtherscanLink>
+          </BlockExplorerLink>
         )}
       </p>
     );

--- a/libs/web3/src/lib/use-ethereum-transaction-toasts.tsx
+++ b/libs/web3/src/lib/use-ethereum-transaction-toasts.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { useAssetsDataProvider } from '@vegaprotocol/assets';
 import {
-  EtherscanLink,
+  BlockExplorerLink,
   getExternalChainLabel,
 } from '@vegaprotocol/environment';
 import { formatNumber, toBigNum } from '@vegaprotocol/utils';
@@ -124,13 +124,13 @@ const EthTxPendingToastContent = ({ tx }: EthTxToastContentProps) => {
       <ToastHeading>{t('Awaiting confirmation')}</ToastHeading>
       <p>{t('Please wait for your transaction to be confirmed.')}</p>
       {tx.txHash && (
-        <EtherscanLink sourceChainId={sourceChainId} tx={tx.txHash}>
+        <BlockExplorerLink sourceChainId={sourceChainId} tx={tx.txHash}>
           {t('View on {{chainLabel}}', {
             chainLabel: sourceChainId
               ? getExternalChainLabel(String(sourceChainId))
               : 'Ethereum',
           })}
-        </EtherscanLink>
+        </BlockExplorerLink>
       )}
       <EthTransactionDetails tx={tx} />
     </>
@@ -171,13 +171,13 @@ const EthTxConfirmedToastContent = ({ tx }: EthTxToastContentProps) => {
       <ToastHeading>{t('Transaction confirmed')}</ToastHeading>
       <p>{t('Your transaction has been confirmed.')}</p>
       {tx.txHash && (
-        <EtherscanLink sourceChainId={sourceChainId} tx={tx.txHash}>
+        <BlockExplorerLink sourceChainId={sourceChainId} tx={tx.txHash}>
           {t('View on {{chainLabel}}', {
             chainLabel: sourceChainId
               ? getExternalChainLabel(String(sourceChainId))
               : 'Ethereum',
           })}
-        </EtherscanLink>
+        </BlockExplorerLink>
       )}
       <EthTransactionDetails tx={tx} />
     </>
@@ -206,13 +206,13 @@ const EthTxCompletedToastContent = ({ tx }: EthTxToastContentProps) => {
         {isDeposit && t('Waiting for deposit confirmation.')}
       </p>
       {tx.txHash && (
-        <EtherscanLink sourceChainId={sourceChainId} tx={tx.txHash}>
+        <BlockExplorerLink sourceChainId={sourceChainId} tx={tx.txHash}>
           {t('View on {{chainLabel}}', {
             chainLabel: sourceChainId
               ? getExternalChainLabel(String(sourceChainId))
               : 'Ethereum',
           })}
-        </EtherscanLink>
+        </BlockExplorerLink>
       )}
       <EthTransactionDetails tx={tx} />
     </>

--- a/libs/withdraws/src/lib/withdrawals-table.tsx
+++ b/libs/withdraws/src/lib/withdrawals-table.tsx
@@ -21,7 +21,7 @@ import {
   type VegaValueFormatterParams,
 } from '@vegaprotocol/datagrid';
 import { AgGrid } from '@vegaprotocol/datagrid';
-import { EtherscanLink } from '@vegaprotocol/environment';
+import { BlockExplorerLink } from '@vegaprotocol/environment';
 import { type WithdrawalFieldsFragment } from './__generated__/Withdrawal';
 import {
   useEthWithdrawApprovalsStore,
@@ -233,13 +233,13 @@ export const EtherscanLinkCell = ({
       : undefined;
 
   return (
-    <EtherscanLink
+    <BlockExplorerLink
       sourceChainId={assetChainId}
       tx={value}
-      data-testid="etherscan-link"
+      data-testid="block-explorer-link"
     >
       {truncateByChars(value)}
-    </EtherscanLink>
+    </BlockExplorerLink>
   );
 };
 
@@ -331,12 +331,12 @@ const RecipientCell = ({
       : undefined;
 
   return (
-    <EtherscanLink
+    <BlockExplorerLink
       sourceChainId={assetChainId}
       address={value}
-      data-testid="etherscan-link"
+      data-testid="block-explorer-link"
     >
       {valueFormatted}
-    </EtherscanLink>
+    </BlockExplorerLink>
   );
 };

--- a/libs/withdraws/src/lib/withdrawals-table.tsx
+++ b/libs/withdraws/src/lib/withdrawals-table.tsx
@@ -157,7 +157,7 @@ export const WithdrawalsTable = ({
         cellRendererSelector: ({
           data,
         }: VegaICellRendererParams<WithdrawalFieldsFragment>) => ({
-          component: data?.txHash ? 'EtherscanLinkCell' : 'CompleteCell',
+          component: data?.txHash ? 'BlockExplorerLinkCell' : 'CompleteCell',
         }),
       },
     ],
@@ -171,7 +171,7 @@ export const WithdrawalsTable = ({
       components={{
         RecipientCell,
         StatusCell,
-        EtherscanLinkCell,
+        BlockExplorerLinkCell,
         CompleteCell,
       }}
       suppressCellFocus
@@ -221,7 +221,7 @@ export const CompleteCell = ({ data, complete }: CompleteCellProps) => {
   );
 };
 
-export const EtherscanLinkCell = ({
+export const BlockExplorerLinkCell = ({
   value,
   data,
 }: VegaValueFormatterParams<WithdrawalFieldsFragment, 'txHash'>) => {


### PR DESCRIPTION
# Related issues 🔗

Closes #6553 

# Description ℹ️

- [x] rename EtherscanLink to BlockExplorerLink
- [x] fix Arbiscan links on approval 

# Demo 📺

<img width="768" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/493b4325-6939-4894-92b5-6589282f7a30">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
