### PR TITLE
feat(trading): deal ticket type selector

### DIFF
--- a/apps/trading/components/margin-mode/margin-mode.tsx
+++ b/apps/trading/components/margin-mode/margin-mode.tsx
@@ -30,10 +30,12 @@ export const MarginModeToggle = () => {
   if (isSpot(market.tradableInstrument.instrument.product)) return null;
 
   const marginMode = margin?.marginMode || MarginMode.MARGIN_MODE_CROSS_MARGIN;
+
   const marginFactor =
     margin?.marginFactor && margin?.marginFactor !== '0'
-      ? margin?.marginFactor
+      ? margin.marginFactor
       : undefined;
+
   const onClose = () => setDialog(undefined);
 
   return (
@@ -77,7 +79,6 @@ const Toggle = ({
   const indicator = (
     <span className="absolute -top-px right-0 -bottom-px left-0 bg-vega-clight-500 dark:bg-vega-cdark-500 rounded" />
   );
-  const leverage = factor ? (1 / Number(factor)).toFixed(1) : DEFAULT_LEVERAGE;
 
   return (
     <ToggleGroup.Root
@@ -103,14 +104,26 @@ const Toggle = ({
         {mode === MarginMode.MARGIN_MODE_ISOLATED_MARGIN ? (
           <span className="relative flex items-center gap-1">
             {t('Isolated')}
-            <span className="py-px px-1 rounded text-2xs bg-vega-green-700 text-vega-green">
-              {leverage}x
-            </span>
+            <Leverage factor={factor} />
           </span>
         ) : (
           <span className="relative">{t('Isolated')}</span>
         )}
       </ToggleGroup.Item>
     </ToggleGroup.Root>
+  );
+};
+
+const Leverage = ({ factor }: { factor: string | undefined }) => {
+  let leverage = DEFAULT_LEVERAGE.toString();
+
+  if (factor && factor !== '0') {
+    leverage = (1 / Number(factor)).toFixed(1);
+  }
+
+  return (
+    <span className="py-px px-1 rounded text-2xs bg-vega-green-700 text-vega-green">
+      {leverage}x
+    </span>
   );
 };

--- a/apps/trading/components/margin-mode/margin-mode.tsx
+++ b/apps/trading/components/margin-mode/margin-mode.tsx
@@ -17,7 +17,6 @@ export const MarginModeToggle = () => {
 
   const [dialog, setDialog] = useState<MarginMode>();
   const { pubKey: partyId } = useVegaWallet();
-
   const { data: market } = useMarket(params.marketId);
   const { data: margin } = useMarginMode({
     partyId,
@@ -31,6 +30,8 @@ export const MarginModeToggle = () => {
 
   const marginMode = margin?.marginMode || MarginMode.MARGIN_MODE_CROSS_MARGIN;
 
+  // Margin factor can be 0, we need to check for this to
+  // avoid dividing by 0
   const marginFactor =
     margin?.marginFactor && margin?.marginFactor !== '0'
       ? margin.marginFactor

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket-stop-order.tsx
@@ -28,7 +28,6 @@ import {
   TradingInputError as InputError,
   TradingSelect as Select,
   Tooltip,
-  TradingButton as Button,
   Pill,
   Intent,
   Notification,
@@ -75,6 +74,7 @@ import { isNonPersistentOrder } from '../../utils/time-in-force-persistence';
 import { useAccountBalance } from '@vegaprotocol/accounts';
 import { ZeroBalanceError } from '../deal-ticket-validation/zero-balance-error';
 import { MarginWarning } from '../deal-ticket-validation';
+import { SubmitButton } from './submit-button';
 
 export interface StopOrderProps {
   market: Market;
@@ -1001,7 +1001,7 @@ const formatTrigger = (
         })
   }`;
 
-const SubmitButton = ({
+const PlaceOrderButton = ({
   assetUnit,
   market,
   oco,
@@ -1151,21 +1151,17 @@ const SubmitButton = ({
     </>
   );
   return (
-    <Button
-      intent={side === Schema.Side.SIDE_BUY ? Intent.Success : Intent.Danger}
-      data-testid="place-order"
-      type="submit"
-      className="w-full"
-      subLabel={subLabel}
-    >
-      {t(
+    <SubmitButton
+      text={t(
         oco
           ? 'Place OCO stop order'
           : type === Schema.OrderType.TYPE_MARKET
           ? 'Place market stop order'
           : 'Place limit stop order'
       )}
-    </Button>
+      subLabel={subLabel}
+      side={side}
+    />
   );
 };
 
@@ -1403,31 +1399,35 @@ export const StopOrder = ({
       onSubmit={isReadOnly || !pubKey ? stopSubmit : handleSubmit(onSubmit)}
       noValidate
     >
-      <Controller
-        name="side"
-        control={control}
-        render={({ field }) => (
-          <SideSelector
-            value={field.value}
-            onValueChange={field.onChange}
-            isSpotMarket={isSpotMarket}
-          />
-        )}
-      />
-      <TypeToggle
-        value={dealTicketType}
-        onValueChange={(dealTicketType) => {
-          setType(market.id, dealTicketType);
-          if (isStopOrderType(dealTicketType)) {
-            reset(
-              getDefaultValues(
-                dealTicketTypeToOrderType(dealTicketType),
-                storedFormValues?.[dealTicketType]
-              )
-            );
-          }
-        }}
-      />
+      <FormGroup label={t('Order side')} labelFor="side" hideLabel>
+        <Controller
+          name="side"
+          control={control}
+          render={({ field }) => (
+            <SideSelector
+              value={field.value}
+              onValueChange={field.onChange}
+              isSpotMarket={isSpotMarket}
+            />
+          )}
+        />
+      </FormGroup>
+      <FormGroup label={t('Order type')} labelFor="type" hideLabel>
+        <TypeToggle
+          value={dealTicketType}
+          onValueChange={(dealTicketType) => {
+            setType(market.id, dealTicketType);
+            if (isStopOrderType(dealTicketType)) {
+              reset(
+                getDefaultValues(
+                  dealTicketTypeToOrderType(dealTicketType),
+                  storedFormValues?.[dealTicketType]
+                )
+              );
+            }
+          }}
+        />
+      </FormGroup>
       {errors.type && (
         <InputError testId="stop-order-error-message-type">
           {errors.type.message}
@@ -1760,7 +1760,7 @@ export const StopOrder = ({
           marketId={market.id}
         />
       )}
-      <SubmitButton
+      <PlaceOrderButton
         assetUnit={assetUnit}
         market={market}
         oco={oco}

--- a/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/deal-ticket.tsx
@@ -98,7 +98,7 @@ import {
   AssetSymbol,
   getAssetSymbol,
 } from '@vegaprotocol/assets';
-import classNames from 'classnames';
+import { SubmitButton } from './submit-button';
 
 export const REDUCE_ONLY_TOOLTIP =
   '"Reduce only" will ensure that this order will not increase the size of an open position. When the order is matched, it will only trade enough volume to bring your open volume towards 0 but never change the direction of your position. If applied to a limit order that is not instantly filled, the order will be stopped.';
@@ -593,35 +593,38 @@ export const DealTicket = ({
       noValidate
       data-testid="deal-ticket-form"
     >
-      <Controller
-        name="side"
-        control={control}
-        render={({ field }) => (
-          <SideSelector
-            isSpotMarket={isSpotMarket}
-            value={field.value}
-            onValueChange={field.onChange}
-          />
-        )}
-      />
-      <TypeSelector
-        value={dealTicketType}
-        onValueChange={(dealTicketType) => {
-          setType(market.id, dealTicketType);
-          if (!isStopOrderType(dealTicketType)) {
-            reset(
-              getDefaultValues(
-                dealTicketTypeToOrderType(dealTicketType),
-                storedFormValues?.[dealTicketType]
-              )
-            );
-          }
-        }}
-        market={market}
-        marketData={marketData}
-        errorMessage={errors.type?.message}
-        showStopOrders={!isSpotMarket}
-      />
+      <FormGroup label={t('Order side')} labelFor="side" hideLabel>
+        <Controller
+          name="side"
+          control={control}
+          render={({ field }) => (
+            <SideSelector
+              isSpotMarket={isSpotMarket}
+              value={field.value}
+              onValueChange={field.onChange}
+            />
+          )}
+        />
+      </FormGroup>
+      <FormGroup label={t('Order type')} labelFor="type" hideLabel>
+        <TypeSelector
+          value={dealTicketType}
+          onValueChange={(dealTicketType) => {
+            setType(market.id, dealTicketType);
+            if (!isStopOrderType(dealTicketType)) {
+              reset(
+                getDefaultValues(
+                  dealTicketTypeToOrderType(dealTicketType),
+                  storedFormValues?.[dealTicketType]
+                )
+              );
+            }
+          }}
+          market={market}
+          marketData={marketData}
+          errorMessage={errors.type?.message}
+        />
+      </FormGroup>
       <div className={isLimitType ? 'mb-4' : 'mb-2'}>
         {useNotional && (
           <Controller
@@ -1331,27 +1334,5 @@ const PlaceOrderButton = ({
 
   const subLabel = `${baseText} @ ${quoteText}`;
 
-  return (
-    <button
-      data-testid="place-order"
-      type="submit"
-      className={classNames(
-        'w-full flex flex-col justify-center items-center rounded text-vega-clight-800 p-2 transition-colors',
-        {
-          'bg-vega-red-500 enabled:hover:bg-vega-red-550 dark:bg-vega-red-600 dark:enabled:hover:bg-vega-red-650':
-            side === Schema.Side.SIDE_SELL,
-          'bg-vega-green-600 enabled:hover:bg-vega-green-650 dark:bg-vega-green-650 dark:enabled:hover:bg-vega-green-600':
-            side === Schema.Side.SIDE_BUY,
-        }
-      )}
-    >
-      <span>{text}</span>
-      <span
-        className="text-xs font-mono leading-4 text-vega-clight-800/60"
-        key="trading-button-sub-label"
-      >
-        {subLabel}
-      </span>
-    </button>
-  );
+  return <SubmitButton text={text} subLabel={subLabel} side={side} />;
 };

--- a/libs/deal-ticket/src/components/deal-ticket/side-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/side-selector.tsx
@@ -42,7 +42,7 @@ export const SideSelector = ({
   return (
     <RadioGroup.Root
       name="order-side"
-      className="relative mb-4 flex h-10 leading-10 bg-vega-clight-700 dark:bg-vega-cdark-700 rounded"
+      className="relative flex h-10 leading-10 bg-vega-clight-700 dark:bg-vega-cdark-700 rounded"
       {...props}
     >
       <span

--- a/libs/deal-ticket/src/components/deal-ticket/submit-button.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/submit-button.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from 'react';
+import classNames from 'classnames';
+
+import { Side } from '@vegaprotocol/types';
+
+export const SubmitButton = ({
+  text,
+  subLabel,
+  side,
+}: {
+  text: string;
+  subLabel: ReactNode;
+  side: Side;
+}) => {
+  return (
+    <button
+      data-testid="place-order"
+      type="submit"
+      className={classNames(
+        'w-full flex flex-col justify-center items-center rounded text-vega-clight-800 p-2 transition-colors',
+        {
+          'bg-vega-red-500 enabled:hover:bg-vega-red-550 dark:bg-vega-red-600 dark:enabled:hover:bg-vega-red-650':
+            side === Side.SIDE_SELL,
+          'bg-vega-green-600 enabled:hover:bg-vega-green-650 dark:bg-vega-green-650 dark:enabled:hover:bg-vega-green-600':
+            side === Side.SIDE_BUY,
+        }
+      )}
+    >
+      <span>{text}</span>
+      <span
+        className="text-xs font-mono leading-4 text-vega-clight-800/60"
+        key="trading-button-sub-label"
+      >
+        {subLabel}
+      </span>
+    </button>
+  );
+};

--- a/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
@@ -192,8 +192,9 @@ export const TypeSelector = ({
   return (
     <>
       <TypeToggle
-        onValueChange={(value) => {
-          onValueChange(value as DealTicketType);
+        onValueChange={(v) => {
+          if (v === ('' as DealTicketType)) return;
+          onValueChange(v);
         }}
         value={value}
       />

--- a/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
@@ -55,11 +55,11 @@ export const TypeToggle = ({
   const toggles = useToggles();
   const selectedStopOption = stopOptions.find((t) => t.value === value);
   const showStopOrdersDropdown = featureFlags.STOP_ORDERS;
-  const toggleClasses = 'flex-1 px-2 -mb-px';
+  const toggleClasses = 'flex-1 -mb-px p-1.5 border-b-2 border-b-transparent';
 
   return (
     <ToggleGroup.Root
-      className="flex h-8 leading-8 font-alpha text-xs border-b border-default"
+      className="flex border-b border-default"
       type="single"
       value={value}
       onValueChange={onValueChange}
@@ -72,7 +72,7 @@ export const TypeToggle = ({
           data-testid={`order-type-${itemValue}`}
           className={classNames(
             toggleClasses,
-            'data-[state=on]:border-b-vega-clight-400 dark:data-[state=on]:border-b-vega-cdark-400 data-[state=on]:border-b-2'
+            'data-[state=on]:border-b-vega-clight-400 dark:data-[state=on]:border-b-vega-cdark-400'
           )}
         >
           {label}
@@ -89,7 +89,7 @@ export const TypeToggle = ({
                   toggleClasses,
                   'flex gap-1 justify-center items-center',
                   {
-                    'border-b-2 border-b-vega-clight-400 dark:border-b-vega-cdark-400':
+                    'border-b-vega-clight-400 dark:border-b-vega-cdark-400':
                       selectedStopOption,
                   }
                 )}

--- a/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
+++ b/libs/deal-ticket/src/components/deal-ticket/type-selector.tsx
@@ -16,7 +16,7 @@ import type { Market, StaticMarketData } from '@vegaprotocol/markets';
 import { compileGridData } from '../trading-mode-tooltip';
 import { MarketModeValidationType } from '../../constants';
 import { DealTicketType } from '@vegaprotocol/react-helpers';
-import * as RadioGroup from '@radix-ui/react-radio-group';
+import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import classNames from 'classnames';
 import { useFeatureFlags } from '@vegaprotocol/environment';
 import { Trans } from 'react-i18next';
@@ -28,7 +28,6 @@ interface TypeSelectorProps {
   market: Market;
   marketData: StaticMarketData;
   errorMessage?: string;
-  showStopOrders: boolean;
 }
 
 const useToggles = () => {
@@ -52,53 +51,50 @@ export const TypeToggle = ({
 }: Pick<TypeSelectorProps, 'onValueChange' | 'value'>) => {
   const featureFlags = useFeatureFlags((state) => state.flags);
   const t = useT();
-  const options = useOptions();
+  const stopOptions = useOptions();
   const toggles = useToggles();
-  const selectedOption = options.find((t) => t.value === value);
+  const selectedStopOption = stopOptions.find((t) => t.value === value);
   const showStopOrdersDropdown = featureFlags.STOP_ORDERS;
+  const toggleClasses = 'flex-1 px-2 -mb-px';
+
   return (
-    <RadioGroup.Root
-      name="order-type"
-      className={classNames('mb-2 grid h-8 leading-8 font-alpha text-xs', {
-        'grid-cols-3': showStopOrdersDropdown,
-        'grid-cols-2': !showStopOrdersDropdown,
-      })}
+    <ToggleGroup.Root
+      className="flex h-8 leading-8 font-alpha text-xs border-b border-default"
+      type="single"
       value={value}
       onValueChange={onValueChange}
     >
       {toggles.map(({ label, value: itemValue }) => (
-        <RadioGroup.Item
+        <ToggleGroup.Item
           value={itemValue}
           key={itemValue}
           id={`order-type-${itemValue}`}
           data-testid={`order-type-${itemValue}`}
-          asChild
+          className={classNames(
+            toggleClasses,
+            'data-[state=on]:border-b-vega-clight-400 dark:data-[state=on]:border-b-vega-cdark-400 data-[state=on]:border-b-2'
+          )}
         >
-          <button
-            className={classNames('rounded', {
-              'bg-vega-clight-500 dark:bg-vega-cdark-500': value === itemValue,
-            })}
-          >
-            {label}
-          </button>
-        </RadioGroup.Item>
+          {label}
+        </ToggleGroup.Item>
       ))}
       {showStopOrdersDropdown && (
         <TradingDropdown
           trigger={
-            <TradingDropdownTrigger
-              data-testid="order-type-Stop"
-              className={classNames(
-                'rounded px-2 flex flex-nowrap items-center justify-center',
-                {
-                  'bg-vega-clight-500 dark:bg-vega-cdark-500': selectedOption,
-                }
-              )}
-            >
-              <button className="flex gap-1">
-                <span className="text-ellipsis whitespace-nowrap shrink overflow-hidden">
-                  {selectedOption ? selectedOption.label : t('Stop')}
-                </span>
+            <TradingDropdownTrigger>
+              <button
+                id="order-type-stop"
+                data-testid="order-type-Stop"
+                className={classNames(
+                  toggleClasses,
+                  'flex gap-1 justify-center items-center',
+                  {
+                    'border-b-2 border-b-vega-clight-400 dark:border-b-vega-cdark-400':
+                      selectedStopOption,
+                  }
+                )}
+              >
+                {selectedStopOption ? selectedStopOption.label : t('Stop')}
                 <VegaIcon name={VegaIconNames.CHEVRON_DOWN} size={14} />
               </button>
             </TradingDropdownTrigger>
@@ -112,7 +108,7 @@ export const TypeToggle = ({
                 }
                 value={value}
               >
-                {options.map(({ label, value: itemValue }) => (
+                {stopOptions.map(({ label, value: itemValue }) => (
                   <TradingDropdownRadioItem
                     key={itemValue}
                     value={itemValue}
@@ -129,7 +125,7 @@ export const TypeToggle = ({
           </TradingDropdownPortal>
         </TradingDropdown>
       )}
-    </RadioGroup.Root>
+    </ToggleGroup.Root>
   );
 };
 
@@ -139,7 +135,6 @@ export const TypeSelector = ({
   market,
   marketData,
   errorMessage,
-  showStopOrders,
 }: TypeSelectorProps) => {
   const t = useT();
   const renderError = (errorType: MarketModeValidationType) => {


### PR DESCRIPTION
# Related issues 🔗

#6574 

# Description ℹ️

- Changes type selector ui
- Makes a specific deal ticket submit button so it can be shared between stop and normal orders
- Adjusts components to not create spacing with margin (that should be the responsibility of the parent)

# Demo 📺

![Screenshot 2024-06-28 at 16 48 38](https://github.com/vegaprotocol/frontend-monorepo/assets/6803987/645071be-b0a6-4029-a4a5-a54d41b24670)
