### PR TITLE
fix(trading): hover color for asset card in sidebar

### DIFF
--- a/apps/trading/components/sidebar/sidebar.tsx
+++ b/apps/trading/components/sidebar/sidebar.tsx
@@ -92,13 +92,10 @@ export const Sidebar = ({ pinnedAssets }: { pinnedAssets?: string[] }) => {
             <SidebarAccordionHeader>
               <AccordionPrimitive.Trigger
                 data-testid="Assets"
-                className={classNames(
-                  'grid w-full bg-vega-clight-700 dark:bg-vega-cdark-700',
-                  {
-                    'grid-cols-2': pinnedAssets.length === 2,
-                    'grid-cols-1': pinnedAssets.length === 1,
-                  }
-                )}
+                className={classNames('grid w-full', {
+                  'grid-cols-2': pinnedAssets.length === 2,
+                  'grid-cols-1': pinnedAssets.length === 1,
+                })}
               >
                 {pinnedAssets.map((assetId) => (
                   <AssetCard


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Removes bg color for the asset card accordion trigger, instead letting the header bg color show which includes the hover state.