### PR TITLE
chore(trading): add padding to drop down

### DIFF
--- a/apps/trading/components/market-selector/market-selector.tsx
+++ b/apps/trading/components/market-selector/market-selector.tsx
@@ -344,7 +344,7 @@ const List = ({
 
   return (
     <FixedSizeList
-      className="vega-scrollbar"
+      className="vega-scrollbar mb-2"
       itemCount={data.length}
       itemData={itemData}
       itemSize={itemSize}


### PR DESCRIPTION
# Related issues 🔗

Closes #6975

# Description ℹ️

Add padding to the bottom of the market selector drop down.

# Demo 📺

<img width="688" alt="Screenshot 2024-10-02 at 12 19 42" src="https://github.com/user-attachments/assets/228a0500-d784-4d9a-9181-d072fd0f0ff5">
