### PR TITLE
ci(governance): update vega and capsule for e2e runs

### DIFF
--- a/.github/workflows/cypress-run.yml
+++ b/.github/workflows/cypress-run.yml
@@ -46,8 +46,8 @@ jobs:
     steps:
       - name: Install vega & vegacapsule
         run: |
-          sudo install-vega v0.77.6
-          sudo install-vegacapsule v0.77.6
+          sudo install-vega v0.78.0-preview.1
+          sudo install-vegacapsule v0.78.0-preview.1
 
       # Checks if skip cache was requested
       - name: Set skip-nx-cache flag


### PR DESCRIPTION
# Related issues 🔗

Closes #6810

# Description ℹ️

e2e tests are failing because 0.77.0 is *ancient*. v0.78.0-preview.1 has been tagged for 20 minutes by now
