### PR TITLE
feat(trading):  add deposit and connect prompt to the spot swap UI

### DIFF
--- a/apps/trading/client-pages/portfolio/portfolio.tsx
+++ b/apps/trading/client-pages/portfolio/portfolio.tsx
@@ -40,13 +40,15 @@ import { WithdrawalsMenu } from '../../components/withdrawals-menu';
 import { useT } from '../../lib/use-t';
 import { ErrorBoundary } from '../../components/error-boundary';
 import { usePageTitle } from '../../lib/hooks/use-page-title';
-
-import { DepositContainer } from '@vegaprotocol/deposits';
-import { TransferContainer } from '@vegaprotocol/accounts';
+import { Links } from '../../lib/links';
 import { WithdrawContainer } from '../../components/withdraw-container';
 import { SwapContainer } from '../../components/swap/swap-container';
 import { SquidContainer } from '../../components/squid-container';
+
+import { DepositContainer } from '@vegaprotocol/deposits';
+import { TransferContainer } from '@vegaprotocol/accounts';
 import { useFeatureFlags } from '@vegaprotocol/environment';
+import { useNavigate } from 'react-router-dom';
 
 const WithdrawalsIndicator = () => {
   const { ready } = useIncompleteWithdrawals();
@@ -140,6 +142,8 @@ const PortfolioSmall = () => {
 const PortfolioActionTabs = () => {
   const t = useT();
   const flags = useFeatureFlags((state) => state.flags);
+  const navigate = useNavigate();
+  const onDeposit = () => navigate(Links.DEPOSIT());
   return (
     <Tabs storageKey="portfolio-sidebar">
       <Tab id="deposit" name={t('Deposit (Basic)')}>
@@ -189,7 +193,7 @@ const PortfolioActionTabs = () => {
         <Tab id="swap" name={t('Swap')}>
           <ErrorBoundary feature="assets-swap">
             <div className="p-4">
-              <SwapContainer />
+              <SwapContainer onDeposit={onDeposit} />
             </div>
           </ErrorBoundary>
         </Tab>

--- a/apps/trading/client-pages/swap/swap.tsx
+++ b/apps/trading/client-pages/swap/swap.tsx
@@ -1,8 +1,11 @@
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { SwapContainer } from '../../components/swap';
+import { Links } from '../../lib/links';
 
 export const Swap = () => {
   const [searchParams] = useSearchParams();
   const assetId = searchParams.get('assetId') || undefined;
-  return <SwapContainer assetId={assetId} />;
+  const navigate = useNavigate();
+  const onDeposit = () => navigate(Links.DEPOSIT());
+  return <SwapContainer assetId={assetId} onDeposit={onDeposit} />;
 };

--- a/apps/trading/components/swap/swap-container.tsx
+++ b/apps/trading/components/swap/swap-container.tsx
@@ -14,7 +14,13 @@ import { useDataProvider } from '@vegaprotocol/data-provider';
 import { SwapForm } from './swap-form';
 import { Loader, Splash } from '@vegaprotocol/ui-toolkit';
 
-export const SwapContainer = ({ assetId }: { assetId?: string }) => {
+export const SwapContainer = ({
+  assetId,
+  onDeposit,
+}: {
+  assetId?: string;
+  onDeposit: (assetId?: string) => void;
+}) => {
   const { pubKey } = useVegaWallet();
   const { data: markets, loading } = useMarketsMapProvider();
   const { data: accounts } = useAggregatedAccounts(pubKey);
@@ -56,6 +62,7 @@ export const SwapContainer = ({ assetId }: { assetId?: string }) => {
       // TODO: Update market queries and assets list query to use AssetFieldsFragment
       assets={spotAssets as AssetFieldsFragment[]}
       setCurrentMarketId={(marketId) => setMarketId(marketId)}
+      onDeposit={onDeposit}
     />
   );
 };

--- a/apps/trading/components/swap/swap-form.tsx
+++ b/apps/trading/components/swap/swap-form.tsx
@@ -296,7 +296,7 @@ export const SwapForm = ({
         {t('Swap now')}
       </TradingButton>
       <GetStarted lead={t('Connect wallet')} />
-      {pubKey && !isReadOnly && topAsset && (
+      {pubKey && !isReadOnly && topAsset && !topAssetBalance && (
         <Notification
           intent={Intent.Warning}
           testId="balance-warning-swap-top-asset"

--- a/apps/trading/components/swap/swap-form.tsx
+++ b/apps/trading/components/swap/swap-form.tsx
@@ -26,7 +26,7 @@ import { AssetInput, SwapButton, PriceImpactInput } from './swap-form-elements';
 import BigNumber from 'bignumber.js';
 import { Links } from '../../lib/links';
 import type { Account } from '@vegaprotocol/accounts';
-import type { AssetFieldsFragment } from '@vegaprotocol/assets';
+import { getAssetSymbol, type AssetFieldsFragment } from '@vegaprotocol/assets';
 import {
   getBaseAsset,
   getQuoteAsset,
@@ -34,7 +34,7 @@ import {
   type MarketFieldsFragment,
 } from '@vegaprotocol/markets';
 import { useVegaTransactionStore } from '@vegaprotocol/web3';
-import { getNotionalSize } from '@vegaprotocol/deal-ticket';
+import { NoWalletWarning, getNotionalSize } from '@vegaprotocol/deal-ticket';
 import { usePrevious } from '@vegaprotocol/react-helpers';
 import { SpotData } from './spot-data';
 
@@ -68,6 +68,7 @@ export const SwapForm = ({
   accounts,
   assets,
   setCurrentMarketId,
+  onDeposit,
 }: {
   initialAssetId?: string;
   markets: MarketFieldsFragment[];
@@ -75,6 +76,7 @@ export const SwapForm = ({
   assets: AssetFieldsFragment[];
   accounts?: Account[] | null;
   setCurrentMarketId: (marketId: string) => void;
+  onDeposit: (assetId?: string) => void;
 }) => {
   const t = useT();
 
@@ -316,6 +318,32 @@ export const SwapForm = ({
           topAsset={topAsset}
           bottomAsset={bottomAsset}
         />
+        {(isReadOnly || !pubKey) && <NoWalletWarning isReadOnly={isReadOnly} />}
+        {topAsset && bottomAsset && (
+          <Notification
+            intent={Intent.Warning}
+            testId="deal-ticket-error-message-zero-balance"
+            message={
+              <>
+                {t(
+                  'You need {{symbol1}} or {{symbol2}} in your wallet to trade in this market.',
+                  {
+                    symbol1: getAssetSymbol(topAsset),
+                    symbol2: getAssetSymbol(bottomAsset),
+                  }
+                )}
+              </>
+            }
+            buttonProps={{
+              text: t(`Make a deposit`),
+              action: () => {
+                onDeposit(topAsset.id);
+              },
+              dataTestId: 'deal-ticket-deposit-dialog-button',
+              size: 'small',
+            }}
+          />
+        )}
       </div>
     </form>
   );

--- a/apps/trading/components/swap/swap-form.tsx
+++ b/apps/trading/components/swap/swap-form.tsx
@@ -299,7 +299,7 @@ export const SwapForm = ({
       {pubKey && !isReadOnly && topAsset && (
         <Notification
           intent={Intent.Warning}
-          testId="deal-ticket-error-message-zero-balance"
+          testId="balance-warning-swap-top-asset"
           message={
             <>
               {t('You need {{symbol}} in your wallet to swap.', {

--- a/apps/trading/components/swap/swap-form.tsx
+++ b/apps/trading/components/swap/swap-form.tsx
@@ -318,20 +318,16 @@ export const SwapForm = ({
           topAsset={topAsset}
           bottomAsset={bottomAsset}
         />
-        {(isReadOnly || !pubKey) && <NoWalletWarning isReadOnly={isReadOnly} />}
-        {topAsset && bottomAsset && (
+        {!pubKey && <NoWalletWarning isReadOnly={isReadOnly} />}
+        {pubKey && !isReadOnly && topAsset && (
           <Notification
             intent={Intent.Warning}
             testId="deal-ticket-error-message-zero-balance"
             message={
               <>
-                {t(
-                  'You need {{symbol1}} or {{symbol2}} in your wallet to trade in this market.',
-                  {
-                    symbol1: getAssetSymbol(topAsset),
-                    symbol2: getAssetSymbol(bottomAsset),
-                  }
-                )}
+                {t('You need {{symbol}} in your wallet to swap.', {
+                  symbol: getAssetSymbol(topAsset),
+                })}
               </>
             }
             buttonProps={{

--- a/apps/trading/components/swap/swap-form.tsx
+++ b/apps/trading/components/swap/swap-form.tsx
@@ -34,9 +34,10 @@ import {
   type MarketFieldsFragment,
 } from '@vegaprotocol/markets';
 import { useVegaTransactionStore } from '@vegaprotocol/web3';
-import { NoWalletWarning, getNotionalSize } from '@vegaprotocol/deal-ticket';
+import { getNotionalSize } from '@vegaprotocol/deal-ticket';
 import { usePrevious } from '@vegaprotocol/react-helpers';
 import { SpotData } from './spot-data';
+import { GetStarted } from '../../components/welcome-dialog/get-started';
 
 const getAssetBalance = (
   asset?: AssetFieldsFragment,
@@ -294,6 +295,28 @@ export const SwapForm = ({
       >
         {t('Swap now')}
       </TradingButton>
+      <GetStarted lead={t('Connect wallet')} />
+      {pubKey && !isReadOnly && topAsset && (
+        <Notification
+          intent={Intent.Warning}
+          testId="deal-ticket-error-message-zero-balance"
+          message={
+            <>
+              {t('You need {{symbol}} in your wallet to swap.', {
+                symbol: getAssetSymbol(topAsset),
+              })}
+            </>
+          }
+          buttonProps={{
+            text: t(`Make a deposit`),
+            action: () => {
+              onDeposit(topAsset.id);
+            },
+            dataTestId: 'deal-ticket-deposit-dialog-button',
+            size: 'small',
+          }}
+        />
+      )}
       <div className="flex flex-col gap-4">
         {!market?.id && bottomAsset && topAsset && (
           <Notification
@@ -318,28 +341,6 @@ export const SwapForm = ({
           topAsset={topAsset}
           bottomAsset={bottomAsset}
         />
-        {!pubKey && <NoWalletWarning isReadOnly={isReadOnly} />}
-        {pubKey && !isReadOnly && topAsset && (
-          <Notification
-            intent={Intent.Warning}
-            testId="deal-ticket-error-message-zero-balance"
-            message={
-              <>
-                {t('You need {{symbol}} in your wallet to swap.', {
-                  symbol: getAssetSymbol(topAsset),
-                })}
-              </>
-            }
-            buttonProps={{
-              text: t(`Make a deposit`),
-              action: () => {
-                onDeposit(topAsset.id);
-              },
-              dataTestId: 'deal-ticket-deposit-dialog-button',
-              size: 'small',
-            }}
-          />
-        )}
       </div>
     </form>
   );

--- a/libs/deal-ticket/src/components/deal-ticket-validation/zero-balance-error.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket-validation/zero-balance-error.tsx
@@ -4,11 +4,13 @@ import { getAssetSymbol, type AssetFieldsFragment } from '@vegaprotocol/assets';
 
 interface ZeroBalanceErrorProps {
   asset: AssetFieldsFragment;
+  baseAsset?: AssetFieldsFragment;
   onDeposit: (assetId: string) => void;
 }
 
 export const ZeroBalanceError = ({
   asset,
+  baseAsset,
   onDeposit,
 }: ZeroBalanceErrorProps) => {
   const t = useT();
@@ -18,11 +20,23 @@ export const ZeroBalanceError = ({
       intent={Intent.Warning}
       testId="deal-ticket-error-message-zero-balance"
       message={
-        <>
-          {t('You need {{symbol}} in your wallet to trade in this market.', {
-            symbol: getAssetSymbol(asset),
-          })}
-        </>
+        baseAsset ? (
+          <>
+            {t(
+              'You need {{symbol1}} or {{symbol2}} in your wallet to trade in this market.',
+              {
+                symbol1: getAssetSymbol(asset),
+                symbol2: getAssetSymbol(baseAsset),
+              }
+            )}
+          </>
+        ) : (
+          <>
+            {t('You need {{symbol}} in your wallet to trade in this market.', {
+              symbol: getAssetSymbol(asset),
+            })}
+          </>
+        )
       }
       buttonProps={{
         text: t(`Make a deposit`),

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -1050,6 +1050,7 @@ export const DealTicket = ({
       <SummaryMessage
         error={summaryError}
         asset={(useBaseAsset && baseAsset) || asset}
+        baseAsset={baseAsset}
         marketTradingMode={marketData.marketTradingMode}
         balance={useBaseAsset ? baseAssetAccountBalance : generalAccountBalance}
         isSpotMarket={isSpotMarket}
@@ -1095,6 +1096,7 @@ interface SummaryMessageProps {
   isSpotMarket?: boolean;
   error?: { message: string; type: string };
   asset: AssetFieldsFragment;
+  baseAsset?: AssetFieldsFragment;
   marketTradingMode: MarketData['marketTradingMode'];
   balance: string;
   margin: string;
@@ -1139,6 +1141,7 @@ const SummaryMessage = memo(
     isSpotMarket,
     error,
     asset,
+    baseAsset,
     marketTradingMode,
     balance,
     margin,
@@ -1155,6 +1158,17 @@ const SummaryMessage = memo(
     }
 
     if (error?.type === SummaryValidationType.NoCollateral) {
+      if (isSpotMarket) {
+        return (
+          <div className="mb-2">
+            <ZeroBalanceError
+              asset={asset}
+              baseAsset={baseAsset}
+              onDeposit={onDeposit}
+            />
+          </div>
+        );
+      }
       return (
         <div className="mb-2">
           <ZeroBalanceError asset={asset} onDeposit={onDeposit} />


### PR DESCRIPTION
# Related issues 🔗

Closes #6527 
Closes #6491 

# Description ℹ️

- [x] Add deposit and connect prompt to the spot swap UI
- [x] Deposit prompt on spot markets 

# Demo 📺

<img width="554" alt="Screenshot 2024-06-18 at 16 08 26" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/417cd6b8-e64e-44b7-99ec-40d176dc9961">

<img width="478" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/d2d57d89-ae6a-4ff5-854e-ba14c7dfb0ee">

<img width="1680" alt="Screenshot 2024-06-18 at 16 21 46" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/22c5aeb6-4450-4ad8-9143-be31c9b0e6b7">


# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
