### PR TITLE
fix(explorer): emblem alignment

### DIFF
--- a/apps/explorer/src/app/components/links/market-link/market-link.tsx
+++ b/apps/explorer/src/app/components/links/market-link/market-link.tsx
@@ -48,23 +48,27 @@ const MarketLink = ({
   if (showMarketName) {
     return (
       <Link
-        className="underline"
+        className="underline flex leading-loose"
         {...props}
         to={`/${Routes.MARKETS}/${id}`}
         title={id}
       >
-        <span className="mr-1">
+        <div className="mr-1">
           <EmblemWithChain market={id} />
-        </span>
+        </div>
         {label}
       </Link>
     );
   } else {
     return (
-      <Link className="underline" {...props} to={`/${Routes.MARKETS}/${id}`}>
-        <span className="mr-1">
+      <Link
+        className="underline leading-loose flex"
+        {...props}
+        to={`/${Routes.MARKETS}/${id}`}
+      >
+        <div className="mr-1">
           <EmblemWithChain market={id} />
-        </span>
+        </div>
         <Hash text={id} />
       </Link>
     );

--- a/libs/ui-toolkit/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/libs/ui-toolkit/src/components/breadcrumbs/breadcrumbs.tsx
@@ -14,8 +14,8 @@ export const Breadcrumbs = ({
     <li
       key={i}
       className={classNames(
-        'before:content-["/"] before:pr-2 before:text-vega-light-300 dark:before:text-vega-dark-300',
-        'overflow-hidden text-ellipsis'
+        'before:content-["/"] before:pr-2 before:text-vega-light-300 dark:before:text-vega-dark-300 before:float-left',
+        'overflow-hidden text-ellipsis leading-loose'
       )}
     >
       {crumb}


### PR DESCRIPTION
# Related issues 🔗

Closes #6634

# Description ℹ️

Fixes the alignment of Emblems in MarketLinks



# Demo 📺

<img width="595" alt="Screenshot 2024-07-03 at 12 40 23" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/4bea5a0b-4597-44d3-9df6-82cf54a82f9a">
<img width="1615" alt="Screenshot 2024-07-03 at 12 40 13" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/0abda800-80df-41d3-b1fb-477568f4e340">
<img width="492" alt="Screenshot 2024-07-03 at 12 40 19" src="https://github.com/vegaprotocol/frontend-monorepo/assets/6678/001ff5fb-ce7e-4e1b-b8f8-feeb1cb3a65d">