### PR TITLE
fix(trading,explorer): show unlimited in asset details for large numbers

### DIFF
--- a/libs/assets/src/lib/asset-details-table.spec.tsx
+++ b/libs/assets/src/lib/asset-details-table.spec.tsx
@@ -6,8 +6,18 @@ import {
   AssetDetailsTable,
   useRows,
   testId,
+  num,
 } from './asset-details-table';
 import { generateBuiltinAsset, generateERC20Asset } from './test-helpers';
+
+describe('num formatting', () => {
+  it('show unlimited for large values', () => {
+    const usdLimit =
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+    const asset = { decimals: 10 } as unknown as Asset;
+    expect(num(asset, usdLimit)).toEqual('Unlimited');
+  });
+});
 
 describe('AssetDetailsTable', () => {
   const cases: [string, Asset, { key: AssetDetail; value: string }[]][] = [

--- a/libs/assets/src/lib/asset-details-table.tsx
+++ b/libs/assets/src/lib/asset-details-table.tsx
@@ -47,9 +47,17 @@ export enum AssetDetail {
 
 type Mapping = { [key in string]: { value: string; tooltip: string } };
 
-const num = (asset: Asset, n: string | undefined | null) => {
+export const num = (asset: Asset, n: string | undefined | null) => {
   if (typeof n === 'undefined' || n == null) return '';
-  return addDecimalsFormatNumber(n, asset.decimals);
+
+  // Semi arbitrary, based on USDT's 78 characters (unformatted)
+  if (n.length >= 70) {
+    return 'Unlimited';
+  }
+
+  const formatted = addDecimalsFormatNumber(n, asset.decimals);
+
+  return formatted;
 };
 
 const Diff = ({


### PR DESCRIPTION
# Related issues 🔗

Closes #6508

# Description ℹ️

USDTT has a lifetime deposit limit of 115792089237316195423570985008687907853269984665640564039457584007913129639935, which when formatted is a very very long number. This broke the table. This very large number is *effectively* unlimited, so this fix changes it to show that for very very large numbers. It is quite a dumb fix that could break, say if the asset was precise to a very large number of decimal places, but this is not true for any current asset.

# Demo 📺
<img width="817" alt="Screenshot 2024-06-27 at 12 41 33" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/426177f4-7e9e-4d7b-8b52-cd3f76ea4d82">

