### PR TITLE
fix(explorer): fix status for accepted transfers with a future deliver on date

### DIFF
--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.spec.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import {
+  fixStatus,
+  TransferStatusIcon,
+  getIconForStatus,
+  getColourForStatus,
+} from './transfer-status';
+import { TransferStatus, TransferStatusMapping } from '@vegaprotocol/types';
+import addYears from 'date-fns/addYears';
+import subYears from 'date-fns/subYears';
+
+describe('TransferStatusIcon', () => {
+  it('renders transfer status icon', () => {
+    const status = TransferStatus.STATUS_PENDING;
+    render(<TransferStatusIcon status={status} />);
+    expect(
+      screen.getByTitle(TransferStatusMapping[status])
+    ).toBeInTheDocument();
+  });
+
+  it('renders one off transfers with deliveron in the future', () => {
+    const status = TransferStatus.STATUS_PENDING;
+    render(
+      <TransferStatusIcon
+        status={status}
+        deliverOn={addYears(new Date(), 1).toISOString()}
+      />
+    );
+    expect(
+      screen.getByTitle(TransferStatusMapping[status])
+    ).toBeInTheDocument();
+  });
+});
+
+describe('getIconForStatus', () => {
+  it('returns correct icon name for transfer status', () => {
+    expect(getIconForStatus(TransferStatus.STATUS_PENDING)).toBe('time');
+    expect(getIconForStatus(TransferStatus.STATUS_DONE)).toBe('tick');
+    expect(getIconForStatus(TransferStatus.STATUS_REJECTED)).toBe('cross');
+    expect(getIconForStatus(TransferStatus.STATUS_CANCELLED)).toBe('cross');
+    expect(getIconForStatus('' as TransferStatus)).toBe('time');
+  });
+});
+
+describe('getColourForStatus', () => {
+  it('returns correct colour for transfer status', () => {
+    expect(getColourForStatus(TransferStatus.STATUS_PENDING)).toBe(
+      'text-yellow-500'
+    );
+    expect(getColourForStatus(TransferStatus.STATUS_DONE)).toBe(
+      'text-green-500'
+    );
+    expect(getColourForStatus(TransferStatus.STATUS_REJECTED)).toBe(
+      'text-red-500'
+    );
+    expect(getColourForStatus(TransferStatus.STATUS_CANCELLED)).toBe(
+      'text-red-600'
+    );
+    expect(getColourForStatus('' as TransferStatus)).toBe('text-yellow-500');
+  });
+});
+
+describe('fixStatus', () => {
+  it('returns STATUS_PENDING if deliverOn is a future date', () => {
+    const status = TransferStatus.STATUS_DONE;
+    const deliverOn = addYears(new Date(), 1).toISOString();
+    const fixedStatus = fixStatus(status, deliverOn);
+    expect(fixedStatus).toBe(TransferStatus.STATUS_PENDING);
+  });
+
+  it('returns the same status if deliverOn is not a future date', () => {
+    const status = TransferStatus.STATUS_DONE;
+    // Just to be safe, make deliverOn a date in the far past
+    const deliverOn = subYears(new Date(), 1).toISOString();
+    const fixedStatus = fixStatus(status, deliverOn);
+    expect(fixedStatus).toBe(status);
+  });
+});

--- a/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
+++ b/apps/explorer/src/app/components/txs/details/transfer/blocks/transfer-status.tsx
@@ -5,6 +5,7 @@ import type { IconName } from '@vegaprotocol/ui-toolkit';
 import type { ApolloError } from '@apollo/client';
 import { TransferStatus, TransferStatusMapping } from '@vegaprotocol/types';
 import { IconNames } from '@blueprintjs/icons';
+import isFuture from 'date-fns/isFuture';
 
 interface TransferStatusProps {
   status: TransferStatus | undefined;
@@ -46,17 +47,45 @@ export function TransferStatusView({ status, loading }: TransferStatusProps) {
 
 interface TransferStatusIconProps {
   status: TransferStatus;
+  deliverOn?: string;
 }
 
-export function TransferStatusIcon({ status }: TransferStatusIconProps) {
+export function TransferStatusIcon({
+  status,
+  deliverOn,
+}: TransferStatusIconProps) {
+  const s: TransferStatus = fixStatus(status);
+
   return (
-    <span title={TransferStatusMapping[status]}>
-      <Icon
-        name={getIconForStatus(status)}
-        className={getColourForStatus(status)}
-      />
+    <span title={TransferStatusMapping[s]}>
+      <Icon name={getIconForStatus(s)} className={getColourForStatus(s)} />
     </span>
   );
+}
+
+/**
+ * One off transfers with a future delivery date have a 'status' of 'DONE'
+ * because they are scheduled, but not actually transferred until the date
+ *
+ * @param status TransferStatus API reported status for the transfer
+ * @param deliverOn String date for the transfer to be executed
+ * @returns TransferStatus
+ */
+export function fixStatus(
+  status: TransferStatus,
+  deliverOn?: string
+): TransferStatus {
+  if (deliverOn) {
+    try {
+      if (isFuture(new Date(deliverOn))) {
+        return TransferStatus.STATUS_PENDING;
+      }
+    } catch (e) {
+      /* continue as normal */
+    }
+  }
+
+  return status;
 }
 
 /**

--- a/apps/explorer/src/app/routes/treasury/components/network-transfers-table.tsx
+++ b/apps/explorer/src/app/routes/treasury/components/network-transfers-table.tsx
@@ -157,6 +157,11 @@ export const NetworkTransfersTable = () => {
                   const isIncoming =
                     a?.toAccountType ===
                     AccountType.ACCOUNT_TYPE_NETWORK_TREASURY;
+                  const deliverOn =
+                    a?.kind.__typename === 'OneOffTransfer' ||
+                    a?.kind.__typename === 'OneOffGovernanceTransfer'
+                      ? a.kind.deliverOn
+                      : undefined;
                   return (
                     <tr key={a?.id}>
                       {a && a.amount && a.asset && (
@@ -235,7 +240,10 @@ export const NetworkTransfersTable = () => {
                         }`}
                       >
                         {a && a.status && (
-                          <TransferStatusIcon status={a.status} />
+                          <TransferStatusIcon
+                            status={a.status}
+                            deliverOn={deliverOn}
+                          />
                         )}
                       </td>
                       <td


### PR DESCRIPTION
# Related issues 🔗

Closes #6599

# Description ℹ️

Single transfers (governance or otherwise) will have a status of DONE, even if the deliverOn date is set and in the future. This PR adds a function that switches the transfer status icon to pending in this case.

# Demo 📺
