### PR TITLE
fix(accounts): incorrect asset balance shown on transfer form

### DIFF
--- a/libs/accounts/src/lib/transfer-form.tsx
+++ b/libs/accounts/src/lib/transfer-form.tsx
@@ -593,9 +593,7 @@ const AssetOption = ({
             : asset.source.__typename}
         </div>
       </div>
-      <div className="ml-auto text-sm">
-        {addDecimalsFormatNumber(asset.balance, asset.decimals)}
-      </div>
+      <div className="ml-auto text-sm">{asset.balance}</div>
     </div>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #6648 

# Description ℹ️

Asset balance was being formatted by decimal places twice