### PR TITLE
fix(explorer): remove proposer priority chart

### DIFF
--- a/apps/explorer/src/app/routes/validators/validators-page.tsx
+++ b/apps/explorer/src/app/routes/validators/validators-page.tsx
@@ -271,20 +271,6 @@ export const ValidatorsPage = () => {
                             </div>
                           </div>
                         </KeyValueTableRow>
-                        <KeyValueTableRow>
-                          <div>{t('Proposer priority')}</div>
-                          <div className="w-44 text-right">
-                            <Rate
-                              value={tm?.proposerPriorityRatio}
-                              colour="orange"
-                              asPoint={true}
-                              zero={true}
-                            />
-                            <div className="text-[10px] leading-3">
-                              {tm?.proposerPriority.toString()}
-                            </div>
-                          </div>
-                        </KeyValueTableRow>
 
                         <KeyValueTableRow>
                           <div>{t('Stake share')}</div>


### PR DESCRIPTION
# Related issues 🔗

Closes #3152

# Description ℹ️

The original issue requested a description for the frequently changing Proposer Priority field. This PR instead just removes it. Proposer priority is only relevant for the Tendermint/CometBFT priority of the validator's place (see: https://docs.cometbft.com/v0.37/spec/consensus/proposer-selection) and the changes are not useful or meaningful for the explorer to display as the results are so short lived. Instead of displaying & explaining it, we're better of just not rendering it.

