### PR TITLE
fix(trading,browser-wallet): exporting recovery phrase after opening

### DIFF
--- a/libs/browser-wallet/src/frontend/routes/auth/settings/home/sections/export-recovery-phrase-section/export-recovery-phrase-section.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/settings/home/sections/export-recovery-phrase-section/export-recovery-phrase-section.tsx
@@ -30,7 +30,6 @@ export const ExportRecoveryPhraseSection = () => {
   }, [request]);
 
   const resetDialog = () => {
-    setRecoveryPhrase(null);
     setOpen(false);
   };
 


### PR DESCRIPTION
# Related issues 🔗

Closes #6946 