### PR TITLE
fix(trading): update game next payout epoch to be current

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-game.tsx
+++ b/apps/trading/client-pages/competitions/competitions-game.tsx
@@ -784,7 +784,11 @@ export const getPayouts = (
 ) => {
   const passedIntervals = (currentEpoch - startEpoch) / interval;
   const lastPayout = startEpoch + passedIntervals * interval;
-  const nextPayout = startEpoch + (passedIntervals + 1) * interval;
+
+  // Previously this was passedIntervals + 1, meaning 'next payout occurs at the
+  // start of epoch [current +1]', but this was deemed confusing so now it means
+  // 'next payout occurs at the END of epoch [current]'
+  const nextPayout = startEpoch + passedIntervals * interval;
 
   return {
     lastPayout,


### PR DESCRIPTION
# Related issues 🔗

Closes #6902

# Description ℹ️

The label and epoch display were slightly confusing. They were correct, if you read 'Next payout at'
to mean 'Next payout occurs at the start of epoch XXX'. However issue #6902 seemed to interpret it as
'Next payout occurs at the end of epoch XXX +1' and thus it looked wrong. So this PR simply returns
the current epoch.

An alternative solution would be to change the label to be clearer. But there's not much space.
