### PR TITLE
fix(trading): input zoom on safari

### DIFF
--- a/apps/trading/pages/index.page.tsx
+++ b/apps/trading/pages/index.page.tsx
@@ -16,6 +16,10 @@ export default function Index() {
         />
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1"
+        />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Vega Protocol - Console" />
         <meta name="og:type" content="website" />


### PR DESCRIPTION
# Related issues 🔗

Closes #6595 

# Description ℹ️

Disables input zoom on safari which would break the deal ticket layout