### PR TITLE
feat(governance): assets chain names and icons

### DIFF
--- a/apps/governance-e2e/src/integration/view/wallet-eth.cy.ts
+++ b/apps/governance-e2e/src/integration/view/wallet-eth.cy.ts
@@ -141,7 +141,7 @@ context(
           cy.get(vegaInVesting).within(() => {
             cy.get(currencyTitle)
               .should('be.visible')
-              .and('have.text', 'VEGAIn vesting contract');
+              .and('contain.text', 'VEGAIn vesting contract');
           });
         });
 
@@ -214,7 +214,7 @@ context(
           cy.get(vegaInWallet).within(() => {
             cy.get(currencyTitle)
               .should('be.visible')
-              .and('have.text', 'VEGAIn Wallet');
+              .and('contain.text', 'VEGAIn Wallet');
           });
         });
 

--- a/apps/governance/src/components/vega-wallet/Delegations.graphql
+++ b/apps/governance/src/components/vega-wallet/Delegations.graphql
@@ -35,6 +35,7 @@ query Delegations($partyId: ID!, $delegationsPagination: Pagination) {
               __typename
               ... on ERC20 {
                 contractAddress
+                chainId
               }
             }
           }

--- a/apps/governance/src/components/vega-wallet/__generated__/Delegations.ts
+++ b/apps/governance/src/components/vega-wallet/__generated__/Delegations.ts
@@ -11,7 +11,7 @@ export type DelegationsQueryVariables = Types.Exact<{
 }>;
 
 
-export type DelegationsQuery = { __typename?: 'Query', epoch: { __typename?: 'Epoch', id: string }, party?: { __typename?: 'Party', id: string, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number, node: { __typename?: 'Node', id: string, name: string } } } | null> | null } | null, stakingSummary: { __typename?: 'StakingSummary', currentStakeAvailable: string }, accountsConnection?: { __typename?: 'AccountsConnection', edges?: Array<{ __typename?: 'AccountEdge', node: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string } } } } | null> | null } | null } | null };
+export type DelegationsQuery = { __typename?: 'Query', epoch: { __typename?: 'Epoch', id: string }, party?: { __typename?: 'Party', id: string, delegationsConnection?: { __typename?: 'DelegationsConnection', edges?: Array<{ __typename?: 'DelegationEdge', node: { __typename?: 'Delegation', amount: string, epoch: number, node: { __typename?: 'Node', id: string, name: string } } } | null> | null } | null, stakingSummary: { __typename?: 'StakingSummary', currentStakeAvailable: string }, accountsConnection?: { __typename?: 'AccountsConnection', edges?: Array<{ __typename?: 'AccountEdge', node: { __typename?: 'AccountBalance', type: Types.AccountType, balance: string, asset: { __typename?: 'Asset', name: string, id: string, decimals: number, symbol: string, source: { __typename: 'BuiltinAsset' } | { __typename: 'ERC20', contractAddress: string, chainId: string } } } } | null> | null } | null } | null };
 
 export const WalletDelegationFieldsFragmentDoc = gql`
     fragment WalletDelegationFields on Delegation {
@@ -52,6 +52,7 @@ export const DelegationsDocument = gql`
               __typename
               ... on ERC20 {
                 contractAddress
+                chainId
               }
             }
           }

--- a/apps/governance/src/components/vega-wallet/hooks.ts
+++ b/apps/governance/src/components/vega-wallet/hooks.ts
@@ -109,6 +109,10 @@ export const usePollForDelegations = () => {
                     isAssetTypeERC20(a.asset) &&
                     a.asset.source.contractAddress === vegaToken.address;
 
+                  const chainId = isAssetTypeERC20(a.asset)
+                    ? a.asset.source.chainId
+                    : undefined;
+
                   const isVesting =
                     a.type === Schema.AccountType.ACCOUNT_TYPE_VESTED_REWARDS ||
                     a.type === Schema.AccountType.ACCOUNT_TYPE_VESTING_REWARDS;
@@ -126,6 +130,7 @@ export const usePollForDelegations = () => {
                     symbol: a.asset.symbol,
                     decimals: a.asset.decimals,
                     assetId: a.asset.id,
+                    chainId: chainId,
                     balance: new BigNumber(
                       addDecimal(a.balance, a.asset.decimals)
                     ),

--- a/apps/governance/src/components/wallet-card/wallet-card.tsx
+++ b/apps/governance/src/components/wallet-card/wallet-card.tsx
@@ -11,10 +11,14 @@ import {
   CONSOLE_TRANSFER_ASSET,
   DApp,
   DocsLinks,
+  getExternalChainShortLabel,
   useLinks,
 } from '@vegaprotocol/environment';
 import { useNetworkParam } from '@vegaprotocol/network-parameters';
 import { formatNumberPercentage } from '@vegaprotocol/utils';
+import noIcon from '../../images/token-no-icon.png';
+import { EmblemByAsset } from '@vegaprotocol/emblem';
+import { useWallet } from '@vegaprotocol/wallet-react';
 
 interface WalletCardProps {
   children: React.ReactNode;
@@ -112,6 +116,7 @@ export type WalletCardAssetProps = {
   balance: BigNumber;
   decimals: number;
   assetId?: string;
+  chainId?: string;
   border?: boolean;
   subheading?: string;
   type?: Schema.AccountType;
@@ -131,6 +136,7 @@ export const WalletCardAsset = ({
   symbol,
   decimals,
   assetId,
+  chainId,
   border,
   subheading,
   allowZeroBalance = false,
@@ -169,17 +175,30 @@ export const WalletCardAsset = ({
         />
       ));
 
+  const vegaChainId = useWallet((store) => store.chainId);
   if (!values || values.length === 0) return;
+
+  let img = (
+    <img
+      alt="Vega"
+      src={image}
+      className={`inline-block w-6 h-6 mt-2 rounded-full border ${
+        border ? 'border-white' : 'border-black'
+      }`}
+    />
+  );
+
+  if (image === noIcon && assetId) {
+    img = (
+      <div className="w-6 h-6">
+        <EmblemByAsset asset={assetId} vegaChain={vegaChainId} />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-nowrap gap-2 mt-2 mb-4">
-      <img
-        alt="Vega"
-        src={image}
-        className={`inline-block w-6 h-6 mt-2 rounded-full border ${
-          border ? 'border-white' : 'border-black'
-        }`}
-      />
+      {img}
       <div>
         <div
           className="flex align-center items-baseline text-base gap-2"
@@ -187,7 +206,12 @@ export const WalletCardAsset = ({
         >
           <div className="mb-0 uppercase">{name}</div>
           <div className="mb-0 uppercase text-neutral-400">
-            {subheading || symbol}
+            {subheading || symbol}{' '}
+            {chainId && (
+              <span className="text-xs">
+                {getExternalChainShortLabel(chainId)}
+              </span>
+            )}
           </div>
         </div>
         {values}

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.spec.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.spec.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
 import { AppStateProvider } from '../../../contexts/app-state/app-state-provider';
 import { EpochIndividualRewardsTable } from './epoch-individual-rewards-table';
+import { useWallet } from '@vegaprotocol/wallet-react';
+jest.mock('@vegaprotocol/wallet-react');
 
 const mockData = {
   epoch: 4441,
@@ -40,6 +42,11 @@ const mockData = {
 };
 
 describe('EpochIndividualRewardsTable', () => {
+  beforeAll(() => {
+    (useWallet as jest.Mock).mockReturnValue(() => () => ({
+      chainId: 'vega-chain-id',
+    }));
+  });
   it('should render correctly', () => {
     const { getByTestId } = render(
       <AppStateProvider>

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/epoch-individual-rewards-table.tsx
@@ -5,6 +5,8 @@ import {
   RewardsTable,
 } from '../shared-rewards-table-assets/shared-rewards-table-assets';
 import type { EpochIndividualReward } from './generate-epoch-individual-rewards-list';
+import { useWallet } from '@vegaprotocol/wallet-react';
+import { EmblemByAsset } from '@vegaprotocol/emblem';
 
 interface EpochIndividualRewardsGridProps {
   data: EpochIndividualReward;
@@ -72,39 +74,46 @@ export const EpochIndividualRewardsTable = ({
   data,
   marketCreationQuantumMultiple,
 }: EpochIndividualRewardsGridProps) => {
+  const vegaChainId = useWallet((store) => store.chainId);
   return (
     <RewardsTable
       marketCreationQuantumMultiple={marketCreationQuantumMultiple}
       dataTestId="epoch-individual-rewards-table"
       epoch={Number(data.epoch)}
     >
-      {data.rewards.map(({ asset, rewardTypes, totalAmount, decimals }, i) => (
-        <div className="contents" key={i}>
-          <div
-            data-testid="individual-rewards-asset"
-            className={`${rowGridItemStyles()} p-5`}
-          >
-            {asset}
+      {data.rewards.map(
+        ({ assetId, asset, rewardTypes, totalAmount, decimals }, i) => (
+          <div className="contents" key={i}>
+            <div className={`${rowGridItemStyles()} p-5`}>
+              <div className="flex items-center gap-2">
+                {assetId && (
+                  <div className="w-6 h-6">
+                    <EmblemByAsset asset={assetId} vegaChain={vegaChainId} />
+                  </div>
+                )}
+                <span data-testid="individual-rewards-asset">{asset}</span>
+              </div>
+            </div>
+            {Object.entries(rewardTypes).map(
+              ([key, { amount, percentageOfTotal }]) => (
+                <RewardItem
+                  key={key}
+                  amount={amount}
+                  decimals={decimals}
+                  percentageOfTotal={percentageOfTotal}
+                  dataTestId={key}
+                />
+              )
+            )}
+            <RewardItem
+              dataTestId="total"
+              amount={totalAmount}
+              decimals={decimals}
+              last={true}
+            />
           </div>
-          {Object.entries(rewardTypes).map(
-            ([key, { amount, percentageOfTotal }]) => (
-              <RewardItem
-                key={key}
-                amount={amount}
-                decimals={decimals}
-                percentageOfTotal={percentageOfTotal}
-                dataTestId={key}
-              />
-            )
-          )}
-          <RewardItem
-            dataTestId="total"
-            amount={totalAmount}
-            decimals={decimals}
-            last={true}
-          />
-        </div>
-      ))}
+        )
+      )}
     </RewardsTable>
   );
 };

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.spec.ts
@@ -83,6 +83,7 @@ describe('generateEpochIndividualRewardsList', () => {
       rewards: [
         {
           asset: 'USD',
+          assetId: 'usd',
           decimals: 6,
           totalAmount: '100',
           rewardTypes: {
@@ -137,6 +138,7 @@ describe('generateEpochIndividualRewardsList', () => {
         rewards: [
           {
             asset: 'EUR',
+            assetId: 'eur',
             totalAmount: '50',
             decimals: 5,
             rewardTypes: {
@@ -157,6 +159,7 @@ describe('generateEpochIndividualRewardsList', () => {
         rewards: [
           {
             asset: 'USD',
+            assetId: 'usd',
             totalAmount: '100',
             decimals: 6,
             rewardTypes: {
@@ -195,6 +198,7 @@ describe('generateEpochIndividualRewardsList', () => {
         rewards: [
           {
             asset: 'EUR',
+            assetId: 'eur',
             totalAmount: '50',
             decimals: 5,
             rewardTypes: {
@@ -226,6 +230,7 @@ describe('generateEpochIndividualRewardsList', () => {
         rewards: [
           {
             asset: 'USD',
+            assetId: 'usd',
             totalAmount: '100',
             decimals: 6,
             rewardTypes: {

--- a/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
+++ b/apps/governance/src/routes/rewards/epoch-individual-rewards/generate-epoch-individual-rewards-list.ts
@@ -11,6 +11,7 @@ export interface EpochIndividualReward {
   epoch: number;
   rewards: {
     asset: string;
+    assetId?: string;
     totalAmount: string;
     decimals: number;
     rewardTypes: {
@@ -81,6 +82,7 @@ export const generateEpochIndividualRewardsList = ({
     if (!asset) {
       asset = {
         asset: assetName,
+        assetId: reward.asset.id,
         decimals: assetDecimals,
         totalAmount: '0',
         rewardTypes: Object.fromEntries(emptyRowAccountTypes),

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.spec.tsx
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.spec.tsx
@@ -7,6 +7,8 @@ import type {
   RewardItem,
 } from './generate-epoch-total-rewards-list';
 import { AccountType } from '@vegaprotocol/types';
+import { useWallet } from '@vegaprotocol/wallet-react';
+jest.mock('@vegaprotocol/wallet-react');
 
 const assetId =
   'b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663';
@@ -63,6 +65,11 @@ const mockData = {
 };
 
 describe('EpochTotalRewardsTable', () => {
+  beforeAll(() => {
+    (useWallet as jest.Mock).mockReturnValue(() => () => ({
+      chainId: 'vega-chain-id',
+    }));
+  });
   it('should render correctly', () => {
     const { getByTestId } = render(
       <AppStateProvider>

--- a/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.tsx
+++ b/apps/governance/src/routes/rewards/epoch-total-rewards/epoch-total-rewards-table.tsx
@@ -5,6 +5,8 @@ import {
   RewardsTable,
 } from '../shared-rewards-table-assets/shared-rewards-table-assets';
 import type { EpochTotalSummary } from './generate-epoch-total-rewards-list';
+import { EmblemByAsset } from '@vegaprotocol/emblem';
+import { useWallet } from '@vegaprotocol/wallet-react';
 
 interface EpochTotalRewardsGridProps {
   data: EpochTotalSummary;
@@ -55,6 +57,7 @@ export const EpochTotalRewardsTable = ({
   data,
   marketCreationQuantumMultiple,
 }: EpochTotalRewardsGridProps) => {
+  const vegaChainId = useWallet((store) => store.chainId);
   return (
     <RewardsTable
       marketCreationQuantumMultiple={marketCreationQuantumMultiple}
@@ -62,10 +65,15 @@ export const EpochTotalRewardsTable = ({
       epoch={data.epoch}
     >
       {Array.from(data.assetRewards.values()).map(
-        ({ name, rewards, totalAmount, decimals }, i) => (
+        ({ assetId, name, rewards, totalAmount, decimals }, i) => (
           <div className="contents" key={i}>
-            <div data-testid="asset" className={`${rowGridItemStyles()} p-5`}>
-              {name}
+            <div className={`${rowGridItemStyles()} p-5`}>
+              <div className="flex items-center gap-2">
+                <div className="w-6 h-6">
+                  <EmblemByAsset asset={assetId} vegaChain={vegaChainId} />
+                </div>
+                <span data-testid="asset">{name}</span>
+              </div>
             </div>
             {Array.from(rewards.values()).map(({ rewardType, amount }, i) => (
               <RewardItem


### PR DESCRIPTION
# Related issues 🔗

Closes #6531 

# Description ℹ️

* adds chain name and icon to the wallet breakdown
* adds icons to rewards page

# Demo 📺

<img width="469" alt="Screenshot 2024-06-28 at 16 53 27" src="https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/98f5a97d-1202-4cf7-8c75-7426215c2fb1">

<img width="1156" alt="Screenshot 2024-06-28 at 17 09 11" src="https://github.com/vegaprotocol/frontend-monorepo/assets/1980305/27c2dd21-9448-41ac-bbec-8eb4af32871c">



# Technical 👨‍🔧

N/A