### PR TITLE
fix(explorer): remove incorrect staked to validator field

### DIFF
--- a/apps/explorer/src/app/routes/parties/id/components/party-block-stake.tsx
+++ b/apps/explorer/src/app/routes/parties/id/components/party-block-stake.tsx
@@ -8,8 +8,6 @@ import {
   Loader,
 } from '@vegaprotocol/ui-toolkit';
 import { PartyBlock } from './party-block';
-import BigNumber from 'bignumber.js';
-
 export interface PartyBlockStakeProps {
   partyId: string;
   accountLoading: boolean;
@@ -37,24 +35,6 @@ export const PartyBlockStake = ({
 
   const p = partyRes.data?.partiesConnection?.edges[0].node;
 
-  const linkedLength = p?.stakingSummary?.linkings?.edges?.length;
-  const linkedStake =
-    linkedLength && linkedLength > 0
-      ? p?.stakingSummary?.linkings?.edges
-          ?.reduce((total, e) => {
-            const accumulator = new BigNumber(total);
-            const diff = new BigNumber(e?.node.amount || 0);
-            if (e?.node.type === 'TYPE_LINK') {
-              return accumulator.plus(diff);
-            } else if (e?.node.type === 'TYPE_UNLINK') {
-              return accumulator.minus(diff);
-            } else {
-              return accumulator;
-            }
-          }, new BigNumber(0))
-          .toString()
-      : '0';
-
   return (
     <PartyBlock title={t('Staking')}>
       {p?.stakingSummary.currentStakeAvailable ? (
@@ -65,12 +45,6 @@ export const PartyBlockStake = ({
               <GovernanceAssetBalance
                 price={p.stakingSummary.currentStakeAvailable}
               />
-            </div>
-          </KeyValueTableRow>
-          <KeyValueTableRow noBorder={true}>
-            <div>{t('Staked to validator')}</div>
-            <div>
-              <GovernanceAssetBalance price={linkedStake || '0'} />
             </div>
           </KeyValueTableRow>
         </KeyValueTable>

--- a/apps/explorer/src/app/routes/parties/id/components/party-block.tsx
+++ b/apps/explorer/src/app/routes/parties/id/components/party-block.tsx
@@ -8,7 +8,7 @@ export interface PartyBlockProps {
 
 export function PartyBlock({ children, title, action }: PartyBlockProps) {
   return (
-    <div className="border-2 min-h-[138px] border-gs-300 dark:border-gs-700  p-5 mt-5">
+    <div className="border-2 min-h-[100px] border-gs-300 dark:border-gs-700  p-5 mt-5">
       <div
         className="flex flex-col md:flex-row gap-1 justify-between content-start mb-2"
         data-testid="page-title"


### PR DESCRIPTION
# Related issues 🔗

Closes #6893

# Description ℹ️

The 'Staked to Validator' row on a party page was calculated incorrectly. As the method for correctly
calculating this field is too convoluted, I have simply removed it. There is also no good page on 
explorer to link to for a specific party's stake, so I did not add a link out to that.
