### PR TITLE
chore(trading): default border color

### DIFF
--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -211,7 +211,7 @@
     --button-border-radius-lg: theme(borderRadius.lg);
 
     /* Border */
-    --border: rgb(var(--gs-200));
+    --border: rgb(var(--gs-300));
   }
 
   .dark {

--- a/apps/trading/pages/styles.css
+++ b/apps/trading/pages/styles.css
@@ -209,6 +209,9 @@
     --button-border-radius-sm: theme(borderRadius.DEFAULT);
     --button-border-radius-md: theme(borderRadius.DEFAULT);
     --button-border-radius-lg: theme(borderRadius.lg);
+
+    /* Border */
+    --border: rgb(var(--gs-200));
   }
 
   .dark {
@@ -246,6 +249,9 @@
     --dir-up-bg: var(--color-green-600);
     --dir-up-outline: var(--color-green-450);
     --dir-up-fg: var(--color-green);
+
+    /* Border */
+    --border: rgb(var(--gs-700));
   }
 }
 

--- a/libs/tailwindcss-config/src/theme.ts
+++ b/libs/tailwindcss-config/src/theme.ts
@@ -11,6 +11,9 @@ export const theme = {
     xxl: '1440px',
     xxxl: '1800px',
   },
+  borderColor: {
+    DEFAULT: 'var(--border)',
+  },
   borderRadius: {
     'button-xs': 'var(--button-border-radius-xs)',
     'button-sm': 'var(--button-border-radius-sm)',


### PR DESCRIPTION
No need to set `border-COLOR dark:border-ABOTHER-COLOR` anymore if the element should have the default border color.

