### PR TITLE
fix(explorer): improve AMM submit and amend views

### DIFF
--- a/apps/explorer/src/app/components/blocks/blocks-refetch.tsx
+++ b/apps/explorer/src/app/components/blocks/blocks-refetch.tsx
@@ -14,8 +14,8 @@ export const BlocksRefetch = ({ refetch }: BlocksRefetchProps) => {
     <Button
       onClick={refresh}
       data-testid="refresh"
+      className="text-surface-2-fg"
       size="xs"
-      className="dark:text-white"
     >
       <Icon name="refresh" size={3} />
       {t('Load new')}

--- a/apps/explorer/src/app/components/blocks/blocks-refetch.tsx
+++ b/apps/explorer/src/app/components/blocks/blocks-refetch.tsx
@@ -11,7 +11,12 @@ export const BlocksRefetch = ({ refetch }: BlocksRefetchProps) => {
   };
 
   return (
-    <Button onClick={refresh} data-testid="refresh" size="xs">
+    <Button
+      onClick={refresh}
+      data-testid="refresh"
+      size="xs"
+      className="dark:text-white"
+    >
       <Icon name="refresh" size={3} />
       {t('Load new')}
     </Button>

--- a/apps/explorer/src/app/components/links/external-explorer-link/external-chain-icon.tsx
+++ b/apps/explorer/src/app/components/links/external-explorer-link/external-chain-icon.tsx
@@ -8,6 +8,7 @@ export const SUPPORTED_CHAIN_ICON_URLS: ChainIdMapping = {
   '1': '/assets/chain-eth-logo.svg',
   '100': '/assets/chain-gno-logo.svg',
   '42161': '/assets/chain-arb-logo.svg',
+  '421614': '/assets/chain-arb-logo.svg',
   '11155111': '/assets/chain-eth-logo.svg',
 };
 

--- a/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
+++ b/apps/explorer/src/app/components/size-in-market/size-in-market.tsx
@@ -1,12 +1,13 @@
 import { addDecimalsFormatNumber } from '@vegaprotocol/utils';
 import { useExplorerMarketQuery } from '../links/market-link/__generated__/Market';
 
-export type DecimalSource = 'MARKET';
+export type DecimalSource = 'MARKET' | 'ASSET';
 
 export type SizeInMarketProps = {
   marketId: string;
   size?: string | number;
   decimalSource?: DecimalSource;
+  showAssetLabel?: boolean;
 };
 
 /**
@@ -17,6 +18,7 @@ export const SizeInMarket = ({
   marketId,
   size,
   decimalSource = 'MARKET',
+  showAssetLabel = false,
 }: SizeInMarketProps) => {
   const { data } = useExplorerMarketQuery({
     variables: { id: marketId },
@@ -27,16 +29,48 @@ export const SizeInMarket = ({
   }
 
   let label = size;
+  let assetLabel = '';
+  if (
+    data?.market?.tradableInstrument.instrument.product.__typename === 'Future'
+  ) {
+    assetLabel = data?.market.tradableInstrument.instrument.product.quoteName;
+  } else if (
+    data?.market?.tradableInstrument.instrument.product.__typename ===
+    'Perpetual'
+  ) {
+    assetLabel = data?.market.tradableInstrument.instrument.product.quoteName;
+  }
 
   if (data) {
     if (decimalSource === 'MARKET' && data.market?.positionDecimalPlaces) {
       label = addDecimalsFormatNumber(size, data.market.positionDecimalPlaces);
+    } else if (decimalSource === 'ASSET') {
+      let decimals = 0;
+      if (
+        data.market?.tradableInstrument.instrument.product.__typename ===
+        'Future'
+      ) {
+        decimals =
+          data.market.tradableInstrument.instrument.product.settlementAsset
+            .decimals;
+      } else if (
+        data.market?.tradableInstrument.instrument.product.__typename ===
+        'Perpetual'
+      ) {
+        decimals =
+          data.market.tradableInstrument.instrument.product.settlementAsset
+            .decimals;
+      }
+      label = addDecimalsFormatNumber(size, decimals);
     }
   }
 
   return (
     <label>
       <span>{label}</span>
+      {showAssetLabel && assetLabel !== '' && (
+        <code className="ml-1">{assetLabel}</code>
+      )}
     </label>
   );
 };

--- a/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
+++ b/apps/explorer/src/app/components/txs/details/chain-response-code/chain-reponse.code.tsx
@@ -39,11 +39,10 @@ export const ChainResponseCode = ({
 
   const isSuccess = successCodes.has(code);
   const size = small ? 3 : 4;
-  const successColour = code === 71 ? '!fill-orange' : '!fill-green-600';
   const icon = isSuccess ? (
-    <Icon size={size} name="tick-circle" className={`${successColour}`} />
+    <Icon size={size} name="tick-circle" className="fill-surface-2-fg" />
   ) : (
-    <Icon size={size} name="cross" className="!fill-pink-500" />
+    <Icon size={size} name="cross" className="!fill-red-500" />
   );
   const label = ErrorCodes.get(code) || 'Unknown response code';
 

--- a/apps/explorer/src/app/components/txs/details/tx-amm-amend.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-amm-amend.tsx
@@ -5,7 +5,7 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
 import type { components } from '../../../../types/explorer';
-import PriceInMarket from '../../price-in-market/price-in-market';
+import SizeInMarket from '../../size-in-market/size-in-market';
 import { ConcentratedLiquidityParametersDetails } from './amm/amm-liquidity-parameters';
 
 interface TxDetailsAMMAmendProps {
@@ -53,7 +53,12 @@ export const TxDetailsAMMAmend = ({
         <TableRow modifier="bordered">
           <TableCell>{t('Amount')}</TableCell>
           <TableCell>
-            <PriceInMarket marketId={marketId} price={commitmentAmount} />
+            <SizeInMarket
+              marketId={marketId}
+              size={commitmentAmount}
+              decimalSource="ASSET"
+              showAssetLabel={true}
+            />
           </TableCell>
         </TableRow>
       )}
@@ -61,18 +66,14 @@ export const TxDetailsAMMAmend = ({
       {proposedFee && marketId && (
         <TableRow modifier="bordered">
           <TableCell>{t('Proposed Fee')}</TableCell>
-          <TableCell>
-            <PriceInMarket marketId={marketId} price={proposedFee} />
-          </TableCell>
+          <TableCell>{proposedFee}%</TableCell>
         </TableRow>
       )}
 
       {slippageTolerance && marketId && (
         <TableRow modifier="bordered">
           <TableCell>{t('Slippage tolerance')}</TableCell>
-          <TableCell>
-            <PriceInMarket marketId={marketId} price={slippageTolerance} />
-          </TableCell>
+          <TableCell>{slippageTolerance}%</TableCell>
         </TableRow>
       )}
 

--- a/apps/explorer/src/app/components/txs/details/tx-amm-submit.tsx
+++ b/apps/explorer/src/app/components/txs/details/tx-amm-submit.tsx
@@ -5,8 +5,8 @@ import type { TendermintBlocksResponse } from '../../../routes/blocks/tendermint
 import { TxDetailsShared } from './shared/tx-details-shared';
 import { TableCell, TableRow, TableWithTbody } from '../../table';
 import type { components } from '../../../../types/explorer';
-import PriceInMarket from '../../price-in-market/price-in-market';
 import { ConcentratedLiquidityParametersDetails } from './amm/amm-liquidity-parameters';
+import SizeInMarket from '../../size-in-market/size-in-market';
 
 interface TxDetailsAMMSubmitProps {
   txData: BlockExplorerTransactionResult | undefined;
@@ -52,7 +52,12 @@ export const TxDetailsAMMSubmit = ({
         <TableRow modifier="bordered">
           <TableCell>{t('Amount')}</TableCell>
           <TableCell>
-            <PriceInMarket marketId={marketId} price={commitmentAmount} />
+            <SizeInMarket
+              marketId={marketId}
+              size={commitmentAmount}
+              decimalSource="ASSET"
+              showAssetLabel={true}
+            />
           </TableCell>
         </TableRow>
       )}
@@ -60,18 +65,14 @@ export const TxDetailsAMMSubmit = ({
       {proposedFee && marketId && (
         <TableRow modifier="bordered">
           <TableCell>{t('Proposed Fee')}</TableCell>
-          <TableCell>
-            <PriceInMarket marketId={marketId} price={proposedFee} />
-          </TableCell>
+          <TableCell>{proposedFee}%</TableCell>
         </TableRow>
       )}
 
       {slippageTolerance && marketId && (
         <TableRow modifier="bordered">
           <TableCell>{t('Slippage tolerance')}</TableCell>
-          <TableCell>
-            <PriceInMarket marketId={marketId} price={slippageTolerance} />
-          </TableCell>
+          <TableCell>{slippageTolerance}%</TableCell>
         </TableRow>
       )}
 

--- a/apps/explorer/src/app/components/txs/tx-filter-label.tsx
+++ b/apps/explorer/src/app/components/txs/tx-filter-label.tsx
@@ -11,7 +11,7 @@ export interface FilterLabelProps {
 export function FilterLabel({ filters }: FilterLabelProps) {
   if (!filters || filters.size !== 1) {
     return (
-      <span data-testid="filter-empty" className="uppercase dark:text-white">
+      <span data-testid="filter-empty" className="text-surface-2-fg uppercase">
         {t('Filter')}
       </span>
     );
@@ -19,8 +19,8 @@ export function FilterLabel({ filters }: FilterLabelProps) {
 
   return (
     <div data-testid="filter-selected">
-      <span className="uppercase dark:text-white">{t('Filters')}:</span>&nbsp;
-      <code className="bg-gs-500 px-2 rounded-md capitalize dark:text-white">
+      <span className="uppercase text-surface-2-fg">{t('Filters')}:</span>&nbsp;
+      <code className="bg-gs-500 px-2 rounded-md capitalize text-surface-1">
         {Array.from(filters)[0]}
       </code>
     </div>

--- a/apps/explorer/src/app/components/txs/tx-filter-label.tsx
+++ b/apps/explorer/src/app/components/txs/tx-filter-label.tsx
@@ -11,7 +11,7 @@ export interface FilterLabelProps {
 export function FilterLabel({ filters }: FilterLabelProps) {
   if (!filters || filters.size !== 1) {
     return (
-      <span data-testid="filter-empty" className="uppercase">
+      <span data-testid="filter-empty" className="uppercase dark:text-white">
         {t('Filter')}
       </span>
     );
@@ -19,8 +19,8 @@ export function FilterLabel({ filters }: FilterLabelProps) {
 
   return (
     <div data-testid="filter-selected">
-      <span className="uppercase">{t('Filters')}:</span>&nbsp;
-      <code className="bg-gs-500 px-2 rounded-md capitalize">
+      <span className="uppercase dark:text-white">{t('Filters')}:</span>&nbsp;
+      <code className="bg-gs-500 px-2 rounded-md capitalize dark:text-white">
         {Array.from(filters)[0]}
       </code>
     </div>

--- a/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
+++ b/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
@@ -33,7 +33,7 @@ export const TxsListNavigation = ({
         <BlocksRefetch refetch={refreshTxs} />
         <div className="float-right">
           <Button
-            className="mr-2"
+            className="mr-2 dark:text-white"
             size="xs"
             onClick={() => {
               previousPage();
@@ -42,6 +42,7 @@ export const TxsListNavigation = ({
             {t('Newer')}
           </Button>
           <Button
+            className="dark:text-white"
             size="xs"
             disabled={isEmpty}
             onClick={() => {

--- a/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
+++ b/apps/explorer/src/app/components/txs/tx-list-navigation.tsx
@@ -33,7 +33,7 @@ export const TxsListNavigation = ({
         <BlocksRefetch refetch={refreshTxs} />
         <div className="float-right">
           <Button
-            className="mr-2 dark:text-white"
+            className="mr-2 text-surface-2-fg"
             size="xs"
             onClick={() => {
               previousPage();
@@ -42,8 +42,8 @@ export const TxsListNavigation = ({
             {t('Newer')}
           </Button>
           <Button
-            className="dark:text-white"
             size="xs"
+            className="text-surface-2-fg"
             disabled={isEmpty}
             onClick={() => {
               nextPage();

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -53,7 +53,7 @@ const displayString: StringMap = {
   'Apply Referral Code': 'Referral',
   'Create Referral Set': 'Create referral',
   'Update Party Profile': 'Update profile',
-  'Submit AMM': 'AMM',
+  'Submit AMM': 'Submit AMM',
   'Amend AMM': 'Amend AMM',
   'Cancel AMM': 'Cancel AMM',
   'Delayed Transaction Wrapper': 'Delayed',
@@ -173,7 +173,7 @@ export function getLabelForTransfer(
   }
   return {
     type,
-    colours: 'text-white bg-surface-3',
+    colours: 'text-black dark:text-white bg-surface-3',
   };
 }
 
@@ -258,7 +258,7 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
   // Note that colours are currently arbitrary
   if (type === 'Chain Event' && !!command?.chainEvent) {
     type = getLabelForChainEvent(command.chainEvent);
-    colours = 'text-white dark-text-white bg-pink dark:bg-pink';
+    colours = 'text-black dark-text-white bg-green-200';
   } else if (type === 'Transfer Funds' && command?.transfer) {
     const res = getLabelForTransfer(command.transfer);
     type = res.type;

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -258,7 +258,7 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
   // Note that colours are currently arbitrary
   if (type === 'Chain Event' && !!command?.chainEvent) {
     type = getLabelForChainEvent(command.chainEvent);
-    colours = 'text-black dark-text-white bg-green-200';
+    colours = 'text-black bg-green-200';
   } else if (type === 'Transfer Funds' && command?.transfer) {
     const res = getLabelForTransfer(command.transfer);
     type = res.type;

--- a/apps/explorer/src/app/components/txs/tx-order-type.tsx
+++ b/apps/explorer/src/app/components/txs/tx-order-type.tsx
@@ -53,7 +53,7 @@ const displayString: StringMap = {
   'Apply Referral Code': 'Referral',
   'Create Referral Set': 'Create referral',
   'Update Party Profile': 'Update profile',
-  'Submit AMM': 'Submit AMM',
+  'Submit AMM': 'SubmitAMM',
   'Amend AMM': 'Amend AMM',
   'Cancel AMM': 'Cancel AMM',
   'Delayed Transaction Wrapper': 'Delayed',
@@ -173,7 +173,7 @@ export function getLabelForTransfer(
   }
   return {
     type,
-    colours: 'text-black dark:text-white bg-surface-3',
+    colours: 'text-surface-2-fg bg-surface-3',
   };
 }
 
@@ -267,7 +267,7 @@ export const TxOrderType = ({ orderType, command }: TxOrderTypeProps) => {
     if (command && !!command.proposalSubmission) {
       type = getLabelForProposal(command.proposalSubmission);
     }
-    colours = 'text-black bg-yellow';
+    colours = 'text-surface-2-fg bg-gray-600';
   } else if (type === 'Order' && command) {
     type = getLabelForOrderType(orderType, command);
     colours = 'text-white dark-text-white bg-blue dark:bg-blue';

--- a/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
+++ b/apps/explorer/src/app/components/txs/txs-infinite-list.tsx
@@ -70,7 +70,7 @@ export const TxsInfiniteList = ({
     <div>
       <table className={className} data-testid="transactions-list">
         <thead>
-          <tr className="w-full mb-3 text-gs-300 uppercase text-left">
+          <tr className="w-full mb-3 text-surface-2-fg uppercase text-left">
             <th>
               <span className="hidden xl:inline">{t('Txn')} &nbsp;</span>
               <span>ID</span>

--- a/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
+++ b/apps/explorer/src/app/components/vote-icon/vote-icon.tsx
@@ -22,7 +22,7 @@ function getBgColour(useVoteColour: boolean, vote: boolean) {
 
 function getFillColour(useVoteColour: boolean, vote: boolean) {
   if (useVoteColour === false) {
-    return 'white';
+    return 'surface-2-fg';
   }
 
   return vote ? 'green-300' : 'pink-300';
@@ -30,7 +30,7 @@ function getFillColour(useVoteColour: boolean, vote: boolean) {
 
 function getTextColour(useVoteColour: boolean, vote: boolean) {
   if (useVoteColour === false) {
-    return 'white';
+    return 'surface-2-fg';
   }
 
   return vote ? 'green-200' : 'pink-200';
@@ -56,7 +56,7 @@ export function VoteIcon({
 
   return (
     <div
-      className={`voteicon inline-block py-0 px-2 py rounded-md text-white whitespace-nowrap leading-tight sm align-top ${bg}`}
+      className={`voteicon inline-block py-0 px-2 py rounded-md whitespace-nowrap leading-tight sm align-top ${bg}`}
     >
       <Icon
         name={icon}


### PR DESCRIPTION
# Related issues 🔗

Closes #6627

# Description ℹ️

Fixes the feedback on the initial AMM tx views for submit and amend:
- Update `proposedFee` to display as percentage
- Update `slippageTolerage` to display as percentage
- Update `commitmentAmount` to be displayed in the correct asset decimals instead of market decimals
- Update `<SizeInMarket />` component to allow labels to be displayed and asset decimals to be used

# Demo 📺

<img width="933" alt="Screenshot 2024-09-09 at 14 28 17" src="https://github.com/user-attachments/assets/7d53fe80-e6a2-4109-a9a0-99d2735cf1a9">
