### PR TITLE
feat(trading): asset activity withdrawal completion flow

### DIFF
--- a/apps/trading/components/asset-activity/asset-activity.tsx
+++ b/apps/trading/components/asset-activity/asset-activity.tsx
@@ -247,6 +247,7 @@ export const AssetActivityDatagrid = ({
         rowData={rowData}
         pinnedTopRowData={pinnedTopRowData}
         overlayNoRowsTemplate={t('No data')}
+        rowClass="ag-highlight-pinned"
       />
       <Pagination
         count={rowData.length}

--- a/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
+++ b/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
@@ -13,6 +13,7 @@ import { useAccount, useReadContract } from 'wagmi';
 import { BRIDGE_ABI } from '@vegaprotocol/smart-contracts';
 import { useEffect, useRef, useState } from 'react';
 import { useModal } from 'connectkit';
+import { TradingButton as Button, Intent } from '@vegaprotocol/ui-toolkit';
 
 type Props = {
   data: RowWithdrawal;
@@ -152,7 +153,9 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
     return (
       <span className="flex gap-1 items-center">
         {t('Pending')}:{' '}
-        <button
+        <Button
+          intent={Intent.Secondary}
+          size="extra-small"
           onClick={() => {
             if (ethWalletStatus === 'disconnected') {
               modal.setOpen(true);
@@ -161,16 +164,12 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
 
             handleComplete();
           }}
-          className="underline underline-offset-4"
         >
           {t('Complete')}
-        </button>
-        <button
-          onClick={() => openDialog(data.detail.id)}
-          className="underline underline-offset-4"
-        >
+        </Button>
+        <Button size="extra-small" onClick={() => openDialog(data.detail.id)}>
           {t('View')}
-        </button>
+        </Button>
       </span>
     );
   }

--- a/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
+++ b/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
@@ -13,7 +13,12 @@ import { useAccount, useReadContract } from 'wagmi';
 import { BRIDGE_ABI } from '@vegaprotocol/smart-contracts';
 import { useEffect, useRef, useState } from 'react';
 import { useModal } from 'connectkit';
-import { TradingButton as Button, Intent } from '@vegaprotocol/ui-toolkit';
+import {
+  TradingButton as Button,
+  Intent,
+  VegaIcon,
+  VegaIconNames,
+} from '@vegaprotocol/ui-toolkit';
 
 type Props = {
   data: RowWithdrawal;
@@ -152,7 +157,6 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
   if (status === 'ready') {
     return (
       <span className="flex gap-1 items-center">
-        {t('Pending')}:{' '}
         <Button
           intent={Intent.Secondary}
           size="extra-small"
@@ -167,9 +171,12 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
         >
           {t('Complete')}
         </Button>
-        <Button size="extra-small" onClick={() => openDialog(data.detail.id)}>
-          {t('View')}
-        </Button>
+        <button
+          onClick={() => openDialog(data.detail.id)}
+          className="text-gs-100"
+        >
+          <VegaIcon name={VegaIconNames.INFO} className="mt-1" />
+        </button>
       </span>
     );
   }

--- a/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
+++ b/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
@@ -29,11 +29,10 @@ export const WithdrawalStatusCell = ({ data, openDialog }: Props) => {
 
 const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
   const t = useT();
-  const ethTxSent = useRef(false);
   const { status: ethWalletStatus } = useAccount();
   const { config } = useEthereumConfig();
   const { configs } = useEVMBridgeConfigs();
-  const { submitWithdraw } = useEvmWithdraw();
+  const { submitWithdraw, data: txData } = useEvmWithdraw();
   const { data: approval } = useWithdrawalApprovalQuery({
     variables: {
       withdrawalId: data.detail.id,
@@ -44,8 +43,7 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
     // The onConnect handler from useModal is called twice
     // so this is to make sure if a tx is already created we
     // dont immediately create another one
-    if (ethTxSent.current) return;
-    ethTxSent.current = true;
+    if (txData?.hash) return;
 
     const asset = data.asset;
 

--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -229,6 +229,10 @@ html [data-theme='dark'] {
   --ag-modal-overlay-background-color: rgb(var(--gs-800) / 50%);
 }
 
+.ag-theme-balham .ag-floating-top-container .ag-highlight-pinned {
+  background: theme(colors.vega.blue.300);
+}
+
 /* Dark variables */
 .ag-theme-balham-dark {
   --ag-background-color: theme(colors.gs.900);
@@ -246,6 +250,10 @@ html [data-theme='dark'] {
 .ag-theme-balham .ag-row.no-hover,
 .ag-theme-balham .ag-row.no-hover:hover {
   background: var(--ag-background-color);
+}
+
+.ag-theme-balham-dark .ag-floating-top-container .ag-highlight-pinned {
+  background: theme(colors.vega.blue.700);
 }
 
 /**

--- a/libs/accounts/src/lib/transfers-data-provider.ts
+++ b/libs/accounts/src/lib/transfers-data-provider.ts
@@ -1,42 +1,6 @@
 import compact from 'lodash/compact';
-import {
-  makeDataProvider,
-  useDataProvider,
-  defaultAppend as append,
-  type Cursor,
-} from '@vegaprotocol/data-provider';
-import {
-  TransfersDocument,
-  type TransfersQuery,
-  type TransferFieldsFragment,
-  type TransfersQueryVariables,
-} from './__generated__/Transfers';
+import { useTransfersQuery } from './__generated__/Transfers';
 import { type Pagination } from '@vegaprotocol/types';
-import { useEffect } from 'react';
-
-export const transfersProvider = makeDataProvider<
-  TransfersQuery,
-  Array<TransferFieldsFragment & Cursor>,
-  never,
-  never,
-  TransfersQueryVariables
->({
-  query: TransfersDocument,
-  getData: (responseData) => {
-    if (!responseData?.transfersConnection?.edges?.length) return [];
-
-    return compact(responseData.transfersConnection.edges).map((edge) => ({
-      ...edge.node.transfer,
-      cursor: edge.cursor,
-    }));
-  },
-  pagination: {
-    getPageInfo: (responseData: TransfersQuery) =>
-      responseData?.transfersConnection?.pageInfo || null,
-    append,
-    first: 1000,
-  },
-});
 
 export const useTransfers = ({
   pubKey,
@@ -45,21 +9,18 @@ export const useTransfers = ({
   pubKey?: string;
   pagination?: Pagination;
 }) => {
-  const { reload, ...queryResult } = useDataProvider({
-    dataProvider: transfersProvider,
+  const queryResult = useTransfersQuery({
     variables: { partyId: pubKey || '', pagination },
     skip: !pubKey,
+    pollInterval: 5000,
   });
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      reload();
-    }, 5000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, [reload]);
-
-  return queryResult;
+  return {
+    ...queryResult,
+    data: compact(queryResult.data?.transfersConnection?.edges).map((edge) => ({
+      ...edge.node.transfer,
+      cursor: edge.cursor,
+    })),
+    pageInfo: queryResult.data?.transfersConnection?.pageInfo,
+  };
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #6101 

# Description ℹ️

- Makes useTransfers just use generated query so that polling does not reset the data causing extra mounts/unmounts
- Remove the connectkit button and instead prompt connection and send tx using the same click handler.
- Replace 'view' button link with info icon
- Change complete button link to secondary button
- Highlight pinned withdraw rows with a light blue background

# Screenshot
![Screenshot 2024-08-12 at 12 46 41](https://github.com/user-attachments/assets/53571f23-0969-4e7c-9433-677311966771)

