### PR TITLE
fix(trading): get last score results for historic games

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-game.tsx
+++ b/apps/trading/client-pages/competitions/competitions-game.tsx
@@ -579,6 +579,9 @@ const HistoricScoresTable = ({
       epochFrom: currentEpoch ? currentEpoch - TEAMS_STATS_EPOCHS : 0,
       gameId: gameId || '',
       partyId: pubKey || '',
+      pagination: {
+        last: 2000,
+      },
     },
     skip: !currentEpoch || !gameId,
   });


### PR DESCRIPTION
# Related issues 🔗

Closes #6871 

# Description ℹ️

Fetches scores from the end of the list to ensure the latest results are shown