### PR TITLE
feat(explorer): use well-known oracle data on explorer oracle by id page

### DIFF
--- a/apps/explorer/src/app/config/env.ts
+++ b/apps/explorer/src/app/config/env.ts
@@ -12,6 +12,7 @@ export const ENV = {
   dsn: windowOrDefault('NX_EXPLORER_SENTRY_DSN'),
   dataSources: {
     blockExplorerUrl: windowOrDefault('NX_BLOCK_EXPLORER'),
+    oracleProofsUrl: windowOrDefault('NX_ORACLE_PROOFS_URL'),
     tendermintUrl: windowOrDefault('NX_TENDERMINT_URL'),
     tendermintWebsocketUrl: windowOrDefault('NX_TENDERMINT_WEBSOCKET_URL'),
     governanceUrl: windowOrDefault('NX_VEGA_GOVERNANCE_URL'),

--- a/apps/explorer/src/app/routes/oracles/components/oracle-data.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-data.tsx
@@ -39,7 +39,7 @@ export function OracleData({ data }: OracleDataTypeProps) {
             }
 
             return (
-              <tr key={d.node.externalData.data.broadcastAt}>
+              <tr key={d.node.externalData.data.broadcastAt + node.value}>
                 <td className={`${cellSpacing} font-mono`}>{node.value}</td>
                 <td className={`${cellSpacing} font-mono`}>{node.name}</td>
                 <td className={cellSpacing}>

--- a/apps/explorer/src/app/routes/oracles/components/oracle-signers.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-signers.tsx
@@ -57,18 +57,24 @@ export function getAddressLink(signer: Signer) {
   return <span>{address}</span>;
 }
 
+export function getAddressesOrNothing(sourceType: SourceType): string | null {
+  if (sourceType.__typename !== 'DataSourceDefinitionExternal') {
+    return null;
+  }
+
+  switch (sourceType.sourceType.__typename) {
+    case 'EthCallSpec':
+      return sourceType.sourceType.address;
+  }
+
+  return null;
+}
+
 interface OracleDetailsSignersProps {
   sourceType: SourceType;
 }
 
-/**
- * Given an Oracle, this component will render either a link to Ethereum
- * or the Vega party depending on which type is specified.
- *
- * Note that this won't be shown for external contract calls as they do not
- * have a signer in the same way.
- */
-export function OracleSigners({ sourceType }: OracleDetailsSignersProps) {
+export function getSignersOrNothing(sourceType: SourceType) {
   if (sourceType.__typename !== 'DataSourceDefinitionExternal') {
     return null;
   }
@@ -81,18 +87,37 @@ export function OracleSigners({ sourceType }: OracleDetailsSignersProps) {
     return null;
   }
 
+  return signers.map((s) => s.signer);
+}
+
+interface OracleDetailsSignersProps {
+  sourceType: SourceType;
+}
+
+/**
+ * Given an Oracle, this component will render either a link to Ethereum
+ * or the Vega party depending on which type is specified.
+ *
+ * Note that this won't be shown for external contract calls as they do not
+ * have a signer in the same way.
+ */
+export function OracleSigners({ sourceType }: OracleDetailsSignersProps) {
+  const signers = getSignersOrNothing(sourceType);
+
+  if (!signers) {
+    return null;
+  }
+
   return (
     <>
       {signers.map((s) => {
         return (
-          <TableRow modifier="bordered" key={getAddress(s.signer)}>
+          <TableRow modifier="bordered" key={getAddress(s)}>
             <TableHeader scope="row">Signer</TableHeader>
             <TableCell modifier="bordered">
               <div>
-                <span data-testid="keytype">
-                  {getAddressTypeLabel(s.signer)}
-                </span>
-                : {getAddressLink(s.signer)}
+                <span data-testid="keytype">{getAddressTypeLabel(s)}</span>:{' '}
+                {getAddressLink(s)}
               </div>
             </TableCell>
           </TableRow>

--- a/apps/explorer/src/app/routes/oracles/components/oracle-verified-status-icon.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle-verified-status-icon.tsx
@@ -1,0 +1,40 @@
+import { useVerifiedStatusIcon } from '@vegaprotocol/markets';
+import type { Provider } from '@vegaprotocol/markets';
+import { Icon, type IconName, Intent } from '@vegaprotocol/ui-toolkit';
+import classNames from 'classnames';
+
+export type OracleVerifiedStatusIconProps = {
+  provider: Provider;
+};
+
+/**
+ * Modified, but close to the OracleBasicOProfile in the markets lib. This is
+ * required to better fit with the Explorer layout
+ *
+ * @param provider Oracle proof
+ * @returns
+ */
+export const OracleVerifiedStatusIcon = ({
+  provider,
+}: OracleVerifiedStatusIconProps) => {
+  const { icon, message, intent } = useVerifiedStatusIcon(provider);
+  return (
+    <div
+      className={classNames(
+        {
+          'text-gray-700 dark:text-gray-300': intent === Intent.None,
+          'text-vega-blue': intent === Intent.Primary,
+          'text-vega-green dark:text-vega-green': intent === Intent.Success,
+          'text-yellow-600 dark:text-yellow': intent === Intent.Warning,
+          'text-vega-red': intent === Intent.Danger,
+        },
+        'flex items-start align-text-bottom'
+      )}
+    >
+      <Icon size={5} name={icon as IconName} />
+      <p className="ml-1 text-sm dark:text-vega-light-100 text-vega-dark-100 align-text-middle">
+        {message}
+      </p>
+    </div>
+  );
+};

--- a/apps/explorer/src/app/routes/oracles/components/oracle.tsx
+++ b/apps/explorer/src/app/routes/oracles/components/oracle.tsx
@@ -13,13 +13,21 @@ import { OracleData } from './oracle-data';
 import { OracleFilter } from './oracle-filter';
 import { OracleDetailsType } from './oracle-details-type';
 import { OracleMarkets } from './oracle-markets';
-import { OracleSigners } from './oracle-signers';
+import { getAddressesOrNothing, OracleSigners } from './oracle-signers';
 import { OracleEthSource } from './oracle-eth-source';
 import Hash from '../../../components/links/hash';
 import { getStatusString } from '../../../components/links/oracle-link/oracle-link';
+import { useOracleProofs, OracleBranding } from '@vegaprotocol/markets';
+import { ENV } from '../../../config/env';
+import { OracleVerifiedStatusIcon } from './oracle-verified-status-icon';
+
+const brandedOracles = ['PYTH', 'UMA'];
 
 export type SourceType =
   ExplorerOracleDataSourceFragment['dataSourceSpec']['spec']['data']['sourceType'];
+
+export type OracleProofs = ReturnType<typeof useOracleProofs>;
+export type OracleProofData = OracleProofs['data'];
 
 interface OracleDetailsProps {
   id: string;
@@ -41,6 +49,9 @@ export const OracleDetails = ({
   dataSource,
   dataConnection,
 }: OracleDetailsProps) => {
+  const ORACLE_PROOFS_URL = ENV.dataSources.oracleProofsUrl;
+  const { data } = useOracleProofs(ORACLE_PROOFS_URL);
+
   const sourceType = dataSource.dataSourceSpec.spec.data.sourceType;
   const chain =
     dataSource.dataSourceSpec.spec.data.sourceType.sourceType.__typename ===
@@ -52,6 +63,9 @@ export const OracleDetails = ({
     (sourceType.sourceType.__typename === 'EthCallSpec' &&
       sourceType.sourceType.requiredConfirmations) ||
     '';
+
+  const address = getAddressesOrNothing(sourceType);
+  const proof = address ? getOracleDetailsFromProviders(address, data) : null;
 
   return (
     <div>
@@ -86,8 +100,44 @@ export const OracleDetails = ({
             <TableCell modifier="bordered">{requiredConfirmations}</TableCell>
           </TableRow>
         )}
+        {!!data && !!proof && (
+          <>
+            {proof?.type && brandedOracles.indexOf(proof.type) !== -1 && (
+              <TableRow modifier="bordered">
+                <TableHeader scope="row">{t('Provider')}</TableHeader>
+                <TableCell modifier="bordered">
+                  <OracleBranding type={proof.type} />
+                </TableCell>
+              </TableRow>
+            )}
+            {proof && (
+              <TableRow modifier="bordered">
+                <TableHeader scope="row">{t('Status')}</TableHeader>
+                <TableCell modifier="bordered">
+                  <OracleVerifiedStatusIcon provider={proof} />
+                </TableCell>
+              </TableRow>
+            )}
+          </>
+        )}
       </TableWithTbody>
       {dataConnection ? <OracleData data={dataConnection} /> : null}
     </div>
   );
 };
+
+export function getOracleDetailsFromProviders(
+  originAddress: string,
+  providers?: OracleProofData
+) {
+  const oracleDetails = providers?.find((provider) => {
+    switch (provider.oracle.type) {
+      case 'eth_address':
+        return provider.oracle.eth_address === originAddress;
+      default:
+        return false;
+    }
+  });
+
+  return oracleDetails;
+}

--- a/libs/markets/src/index.ts
+++ b/libs/markets/src/index.ts
@@ -1,1 +1,3 @@
+export { OracleBranding } from './lib/components/oracle-full-profile/oracle-branding';
+export { useVerifiedStatusIcon } from './lib/components/oracle-basic-profile/oracle-basic-profile';
 export * from './lib';


### PR DESCRIPTION
- **chore(markets): export extra components from market lib to aid consistency**
- **feat(explorer): add oracle logos and verified status to oracle by id page**

# Related issues 🔗

Closes #6630

# Description ℹ️

Reuses some of the well-known oracle functionality from Trading/markets lib to display a logo/verification status on the oracle page in explorer.

# Demo 📺

<img width="939" alt="Screenshot 2024-07-17 at 15 34 57" src="https://github.com/user-attachments/assets/26d1dd09-022a-4f29-8767-b003c6138bbb">
<img width="939" alt="Screenshot 2024-07-17 at 15 35 17" src="https://github.com/user-attachments/assets/c652c0cf-339c-4d18-a10b-796a22580432">
