### PR TITLE
chore(emblem): add publishing for emblem

### DIFF
--- a/libs/emblem/.gitignore
+++ b/libs/emblem/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/libs/emblem/package.json
+++ b/libs/emblem/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@vegaprotocol/emblem",
+  "type": "module",
+  "version": "0.0.7",
+  "license": "MIT",
+  "private": false,
+  "dependencies": {
+    "react": "^18.2.0",
+    "@vegaprotocol/i18n": "^0.0.5",
+    "i18next": "^23.7.6",
+    "classnames": "^2.5.1"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.16.2"
+  }
+}

--- a/libs/emblem/project.json
+++ b/libs/emblem/project.json
@@ -4,6 +4,31 @@
   "sourceRoot": "libs/emblem/src",
   "projectType": "library",
   "targets": {
+    "build": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/emblem",
+        "tsConfig": "libs/emblem/tsconfig.lib.json",
+        "project": "libs/emblem/package.json",
+        "entryFile": "libs/emblem/src/index.ts",
+        "external": ["react", "react-dom"],
+        "rollupConfig": "@nx/react/plugins/bundle-rollup",
+        "compiler": "swc",
+        "format": ["esm", "cjs"],
+        "assets": [
+          {
+            "glob": "libs/emblem/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs emblem {args.ver} {args.tag}",
+      "dependsOn": ["build"]
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],


### PR DESCRIPTION
# Related issues 🔗

Closes #6745

# Description ℹ️

Adds a package.json and publish step for emblem. This is required for vegaprotocol/nebula#40

# Technical 👨‍🔧

- add package.json
- update project.json with build and publish steps

Note: This has alreaedy been published (see: https://www.npmjs.com/package/@vegaprotocol/emblem), but has been published as 0.0.x so that we can tweak the config before reviewing the setup
