### PR TITLE
fix(explorer): add missing environment variables

### DIFF
--- a/apps/explorer/.env
+++ b/apps/explorer/.env
@@ -13,6 +13,8 @@ NX_ANNOUNCEMENTS_CONFIG_URL=https://raw.githubusercontent.com/vegaprotocol/annou
 NX_VEGA_NETWORKS='{"TESTNET":"https://explorer.fairground.wtf","MAINNET":"https://explorer.vega.xyz"}'
 NX_VEGA_REPO_URL=https://github.com/vegaprotocol/vega/releases/tag/
 NX_VEGA_CHAIN_ID=vega-stagnet1-202307191148
+NX_APP_NAME=Vega
+NX_CONFIGURED_WALLETS="[]"
 
 # App flags
 NX_EXPLORER_ASSETS=1


### PR DESCRIPTION
# Related issues 🔗

Closes #6924

# Description ℹ️

Fairground explorer is currently broken, as these variables are missing
