### PR TITLE
chore(browser-wallet): collapse raw tx by default

### DIFF
--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/sections/raw-transaction.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/sections/raw-transaction.tsx
@@ -13,7 +13,7 @@ export const RawTransaction = ({
     <VegaSection>
       <CollapsiblePanel
         title="View raw transaction"
-        initiallyOpen={true}
+        initiallyOpen={false}
         panelContent={
           <CodeWindow
             text={JSON.stringify(transaction, null, '  ')}


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

Keep transaction details collapsed by default