### PR TITLE
feat(explorer): show the proposal ratioale component on proposal votes

### DIFF
--- a/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
+++ b/apps/explorer/src/app/components/txs/details/proposal/summary.tsx
@@ -92,9 +92,16 @@ export const ProposalSummary = ({
         </section>
       )}
       <div className="pt-5">
-        <button className="underline max-md:hidden mr-5" onClick={openDialog}>
-          {t('View terms')}
-        </button>{' '}
+        {terms && (
+          <>
+            <button
+              className="underline max-md:hidden mr-5"
+              onClick={openDialog}
+            >
+              {t('View terms')}
+            </button>{' '}
+          </>
+        )}
         <ProposalLink id={id} text={t('Full details')} />
         {terms && <ProposalDate terms={terms} id={id} />}
       </div>

--- a/apps/explorer/src/app/components/txs/details/tx-proposal-vote.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-proposal-vote.tsx
@@ -5,6 +5,8 @@ import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
 import ProposalLink from '../../links/proposal-link/proposal-link';
 import { VoteIcon } from '../../vote-icon/vote-icon';
+import { ProposalSummary } from './proposal/summary';
+import { useExplorerProposalQuery } from '../../links/proposal-link/__generated__/Proposal';
 
 interface TxProposalVoteProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -27,27 +29,50 @@ export const TxProposalVote = ({
   pubKey,
   blockData,
 }: TxProposalVoteProps) => {
+  const { data } = useExplorerProposalQuery({
+    variables: { id: txData?.command.voteSubmission.proposalId },
+  });
+
   if (!txData || !txData.command.voteSubmission) {
     return <>{t('Awaiting Block Explorer transaction details')}</>;
   }
 
   const vote = txData.command.voteSubmission.value === 'VALUE_YES';
 
+  const rationale =
+    data?.proposal?.__typename === 'Proposal'
+      ? {
+          description: data.proposal.rationale.description,
+          title: data.proposal.rationale.title,
+        }
+      : undefined;
+
   return (
-    <TableWithTbody className="mb-8" allowWrap={true}>
-      <TxDetailsShared txData={txData} pubKey={pubKey} blockData={blockData} />
-      <TableRow modifier="bordered">
-        <TableCell>{t('Proposal details')}</TableCell>
-        <TableCell>
-          <ProposalLink id={txData.command.voteSubmission.proposalId} />
-        </TableCell>
-      </TableRow>
-      <TableRow modifier="bordered">
-        <TableCell>{t('Vote')}</TableCell>
-        <TableCell>
-          <VoteIcon vote={vote} />
-        </TableCell>
-      </TableRow>
-    </TableWithTbody>
+    <>
+      <TableWithTbody className="mb-8" allowWrap={true}>
+        <TxDetailsShared
+          txData={txData}
+          pubKey={pubKey}
+          blockData={blockData}
+        />
+        <TableRow modifier="bordered">
+          <TableCell>{t('Proposal details')}</TableCell>
+          <TableCell>
+            <ProposalLink id={txData.command.voteSubmission.proposalId} />
+          </TableCell>
+        </TableRow>
+        <TableRow modifier="bordered">
+          <TableCell>{t('Vote')}</TableCell>
+          <TableCell>
+            <VoteIcon vote={vote} />
+          </TableCell>
+        </TableRow>
+      </TableWithTbody>
+      <ProposalSummary
+        id={txData.command.voteSubmission.proposalId}
+        rationale={rationale}
+        terms={undefined}
+      />
+    </>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #3698

# Description ℹ️

Closing off an easy old ticket. Proposal vote txs now show the proposal rationale (title and description). Previously they showed just a title in the details table at the top.

# Demo 📺
<img width="552" alt="Screenshot 2024-08-12 at 16 22 19" src="https://github.com/user-attachments/assets/c715f149-1db1-41f6-bddf-e3712c4063c0">

