### PR TITLE
fix(trading): dont filter out assets without balance in deposit form

### DIFF
--- a/apps/trading/lib/hooks/use-assets-with-balance.ts
+++ b/apps/trading/lib/hooks/use-assets-with-balance.ts
@@ -42,21 +42,15 @@ export const useAssetsWithBalance = () => {
   });
 
   // Add the foreign wallet balance to our array of assets
-  const withBalance = assets
-    .map((a, i) => {
-      let balance = '';
+  const withBalance = assets.map((a, i) => {
+    let balance = '';
 
-      if (balanceData && balanceData[i].result) {
-        balance = (balanceData[i].result as bigint).toString();
-      }
+    if (balanceData && balanceData[i].result) {
+      balance = (balanceData[i].result as bigint).toString();
+    }
 
-      return { ...a, balance };
-    })
-    .filter((a) => {
-      if (a.balance === '') return false;
-      if (a.balance === '0') return false;
-      return true;
-    });
+    return { ...a, balance };
+  });
 
   return {
     ...queryResult,


### PR DESCRIPTION
# Related issues 🔗

Closes #6652 

# Description ℹ️

Filtering out all assets meant that if your wallet isn't connected we were not showing any assets in the dropdown. By keeping them in the selected asset is always present