### PR TITLE
feat(markets): add market insurance account to key market details

### DIFF
--- a/libs/markets/src/lib/components/market-info/market-info-panels.tsx
+++ b/libs/markets/src/lib/components/market-info/market-info-panels.tsx
@@ -49,6 +49,7 @@ import type {
   SignerKind,
 } from '@vegaprotocol/types';
 import {
+  AccountType,
   CompositePriceType,
   ConditionOperatorMapping,
   LiquidityFeeMethodMapping,
@@ -384,6 +385,23 @@ export const KeyDetailsInfoPanel = ({
 
   const assetDecimals = getAsset(market).decimals;
 
+  const marketInsuranceAccount = market.accountsConnection?.edges?.find(
+    (account) => {
+      if (!account || !account.node) return false;
+      if (account.node.type === AccountType.ACCOUNT_TYPE_INSURANCE) {
+        return true;
+      }
+      return false;
+    }
+  );
+
+  const marketInsuranceAccountBalance = marketInsuranceAccount?.node?.balance
+    ? addDecimalsFormatNumber(
+        marketInsuranceAccount.node.balance,
+        assetDecimals
+      )
+    : 0;
+
   return (
     <>
       <KeyValueTable>
@@ -419,6 +437,7 @@ export const KeyDetailsInfoPanel = ({
                 positionDecimalPlaces: market.positionDecimalPlaces,
                 settlementAssetDecimalPlaces: assetDecimals,
                 tickSize: determinePriceStep(market),
+                marketInsuranceAccount: marketInsuranceAccountBalance,
               }
             : {
                 name: market.tradableInstrument.instrument.name,
@@ -430,6 +449,7 @@ export const KeyDetailsInfoPanel = ({
                 positionDecimalPlaces: market.positionDecimalPlaces,
                 settlementAssetDecimalPlaces: assetDecimals,
                 tickSize: determinePriceStep(market),
+                marketInsuranceAccount: marketInsuranceAccountBalance,
               }
         }
         parentData={


### PR DESCRIPTION
# Related issues 🔗

Closes #6674

# Description ℹ️

Add the market's insurance account balance to the market details page on Explorer. The Global Insurance Account balance is still present, in the settlement asset panel. 
 
Note: Vercel build error is unrelated to this PR.

# Demo 📺


<img width="993" alt="Screenshot 2024-08-12 at 15 27 20" src="https://github.com/user-attachments/assets/23afc7d7-df75-4d39-acb0-0c50bfdab63b">
