### PR TITLE
fix(trading): only show enabled assets in sidebar

### DIFF
--- a/libs/accounts/src/lib/accounts-manager.tsx
+++ b/libs/accounts/src/lib/accounts-manager.tsx
@@ -1,7 +1,6 @@
 import orderBy from 'lodash/orderBy';
 import sortBy from 'lodash/sortBy';
-import { useDataProvider } from '@vegaprotocol/data-provider';
-import { assetsProvider } from '@vegaprotocol/assets';
+import { useEnabledAssets } from '@vegaprotocol/assets';
 import { AccountCard, type AssetActions } from './account-card';
 
 interface AccountManagerProps extends AssetActions {
@@ -14,11 +13,7 @@ export const AccountManager = ({
   pinnedAssets,
   ...props
 }: AccountManagerProps) => {
-  const { data } = useDataProvider({
-    dataProvider: assetsProvider,
-    variables: undefined,
-  });
-
+  const { data } = useEnabledAssets();
   const orderedData = orderBy(data || [], 'name', 'asc');
   const rows = sortBy(orderedData, (asset) => {
     if (!pinnedAssets) return 0;


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Changes sidebar to only show enabled assets, otherwise you get two version of usdt arb showing