### PR TITLE
fix(trading): fix too many rpc calls

### DIFF
--- a/libs/accounts/src/lib/transfers-data-provider.ts
+++ b/libs/accounts/src/lib/transfers-data-provider.ts
@@ -12,7 +12,6 @@ import {
   type TransfersQueryVariables,
 } from './__generated__/Transfers';
 import { type Pagination } from '@vegaprotocol/types';
-import { useEffect } from 'react';
 
 export const transfersProvider = makeDataProvider<
   TransfersQuery,
@@ -50,16 +49,6 @@ export const useTransfers = ({
     variables: { partyId: pubKey || '', pagination },
     skip: !pubKey,
   });
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      reload();
-    }, 5000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, [reload]);
 
   return queryResult;
 };


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

The polling of transfers was causing the withdrawal status component to unmount and remount thus triggering an rpc call for the withdrawal delay time on every mount. 