### PR TITLE
feat(trading): allow asset card to be expanded even if in read only mode

### DIFF
--- a/libs/accounts/src/lib/account-card.tsx
+++ b/libs/accounts/src/lib/account-card.tsx
@@ -106,7 +106,7 @@ export const AccountCard = ({
   partyId?: string;
 } & AssetActions) => {
   const t = useT();
-  const expandable = !!partyId && !isReadOnly;
+  const expandable = !!partyId;
   const [expanded, setExpanded] = useState(initialExpanded && expandable);
   const { chainId } = useChainId();
   const { data } = useDataProvider({
@@ -192,7 +192,7 @@ export const AccountCard = ({
           </button>
         )}
       </div>
-      {expandable && expanded ? (
+      {!isReadOnly && expandable && expanded ? (
         <div className="grid gap-1 grid-cols-4 p-3 pt-0">
           <TradingDropdown
             trigger={


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Allow account cards to be expanded in read only mode so you can see the account breakdown