### PR TITLE
fix(emblem): give emblems a bg color

### DIFF
--- a/libs/emblem/src/components/emblem-base.tsx
+++ b/libs/emblem/src/components/emblem-base.tsx
@@ -32,7 +32,7 @@ export function EmblemBase({ size = 30, ...p }: ImgProps) {
         width={size}
         height={size}
         className={className(
-          'rounded-full border-vega-light-600 dark:border-white',
+          'rounded-full bg-vega-light-600 border-vega-light-600 dark:bg-white dark:border-white',
           p.className
         )}
         onLoad={() => setLoading(false)}


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Gives emblems a bg color that matches the border color to avoid visual overlapping of the svg images