### PR TITLE
feat(emblem): simplify loading and use transparent image instead of black for loading

### DIFF
--- a/libs/emblem/src/components/emblem-base.test.tsx
+++ b/libs/emblem/src/components/emblem-base.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { EmblemBase } from './emblem-base';
+import { FALLBACK_URL } from '../config/';
 import React from 'react';
 
 describe('EmblemBase', () => {
@@ -7,10 +8,7 @@ describe('EmblemBase', () => {
     render(<EmblemBase />);
     const imageElement = screen.getByAltText('Emblem');
     expect(imageElement).toBeInTheDocument();
-    expect(imageElement).toHaveAttribute(
-      'src',
-      'https://icon.vega.xyz/missing.svg'
-    );
+    expect(imageElement).toHaveAttribute('src', FALLBACK_URL);
   });
 
   test('renders image with provided source', () => {
@@ -38,9 +36,6 @@ describe('EmblemBase', () => {
     const errorEvent = new Event('error');
     imageElement.dispatchEvent(errorEvent);
 
-    expect(imageElement).toHaveAttribute(
-      'src',
-      'https://icon.vega.xyz/missing.svg'
-    );
+    expect(imageElement).toHaveAttribute('src', FALLBACK_URL);
   });
 });

--- a/libs/emblem/src/components/emblem-base.tsx
+++ b/libs/emblem/src/components/emblem-base.tsx
@@ -1,8 +1,12 @@
-import type ImgHTMLAttributes from 'react';
 import { FALLBACK_URL } from '../config/index';
 import className from 'classnames';
 
-export type ImgProps = ImgHTMLAttributes<HTMLImageElement> & { size?: number };
+export type ImgProps = {
+  size?: number;
+  alt?: string;
+  src?: string;
+  className?: string;
+};
 
 /**
  * Renders an image tag with a known fallback if the emblem does not exist.

--- a/libs/emblem/src/components/emblem-base.tsx
+++ b/libs/emblem/src/components/emblem-base.tsx
@@ -1,4 +1,4 @@
-import { useState, type ImgHTMLAttributes } from 'react';
+import type ImgHTMLAttributes from 'react';
 import { FALLBACK_URL } from '../config/index';
 import className from 'classnames';
 
@@ -10,33 +10,22 @@ export type ImgProps = ImgHTMLAttributes<HTMLImageElement> & { size?: number };
  * @returns React.Node
  */
 export function EmblemBase({ size = 30, ...p }: ImgProps) {
-  // Used to render a holding image while the emblem is loading
-  const [loading, setLoading] = useState(true);
-
   // If loading the emblem fails, we use a remote fallback image
   const renderFallback = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = FALLBACK_URL;
   };
 
   return (
-    <>
-      <span style={{ display: loading ? 'inline-block' : 'none' }}>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 42">
-          <rect width="42" height="42" rx="21" />
-        </svg>
-      </span>
-      <img
-        src={p.src || FALLBACK_URL}
-        onError={renderFallback}
-        alt={p.alt ? p.alt : 'Emblem'}
-        width={size}
-        height={size}
-        className={className(
-          'rounded-full bg-vega-light-600 border-vega-light-600 dark:bg-white dark:border-white',
-          p.className
-        )}
-        onLoad={() => setLoading(false)}
-      />
-    </>
+    <img
+      src={p.src || FALLBACK_URL}
+      onError={renderFallback}
+      alt={p.alt ? p.alt : 'Emblem'}
+      width={size}
+      height={size}
+      className={className(
+        'rounded-full bg-vega-light-600 border-vega-light-600 dark:bg-white dark:border-white',
+        p.className
+      )}
+    />
   );
 }

--- a/libs/emblem/src/components/market-emblem.test.tsx
+++ b/libs/emblem/src/components/market-emblem.test.tsx
@@ -1,5 +1,5 @@
 import { getLogoPaths } from './market-emblem';
-
+import { LOADING } from '../config';
 describe('getLogoPaths', () => {
   it('should return correct logo paths when baseLogo and quoteLogo are provided', () => {
     const baseLogo = '/logo1.svg';
@@ -19,7 +19,7 @@ describe('getLogoPaths', () => {
     const quoteLogo = undefined;
     const expected = {
       base: 'https://icon.vega.xyz/logo1.svg',
-      quote: 'https://icon.vega.xyz/missing.svg',
+      quote: LOADING,
     };
 
     const result = getLogoPaths(baseLogo, quoteLogo);
@@ -31,7 +31,7 @@ describe('getLogoPaths', () => {
     const baseLogo = undefined;
     const quoteLogo = '/logo2.svg';
     const expected = {
-      base: 'https://icon.vega.xyz/missing.svg',
+      base: LOADING,
       quote: 'https://icon.vega.xyz/logo2.svg',
     };
 
@@ -44,8 +44,8 @@ describe('getLogoPaths', () => {
     const baseLogo = undefined;
     const quoteLogo = undefined;
     const expected = {
-      base: 'https://icon.vega.xyz/missing.svg',
-      quote: 'https://icon.vega.xyz/missing.svg',
+      base: LOADING,
+      quote: LOADING,
     };
 
     const result = getLogoPaths(baseLogo, quoteLogo);

--- a/libs/emblem/src/components/market-emblem.tsx
+++ b/libs/emblem/src/components/market-emblem.tsx
@@ -1,4 +1,4 @@
-import { URL_BASE } from '../config';
+import { URL_BASE, LOADING } from '../config';
 import { EmblemBase } from './emblem-base';
 import { useMarketInfo } from './hooks/use-market-info';
 import { getVegaChain } from './lib/get-chain';
@@ -114,11 +114,9 @@ export function getLogoPaths(
   quoteChainLogo?: string,
   settlementChainLogo?: string
 ): LogoPaths {
-  const missing = `${URL_BASE}/missing.svg`;
-
   return {
-    base: baseLogo ? `${URL_BASE}${baseLogo}` : missing,
-    quote: quoteLogo ? `${URL_BASE}${quoteLogo}` : missing,
+    base: baseLogo ? `${URL_BASE}${baseLogo}` : LOADING,
+    quote: quoteLogo ? `${URL_BASE}${quoteLogo}` : LOADING,
     quoteChain: quoteChainLogo ? `${URL_BASE}${quoteChainLogo}` : undefined,
     baseChain: baseChainLogo ? `${URL_BASE}${baseChainLogo}` : undefined,
     settlementChain: settlementChainLogo

--- a/libs/emblem/src/config/index.ts
+++ b/libs/emblem/src/config/index.ts
@@ -1,7 +1,12 @@
 export const URL_BASE = 'https://icon.vega.xyz';
 export const FILENAME = 'logo.svg';
 export const CHAIN_FILENAME = 'chain.svg';
-export const FALLBACK_URL = `${URL_BASE}/missing.svg`;
 
 export const DEFAULT_VEGA_CHAIN = 'vega-mainnet-0011';
 export const DEFAULT_CHAIN = '1';
+
+// Missing and Loaded are a very simple SVG< b64 encoded.
+// Loading is now TRANSPARENT, missing is BLACK
+// <svg width="250" height="250" viewBox="0 0 42 42" xmlns="http://www.w3.org/2000/svg" ><rect width="42" height="42" rx="21" fill="transparent" /></svg>
+export const FALLBACK_URL = `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUwIiBoZWlnaHQ9IjI1MCIgdmlld0JveD0iMCAwIDQyIDQyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciID48cmVjdCB3aWR0aD0iNDIiIGhlaWdodD0iNDIiIHJ4PSIyMSIgZmlsbD0iYmxhY2siIC8+PC9zdmc+`;
+export const LOADING = `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUwIiBoZWlnaHQ9IjI1MCIgdmlld0JveD0iMCAwIDQyIDQyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciID48cmVjdCB3aWR0aD0iNDIiIGhlaWdodD0iNDIiIHJ4PSIyMSIgZmlsbD0idHJhbnNwYXJlbnQiIC8+PC9zdmc+`;


### PR DESCRIPTION
# Related issues 🔗

Closes #6517. Closes #6564.

# Description ℹ️

Simplify the loading to make it a bit less jumpy. This is particularly for Market emblems, but 
changes the loading of EmblemBase so all should load slightly quicker.

- Add a transparent loading image, rather than the flash-of-black loading image
- Add base64 encoded loading & missing images, rather than loading blank images over the network
- Remove loading/useState listener on EmblemBase

