### PR TITLE
feat(trading,browser-wallet): enable auto consent by default, fix auto consent always failing

### DIFF
--- a/libs/browser-wallet-backend/src/lib/setup-listeners.js
+++ b/libs/browser-wallet-backend/src/lib/setup-listeners.js
@@ -1,7 +1,7 @@
 export async function install({ settings }) {
   await Promise.allSettled([
     settings.set('autoOpen', true),
-    settings.set('autoConsent', false),
+    settings.set('autoConsent', true),
     settings.set('version', 0),
   ]);
 }

--- a/libs/browser-wallet-backend/src/src/client-ns.js
+++ b/libs/browser-wallet-backend/src/src/client-ns.js
@@ -163,7 +163,7 @@ export default function init({
         );
         const isLocked = encryptedStore.locked === true;
         const canBeAutoApproved =
-          settings.autoConsent &&
+          (await settings.get('autoConsent')) &&
           AUTO_CONSENT_TRANSACTION_TYPES.includes(transactionType) &&
           !isLocked;
         let approved = canBeAutoApproved;


### PR DESCRIPTION
Fixes the fact auto consent was always disabled due to a syntax error
Enables autoConsent by default