### PR TITLE
fix(trading): text alignment in market update banner

### DIFF
--- a/apps/trading/components/market-banner/market-update-state-banner.tsx
+++ b/apps/trading/components/market-banner/market-update-state-banner.tsx
@@ -152,7 +152,7 @@ const PassedProposalContent = ({
       : undefined;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-1">
       <p className="uppercase">
         {t('Trading on market {{name}} will {{action}} on {{date}}', {
           name: market.tradableInstrument.instrument.code,

--- a/apps/trading/components/market-banner/market-update-state-banner.tsx
+++ b/apps/trading/components/market-banner/market-update-state-banner.tsx
@@ -153,7 +153,7 @@ const PassedProposalContent = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <p>
+      <p className="uppercase">
         {t('Trading on market {{name}} will {{action}} on {{date}}', {
           name: market.tradableInstrument.instrument.code,
           date,

--- a/apps/trading/components/market-banner/market-update-state-banner.tsx
+++ b/apps/trading/components/market-banner/market-update-state-banner.tsx
@@ -62,8 +62,8 @@ export const MarketUpdateStateBanner = ({
 
   if (openTradingProposals.length >= 1) {
     content = (
-      <>
-        <p className="mb-1">
+      <div className="flex flex-col gap-1">
+        <p>
           {t(
             'Trading on market {{name}} was suspended by governance. There are open proposals to resume trading on this market.',
             { name }
@@ -74,7 +74,7 @@ export const MarketUpdateStateBanner = ({
             {t('View proposals')}
           </ExternalLink>
         </p>
-      </>
+      </div>
     );
   } else if (passedProposals.length) {
     content = (
@@ -111,8 +111,8 @@ const OpenProposalContent = ({
       : undefined;
 
   return (
-    <>
-      <p className="mb-1">
+    <div className="flex flex-col gap-1">
+      <p>
         {t(
           'Trading on market {{name}} may {{action}} on {{date}}. There is an open proposal to {{action}} this market.',
           { name: market.tradableInstrument.instrument.code, action, date }
@@ -130,7 +130,7 @@ const OpenProposalContent = ({
           <ExternalLink href={proposalLink}>{t('View proposal')}</ExternalLink>
         </p>
       )}
-    </>
+    </div>
   );
 };
 
@@ -152,8 +152,8 @@ const PassedProposalContent = ({
       : undefined;
 
   return (
-    <>
-      <p className="uppercase mb-1">
+    <div className="flex flex-col gap-2">
+      <p>
         {t('Trading on market {{name}} will {{action}} on {{date}}', {
           name: market.tradableInstrument.instrument.code,
           date,
@@ -175,7 +175,7 @@ const PassedProposalContent = ({
             })}
         </p>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Small styling change to ensure the text aligns in the market header

# Demo 📺

before

![Screenshot 2024-06-25 at 12 08 00](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/1272ba16-b266-456b-b5c7-f295beb9a637)

after

![Screenshot 2024-06-25 at 12 08 11](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/033aab40-d059-4a1b-9f58-8f4d8ff1c739)