### PR TITLE
ci(trading,explorer,governance): make deploy previews use testnet

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -45,13 +45,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --pure-lockfile
 
-      - name: Select stagnet environment config for preview
-        if: github.base_ref == 'next'
-        run: echo "APP_ENV_FILE=.env.stagnet1" >> "$GITHUB_ENV"
-
-      - name: Select mainnet-mirror environment config for preview
-        if: github.base_ref != 'next'
-        run: echo "APP_ENV_FILE=.env.mainnet-mirror" >> "$GITHUB_ENV"
+      - name: Select testnet environment config for preview
+        run: echo "APP_ENV_FILE=.env.testnet" >> "$GITHUB_ENV"
 
       - name: Build trading app
         if: ${{ matrix.app == 'trading' }} # Trading app requires a call to `nx export`

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -40,11 +40,6 @@ jobs:
         run: |
           echo IS_TESTNET_RELEASE=true >> $GITHUB_ENV
 
-      - name: Is validators testnet release
-        if: contains(github.ref, 'release/validators-testnet')
-        run: |
-          echo IS_VALIDATORS_TESTNET_RELEASE=true >> $GITHUB_ENV
-
       - name: Is IPFS Release
         if: matrix.app == 'trading' && github.event_name == 'push' && ( env.IS_MAINNET_RELEASE == 'true' || env.IS_TESTNET_RELEASE == 'true' )
         run: |

--- a/.github/workflows/release-console.yml
+++ b/.github/workflows/release-console.yml
@@ -20,8 +20,6 @@ on:
         options:
           - mainnet
           - testnet
-          - validators-testnet
-          - mainnet-mirror
 
 env:
   E2E_TEST_WORKFLOW: ./.github/workflows/trading-e2e-test-run.yml


### PR DESCRIPTION
# Related issues 🔗

Closes #6942

# Description ℹ️

This should make deploy previews for pull requests point at testnet, instead of the now-dead mainnet-mirror.
