### PR TITLE
feat(trading): improve wallet connection flow when completing withdrawals

### DIFF
--- a/libs/accounts/src/lib/transfers-data-provider.ts
+++ b/libs/accounts/src/lib/transfers-data-provider.ts
@@ -1,42 +1,6 @@
 import compact from 'lodash/compact';
-import {
-  makeDataProvider,
-  useDataProvider,
-  defaultAppend as append,
-  type Cursor,
-} from '@vegaprotocol/data-provider';
-import {
-  TransfersDocument,
-  type TransfersQuery,
-  type TransferFieldsFragment,
-  type TransfersQueryVariables,
-} from './__generated__/Transfers';
+import { useTransfersQuery } from './__generated__/Transfers';
 import { type Pagination } from '@vegaprotocol/types';
-import { useEffect } from 'react';
-
-export const transfersProvider = makeDataProvider<
-  TransfersQuery,
-  Array<TransferFieldsFragment & Cursor>,
-  never,
-  never,
-  TransfersQueryVariables
->({
-  query: TransfersDocument,
-  getData: (responseData) => {
-    if (!responseData?.transfersConnection?.edges?.length) return [];
-
-    return compact(responseData.transfersConnection.edges).map((edge) => ({
-      ...edge.node.transfer,
-      cursor: edge.cursor,
-    }));
-  },
-  pagination: {
-    getPageInfo: (responseData: TransfersQuery) =>
-      responseData?.transfersConnection?.pageInfo || null,
-    append,
-    first: 1000,
-  },
-});
 
 export const useTransfers = ({
   pubKey,
@@ -45,21 +9,18 @@ export const useTransfers = ({
   pubKey?: string;
   pagination?: Pagination;
 }) => {
-  const { reload, ...queryResult } = useDataProvider({
-    dataProvider: transfersProvider,
+  const queryResult = useTransfersQuery({
     variables: { partyId: pubKey || '', pagination },
     skip: !pubKey,
+    pollInterval: 5000,
   });
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      reload();
-    }, 5000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, [reload]);
-
-  return queryResult;
+  return {
+    ...queryResult,
+    data: compact(queryResult.data?.transfersConnection?.edges).map((edge) => ({
+      ...edge.node.transfer,
+      cursor: edge.cursor,
+    })),
+    pageInfo: queryResult.data?.transfersConnection?.pageInfo,
+  };
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #6101 

# Description ℹ️

- Makes useTransfers just use generated query so that polling does not reset the data causing extra mounts/unmounts
- Remove the connectkit button and programatically open the connect modal