### PR TITLE
fix(wallet,wallet-react): persisting previous key without pretending to be connected

### DIFF
--- a/apps/trading/components/navbar/navbar.spec.tsx
+++ b/apps/trading/components/navbar/navbar.spec.tsx
@@ -181,6 +181,7 @@ describe('Navbar', () => {
     await userEvent.click(inactiveKey.getByText(mockKeys[1].name));
     expect(mockSelectPubKey).toHaveBeenCalledWith({
       pubKey: mockKeys[1].publicKey,
+      previousKey: mockKeys[1].publicKey,
     });
   });
 

--- a/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.spec.tsx
+++ b/apps/trading/components/vega-wallet-connect-button/vega-wallet-connect-button.spec.tsx
@@ -111,7 +111,10 @@ describe('VegaWalletConnectButton', () => {
     expect(refreshKeys).toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId(`key-${key2.publicKey}`));
-    expect(setPubKey).toHaveBeenCalledWith({ pubKey: key2.publicKey });
+    expect(setPubKey).toHaveBeenCalledWith({
+      pubKey: key2.publicKey,
+      previousKey: key2.publicKey,
+    });
 
     fireEvent.click(screen.getByTestId('disconnect'));
     expect(disconnect).toHaveBeenCalled();

--- a/libs/wallet-react/src/hooks/use-eager-connect.ts
+++ b/libs/wallet-react/src/hooks/use-eager-connect.ts
@@ -10,7 +10,12 @@ export function useEagerConnect() {
   useEffect(() => {
     const attemptConnect = async () => {
       // No stored config, or config was malformed or no risk accepted
-      if (!current || current === 'embedded-wallet-quickstart') {
+      if (!current) {
+        return;
+      }
+
+      // Do not attempt to connect automatically with transient wallets
+      if (['embedded-wallet-quickstart', 'embedded-wallet'].includes(current)) {
         return;
       }
 

--- a/libs/wallet-react/src/hooks/use-vega-wallet.ts
+++ b/libs/wallet-react/src/hooks/use-vega-wallet.ts
@@ -12,7 +12,8 @@ export const useVegaWallet = () => {
     status: store.status,
     pubKeys: store.keys,
     pubKey: store.pubKey,
-    selectPubKey: (pubKey: string) => config.store.setState({ pubKey }),
+    selectPubKey: (pubKey: string) =>
+      config.store.setState({ pubKey, previousKey: pubKey }),
     isReadOnly: store.current === 'viewParty',
     disconnect: () => {
       config.store.setState({

--- a/libs/wallet/src/types.ts
+++ b/libs/wallet/src/types.ts
@@ -80,6 +80,7 @@ export type CoreStore = {
 
 export type SingleKeyStore = {
   pubKey: string | undefined;
+  previousKey: string | undefined;
 };
 
 export type Store = CoreStore & SingleKeyStore;

--- a/libs/wallet/src/wallet.ts
+++ b/libs/wallet/src/wallet.ts
@@ -18,6 +18,7 @@ export const STORE_KEY = 'vega_wallet_store';
 // can be plain objects
 export const singleKeyStoreSlice: SingleKeyStore = {
   pubKey: undefined,
+  previousKey: undefined,
 };
 
 // get/set functions are not used in the slices so these
@@ -53,7 +54,7 @@ export function createConfig(cfg: Config): Wallet {
         return {
           chainId: state.chainId,
           current: state.current,
-          pubKey: state.pubKey,
+          previousKey: state.pubKey,
           jsonRpcToken: state.jsonRpcToken,
         };
       },
@@ -86,7 +87,7 @@ export function createConfig(cfg: Config): Wallet {
 
       // TODO: this shouldnt be in the default config as we dont want to enforce single key usage
       // need to find a way to optin into using this slice in the store
-      const storedPubKey = store.getState().pubKey;
+      const storedPubKey = store.getState().previousKey;
       let defaultKey;
       if (keys.find((k) => k.publicKey === storedPubKey)) {
         defaultKey = storedPubKey;
@@ -98,6 +99,7 @@ export function createConfig(cfg: Config): Wallet {
         keys,
         status: 'connected',
         pubKey: defaultKey,
+        previousKey: defaultKey,
       });
 
       connector.off('client.disconnected', disconnect);


### PR DESCRIPTION
# Related issues 🔗

Related #6927 

# Description ℹ️

Using the pubkey which is persisted to localstorage would allow a component to get the pubkey of the previously connected wallet while the wallet was not actually connected.

Created a previousKey property to be persisted as well that would allow for selecting the previous key without conflating the ideas of the previously connected public key and the currently connected public key.
