### PR TITLE
fix(ci): governance tests

### DIFF
--- a/.github/actions/run-vegacapsule/action.yml
+++ b/.github/actions/run-vegacapsule/action.yml
@@ -9,6 +9,8 @@ runs:
       shell: bash
       run: |
         sudo pkill -9 nomad || echo;
+        sudo pkill -9 vega || echo;
+        sudo pkill -9 visor || echo;
         rm -rf /home/github-runner/.vegacapsule || echo
         docker stop $(docker ps -a -q) || echo
         docker rm $(docker ps -a -q) || echo

--- a/apps/explorer-e2e/README.md
+++ b/apps/explorer-e2e/README.md
@@ -32,6 +32,10 @@ vegacapsule network bootstrap --config-path=../frontend-monorepo/vegacapsule/con
 
 - You may need to run `vegacapsule nodes unsafe-reset-all` to get a clean network state
 
+### Troubleshooting on the remove server
+
+See this guide at [apps/governance-e2e/README.md](../governance-e2e/README.md)
+
 ## Vega Wallet Setup
 
 You can then refer to (or run) `frontend-monorepo/vegacapsule/setup-vegawallet.sh`. This will initialise and configure your wallet to have the correct public keys and network config to run against capsule.

--- a/apps/governance-e2e/README.md
+++ b/apps/governance-e2e/README.md
@@ -63,7 +63,12 @@ yarn build;
 # bootstrap a new network
 vegacapsule network bootstrap --config-path ./vegacapsule/config.hcl --force --do-not-stop-on-failure;
 
-# Run tests
+# setup vegawallet
+cd ./vegacapsule;
+chmod a+x setup-vegawallet.sh;
+./setup-vegawallet.sh;
+
+# run tests
 XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr \
     yarn nx run governance-e2e:e2e  \
         --browser chrome \
@@ -71,7 +76,8 @@ XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr \
         --verbose \
         --runner-ui \
         --headed \
-        --spec "./apps/governance-e2e/src/integration/view/home.cy.ts"
+        --spec "./apps/governance-e2e/src/integration/view/home.cy.ts" \
+        --no-exit
 ```
 
 ## Vega Wallet Setup

--- a/apps/governance/project.json
+++ b/apps/governance/project.json
@@ -45,6 +45,8 @@
       "executor": "@nx/webpack:dev-server",
       "options": {
         "port": 4210,
+        "host": "0.0.0.0",
+        "allowedHosts": "all",
         "buildTarget": "governance:build:development",
         "hmr": true
       },


### PR DESCRIPTION
# Description ℹ️

Changes:

1. Allow dev server for governance to listen on all interfaces not only on 127.0.0.1(localhost) - it helps to debug and allow access from the external network.
2. Cleanup leftover processes before start new vegacapsule network(it looks like sometimes vega wallet - started by GH action - sometimes is not stopped properly)
3. Adding steps to troubleshoot on remote serer.

# Demo 📺

Gif/video/images of new/corrected functionality if applicable

# Technical 👨‍🔧

Details of technical implementation that reviewers may need to be aware of, if applicable.
