### PR TITLE
fix(trading): decimal places for percentage values, remove maker rebate from ticket

### DIFF
--- a/apps/trading/components/ticket/info/fees-breakdown.spec.tsx
+++ b/apps/trading/components/ticket/info/fees-breakdown.spec.tsx
@@ -20,13 +20,10 @@ describe('FeesBreakdown', () => {
       '12.34'
     );
     expect(screen.getByText('Discount').nextElementSibling).toHaveTextContent(
-      '0.04 (2%)'
+      '0.04 (2.00%)'
     );
     expect(
       screen.getByText('Discounted fee').nextElementSibling
     ).toHaveTextContent('12.30');
-    expect(
-      screen.getByText('Maker rebate').nextElementSibling
-    ).toHaveTextContent('1.00 (8%)');
   });
 });

--- a/apps/trading/components/ticket/info/fees-breakdown.tsx
+++ b/apps/trading/components/ticket/info/fees-breakdown.tsx
@@ -44,7 +44,7 @@ export const FeesBreakdown = ({
         value={`${addDecimalsFormatNumber(
           estimate.discount.toString(),
           decimals
-        )} (${formatNumberPercentage(estimate.discountPct)})`}
+        )} (${formatNumberPercentage(estimate.discountPct, 2)})`}
         testId="fee-discount"
       />
       <FeesBreakdownItem
@@ -54,14 +54,6 @@ export const FeesBreakdown = ({
           decimals
         )}
         testId="discounted-fee"
-      />
-      <FeesBreakdownItem
-        label={t('Maker rebate')}
-        value={`${addDecimalsFormatNumber(
-          estimate.makerRebate.toString(),
-          decimals
-        )} (${formatNumberPercentage(estimate.makerRebatePct)})`}
-        testId="maker-rebate"
       />
     </dl>
   );

--- a/apps/trading/components/ticket/info/fees.tsx
+++ b/apps/trading/components/ticket/info/fees.tsx
@@ -63,7 +63,7 @@ export const Fees = ({ oco = false }: { oco?: boolean }) => {
                 className="ml-1"
                 data-testid="discount-pill"
               >
-                {formatNumberPercentage(BigNumber(estimate.discountPct))}
+                {formatNumberPercentage(BigNumber(estimate.discountPct), 2)}
               </Pill>
             )}
           </span>


### PR DESCRIPTION
# Related issues 🔗

Closes #6752 

# Description ℹ️

- Formats discount percentage with 2 dps
- Removes maker rebate from ticket fees