### PR TITLE
fix(trading,browser-wallet): wallet page title and navbar

### DIFF
--- a/libs/browser-wallet/src/frontend/components/navbar/navbar.spec.tsx
+++ b/libs/browser-wallet/src/frontend/components/navbar/navbar.spec.tsx
@@ -72,7 +72,7 @@ describe('NavBar', () => {
     expect(screen.getAllByTestId('nav-button')).toHaveLength(3);
     const [wallets, transactions, settings] =
       screen.getAllByTestId('nav-button');
-    expect(wallets).toHaveTextContent('Wallets');
+    expect(wallets).toHaveTextContent('Keys');
     expect(transactions).toHaveTextContent('Transactions');
     expect(settings).toHaveTextContent('Settings');
   });

--- a/libs/browser-wallet/src/frontend/components/navbar/navbar.tsx
+++ b/libs/browser-wallet/src/frontend/components/navbar/navbar.tsx
@@ -53,7 +53,7 @@ export const NavBar = () => {
       <NavButton
         icon={<Wallet className="m-auto" squareFill={'black'} />}
         to={{ pathname: FULL_ROUTES.wallets }}
-        text="Wallets"
+        text="Keys"
       />
       <NavButton
         icon={<LeftRightArrows className="m-auto" />}

--- a/libs/browser-wallet/src/frontend/routes/auth/wallets/home/wallets.spec.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/wallets/home/wallets.spec.tsx
@@ -51,9 +51,7 @@ describe('Wallets', () => {
     renderComponent();
     // Wait for list to load
     await screen.findByTestId(locators.listItem);
-    expect(screen.getByTestId(headerLocators.header)).toHaveTextContent(
-      'wallet 1'
-    );
+    expect(screen.getByTestId(headerLocators.header)).toHaveTextContent('Keys');
     expect(screen.getByTestId(vegaKeyLocators.explorerLink)).toBeVisible();
     expect(screen.getByTestId(vegaKeyLocators.explorerLink)).toHaveTextContent(
       '07248a…3673'

--- a/libs/browser-wallet/src/frontend/routes/auth/wallets/home/wallets.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/wallets/home/wallets.tsx
@@ -23,7 +23,7 @@ export const Wallets = () => {
   return (
     <AsyncRenderer
       render={() => (
-        <BasePage dataTestId={locators.walletsPage} title={wallet.name}>
+        <BasePage dataTestId={locators.walletsPage} title={'Keys'}>
           <WalletsPageKeyList
             onSignMessage={setSelectedPubkey}
             wallet={wallet}


### PR DESCRIPTION
Change title and nav item of wallet to be keys as multi wallet is not a thing

<img width="609" alt="Screenshot 2024-09-21 at 14 32 19" src="https://github.com/user-attachments/assets/6bbd6985-4a5d-4bbe-bb70-f05cf6175a18">
