### PR TITLE
fix(trading): exit invite process if the step connect isn't found

### DIFF
--- a/apps/trading/client-pages/invite/step-connect.tsx
+++ b/apps/trading/client-pages/invite/step-connect.tsx
@@ -31,6 +31,7 @@ import {
 } from './step-utils';
 import { usePartyProfile } from '../../lib/hooks/use-party-profiles';
 import { GradientText } from 'apps/trading/components/gradient-text';
+import { ExitInvite } from './exit-invite';
 
 export const StepConnect = () => {
   const t = useT();
@@ -79,7 +80,7 @@ export const StepConnect = () => {
   }
 
   if (!currentStep) {
-    throw new Error('step not found');
+    return <ExitInvite />;
   }
 
   if (currentStep !== Step.Connect) {


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Exits the connect step if its not valid
