### PR TITLE
chore(trading): switch to use new deposit container on mobile

### DIFF
--- a/apps/trading/client-pages/markets/mobile-buttons.tsx
+++ b/apps/trading/client-pages/markets/mobile-buttons.tsx
@@ -12,7 +12,7 @@ import {
 } from '@vegaprotocol/ui-toolkit';
 import { DealTicketContainer } from '@vegaprotocol/deal-ticket';
 import { MarketInfoAccordionContainer } from '@vegaprotocol/markets';
-import { DepositContainer } from '@vegaprotocol/deposits';
+import { DepositContainer } from '../../components/deposit-container';
 import { TransferContainer } from '@vegaprotocol/accounts';
 import { WithdrawContainer } from '../../components/withdraw-container';
 import { useT } from '../../lib/use-t';


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

The mobile view was still using the old depoist ui, this switches to use the new version