### PR TITLE
fix(trading): asset emblem chain logo

### DIFF
--- a/apps/trading/components/market-header/mobile-market-header.tsx
+++ b/apps/trading/components/market-header/mobile-market-header.tsx
@@ -45,7 +45,7 @@ export const MobileMarketHeader = () => {
             className="min-w-0 flex gap-1 items-center"
           >
             <h1 className="whitespace-nowrap overflow-hidden text-ellipsis items-center">
-              <span className="">
+              <span className="flex items-center">
                 {marketId && (
                   <span className="mr-2">
                     <EmblemByMarket market={marketId} vegaChain={chainId} />

--- a/libs/emblem/src/components/asset-emblem.tsx
+++ b/libs/emblem/src/components/asset-emblem.tsx
@@ -26,10 +26,9 @@ export function EmblemByAsset(p: EmblemByAssetProps) {
       {p.showSourceChain !== false && (
         <EmblemBase
           src={getVegaAssetLogoUrl(chain, p.asset, CHAIN_FILENAME)}
-          width={12}
-          height={12}
+          size={12}
           alt={t('Chain logo')}
-          className={`align-text-top absolute bottom-0 right-0`}
+          className={`align-text-top absolute -bottom-1 -right-1`}
         />
       )}
     </div>


### PR DESCRIPTION
# Related issues 🔗

Closes N/A

# Description ℹ️

Adjust asset emblem chain logo.

# Demo 📺

<img width="493" alt="image" src="https://github.com/vegaprotocol/frontend-monorepo/assets/16125548/1f756ae8-0932-47dc-9f47-f12b9d8a1eb0">

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
