### PR TITLE
fix(trading): dps for target notional vol

### DIFF
--- a/apps/trading/client-pages/competitions/competitions-game.tsx
+++ b/apps/trading/client-pages/competitions/competitions-game.tsx
@@ -401,16 +401,19 @@ const GameDetails = ({
             </div>
           </>
         )}
-        <div>
-          <dd className={valueClasses}>{scoreUnit}</dd>
-          <dt className={labelClasses}>{t('Scored in')}</dt>
-        </div>
+        {scoreUnit !== null && (
+          <div>
+            <dd className={valueClasses}>{scoreUnit}</dd>
+            <dt className={labelClasses}>{t('Scored in')}</dt>
+          </div>
+        )}
         {dispatchStrategy.targetNotionalVolume && (
           <div>
             <dd className={valueClasses}>
               {addDecimalsFormatNumber(
                 dispatchStrategy.targetNotionalVolume,
-                asset.decimals
+                asset.decimals,
+                0
               )}
             </dd>
             <dt className={labelClasses}>{t('Reward scaling')}</dt>
@@ -789,6 +792,10 @@ const useScoreUnit = (metric: Metric, asset: AssetFieldsFragment) => {
   }
 
   if (metric === DispatchMetric.DISPATCH_METRIC_LP_FEES_RECEIVED) {
+    return asset.symbol;
+  }
+
+  if (metric === DispatchMetric.DISPATCH_METRIC_RELATIVE_RETURN) {
     return asset.symbol;
   }
 


### PR DESCRIPTION
# Related issues 🔗

N/A

# Description ℹ️

- Removes formatting decimal places for the targetNotionalVolume value when a games rewards are scaled
- Adds asset symbol for the score unit for relative return games