### PR TITLE
chore(trading): use n06 node by default on testnet

### DIFF
--- a/apps/trading/.env.testnet
+++ b/apps/trading/.env.testnet
@@ -38,4 +38,4 @@ NX_CHARTING_LIBRARY_HASH=PDjWaqPFndDp+LCvqbKvntWriaqNzNpZ5i9R/BULzCg=
 
 NX_VEGA_NETWORKS={\"MAINNET\":\"https://console.vega.xyz\",\"TESTNET\":\"https://console.fairground.wtf\",\"STAGNET1\":\"https://trading.stagnet1.vega.rocks\"}
 
-NX_VEGA_URL=https://api.n00.testnet.vega.rocks/graphql
+NX_VEGA_URL=https://api.n06.testnet.vega.rocks/graphql

--- a/libs/environment/src/hooks/use-environment.ts
+++ b/libs/environment/src/hooks/use-environment.ts
@@ -40,7 +40,7 @@ type Actions = {
 export type Env = Environment & EnvState;
 export type EnvStore = Env & Actions;
 
-const VERSION = 1;
+const VERSION = 2;
 export const STORAGE_KEY = `vega_url_${VERSION}`;
 
 const QUERY_TIMEOUT = 3000;


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

The n06 node is faster