### PR TITLE
fix(trading): notional label

### DIFF
--- a/apps/trading/components/ticket/fields/notional.tsx
+++ b/apps/trading/components/ticket/fields/notional.tsx
@@ -91,7 +91,10 @@ const NotionalLabel = () => {
   const t = useT();
   const ticket = useTicketContext();
   const label = t('Notional');
-  const symbol = ticket.quoteAsset.symbol;
+  const symbol =
+    ticket.type === 'default' && ticket.quoteName.length > 0
+      ? ticket.quoteName
+      : ticket.quoteAsset.symbol;
 
   return <InputLabel label={label} symbol={symbol} />;
 };

--- a/apps/trading/components/ticket/fields/price.tsx
+++ b/apps/trading/components/ticket/fields/price.tsx
@@ -57,7 +57,11 @@ export const Price = ({ name = 'price' }: { name?: 'price' | 'ocoPrice' }) => {
               label={
                 <InputLabel
                   label={t('Price')}
-                  symbol={ticket.quoteAsset.symbol}
+                  symbol={
+                    ticket.type === 'default' && ticket.quoteName.length > 0
+                      ? ticket.quoteName
+                      : ticket.quoteAsset.symbol
+                  }
                 />
               }
             />

--- a/apps/trading/components/ticket/info/notional.tsx
+++ b/apps/trading/components/ticket/info/notional.tsx
@@ -14,12 +14,19 @@ export const Notional = ({
   const form = useForm();
   const ticket = useTicketContext();
   const notional = form.watch(name);
-  const symbol = ticket.quoteAsset.symbol;
+  const symbol =
+    ticket.type === 'default' && ticket.quoteName.length > 0
+      ? ticket.quoteName
+      : ticket.quoteAsset.symbol;
 
   return (
     <DatagridRow
       label={
-        <Tooltip description={t('ticketTooltipNotional')}>
+        <Tooltip
+          description={t('ticketTooltipNotional', {
+            quoteName: symbol,
+          })}
+        >
           <span>{t('Notional ({{symbol}})', { symbol })}</span>
         </Tooltip>
       }


### PR DESCRIPTION
# Related issues 🔗

Closes #6896 

# Description ℹ️

* uses `quoteName` instead of settlement asset symbolf for notional and price fields in the deal ticket

# Demo 📺

![image](https://github.com/user-attachments/assets/52caaf90-1949-41d3-8c74-b66c10d72e34)
