### PR TITLE
fix(trading): do not show existing referees text for solo players

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-create-team.tsx
+++ b/apps/trading/client-pages/competitions/competitions-create-team.tsx
@@ -88,7 +88,7 @@ export const CompetitionsCreateTeam = () => {
               </Button>
             </>
           )}
-          {isUpgrade && (
+          {isUpgrade && !isSolo && (
             <p className="text-sm mt-1">
               {t(
                 'Note that your existing referees will not be automatically added to your team. Share your team profile to have them join you in competitions. You will still earn commission from their trading even if they do not join.'


### PR DESCRIPTION
# Related issues 🔗

Closes #6790

# Description ℹ️

Hide some additional text that does not make sense when the create team upgrade is for a
'solo team'.
