### PR TITLE
chore(browser-wallet,trading): make receipts fit on a single screen

### DIFF
--- a/apps/trading/components/browser-wallet-dialog/index.tsx
+++ b/apps/trading/components/browser-wallet-dialog/index.tsx
@@ -42,7 +42,7 @@ export const BrowserWalletDialog = () => {
         set(open);
       }}
     >
-      <div className="h-full" style={{ height: 600 }}>
+      <div className="h-full" style={{ height: 650 }}>
         <BrowserWallet />
       </div>
     </Dialog>

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.spec.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.spec.tsx
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
-import { locators as headerLocators } from '@/components/header';
 import { locators as subheaderLocators } from '@/components/sub-header';
 
-import { locators, TransactionHeader } from './transaction-header';
+import { TransactionHeader } from './transaction-header';
 
 jest.mock('../../keys/vega-key', () => ({
   VegaKey: () => <div data-testid="vega-key" />,
@@ -38,20 +37,11 @@ describe('TransactionHeader', () => {
       <TransactionHeader
         transaction={transaction as any}
         name="Key 1"
-        origin="https://www.google.com"
-        publicKey="3fd42fd5ceb22d99ac45086f1d82d516118a5cb7ad9a2e096cd78ca2c8960c80"
+        receivedAt="0"
       />
     );
     const subheaders = screen.getAllByTestId(subheaderLocators.subHeader);
-    const [requestFromSubheader, signingWithSubheader] = subheaders;
-    expect(signingWithSubheader).toHaveTextContent('Signing with');
-    expect(requestFromSubheader).toHaveTextContent('Request from');
-    expect(screen.getByTestId(headerLocators.header)).toHaveTextContent(
-      'Order Submission'
-    );
-    expect(screen.getByTestId(locators.transactionRequest)).toHaveTextContent(
-      'https://www.google.com'
-    );
-    expect(screen.getByTestId('vega-key')).toBeInTheDocument();
+    const [requestFromSubheader] = subheaders;
+    expect(requestFromSubheader).toHaveTextContent('Signing with:');
   });
 });

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.tsx
@@ -31,13 +31,12 @@ export const TransactionHeader = ({
           data-testid={locators.transactionTimeAgo}
           className="text-sm text-surface-0-fg-muted"
         >
-          (Received{' '}
+          Received{' '}
           <ReactTimeAgo
             timeStyle="round"
             date={new Date(receivedAt)}
             locale="en-US"
           />
-          )
         </div>
       </div>
     </>

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-header.tsx
@@ -2,41 +2,44 @@ import { getTitle } from '@/lib/get-title';
 import type { Transaction } from '@/lib/transactions';
 
 import { Header } from '../../header';
-import { VegaKey } from '../../keys/vega-key';
 import { SubHeader } from '../../sub-header';
-import { VegaSection } from '../../vega-section';
+import ReactTimeAgo from 'react-time-ago';
 
 export const locators = {
   transactionRequest: 'transaction-request',
   transactionKey: 'transaction-key',
+  transactionTimeAgo: 'transaction-time-ago',
 };
 
 export const TransactionHeader = ({
-  origin,
-  publicKey,
   name,
   transaction,
+  receivedAt,
 }: {
-  origin: string;
-  publicKey: string;
   name: string;
   transaction: Transaction;
+  receivedAt: string;
 }) => {
   return (
-    <VegaSection>
+    <>
       <Header content={getTitle(transaction)} />
-      <div className="mb-4 mt-6">
-        <SubHeader content="Request from" />
-      </div>
-      <div className="flex items-center mb-4">
-        <div data-testid={locators.transactionRequest} className="ml-4">
-          {origin}
+      <div className="mb-1 flex justify-between">
+        <div className="flex items-center justify-between">
+          <SubHeader content={`Signing with: ${name}`} />
+        </div>
+        <div
+          data-testid={locators.transactionTimeAgo}
+          className="text-sm text-surface-0-fg-muted"
+        >
+          (Received{' '}
+          <ReactTimeAgo
+            timeStyle="round"
+            date={new Date(receivedAt)}
+            locale="en-US"
+          />
+          )
         </div>
       </div>
-      <div className="mb-4">
-        <SubHeader content="Signing with" />
-      </div>
-      <VegaKey name={name} publicKey={publicKey} />
-    </VegaSection>
+    </>
   );
 };

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.spec.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.spec.tsx
@@ -94,8 +94,5 @@ describe('TransactionModal', () => {
     expect(screen.getByTestId('transaction-header')).toBeVisible();
     expect(screen.getByTestId('transaction-footer')).toBeVisible();
     expect(screen.getByTestId(locators.transactionWrapper)).toBeVisible();
-    expect(screen.getByTestId(locators.transactionTimeAgo)).toHaveTextContent(
-      'Received just now'
-    );
   });
 });

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.tsx
@@ -1,5 +1,3 @@
-import ReactTimeAgo from 'react-time-ago';
-
 import { useInteractionStore } from '@/stores/interaction-store';
 
 import { Splash } from '../../splash';
@@ -27,10 +25,9 @@ export const TransactionModal = () => {
   return (
     <>
       <Splash data-testid={locators.transactionWrapper}>
-        <section className="pb-4 pt-2 px-5">
+        <section className="pb-28 pt-2 px-5">
           <TransactionHeader
-            origin={details.origin}
-            publicKey={details.publicKey}
+            receivedAt={details.receivedAt}
             name={details.name}
             transaction={details.transaction}
           />
@@ -41,17 +38,6 @@ export const TransactionModal = () => {
           />
           <EnrichedDetails transaction={details.transaction} />
           <RawTransaction transaction={details.transaction} />
-          <div
-            data-testid={locators.transactionTimeAgo}
-            className="text-sm text-surface-0-fg-muted mt-6 mb-20"
-          >
-            Received{' '}
-            <ReactTimeAgo
-              timeStyle="round"
-              date={new Date(details.receivedAt)}
-              locale="en-US"
-            />
-          </div>
         </section>
       </Splash>
       <TransactionModalFooter

--- a/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.tsx
+++ b/libs/browser-wallet/src/frontend/components/modals/transaction-modal/transaction-modal.tsx
@@ -9,7 +9,6 @@ import { TransactionModalFooter } from './transaction-modal-footer';
 
 export const locators = {
   transactionWrapper: 'transaction-wrapper',
-  transactionTimeAgo: 'transaction-time-ago',
 };
 
 export const TransactionModal = () => {

--- a/libs/browser-wallet/src/frontend/components/receipts/orders/stop-submission/submission.tsx
+++ b/libs/browser-wallet/src/frontend/components/receipts/orders/stop-submission/submission.tsx
@@ -7,7 +7,7 @@ import type { ReceiptComponentProperties } from '../../receipts';
 import { OrderBadges } from '../../utils/order/badges';
 import { OrderTable } from '../../utils/order-table';
 import { ReceiptWrapper } from '../../utils/receipt-wrapper';
-import { PriceWithTooltip } from '../../utils/string-amounts/price-with-tooltip';
+import { OrderPrice } from '../../utils/order/order-price';
 
 export const locators = {
   sectionHeader: 'section-header',
@@ -27,12 +27,12 @@ const SubmissionDetails = ({
     {
       prop: 'price',
       props: ['orderSubmission.marketId', 'price'],
-      render: (price, { marketId }) => [
+      render: (price, props) => [
         'Trigger price',
-        <PriceWithTooltip
+        <OrderPrice
           key={`${title}-trigger-price`}
           price={price}
-          marketId={marketId}
+          marketId={props['orderSubmission.marketId']}
         />,
       ],
     },

--- a/libs/browser-wallet/src/frontend/components/vega-section/vega-section.tsx
+++ b/libs/browser-wallet/src/frontend/components/vega-section/vega-section.tsx
@@ -5,7 +5,7 @@ export const locators = {
 export const VegaSection = ({ children }: { children: React.ReactNode }) => (
   <section
     data-testid={locators.vegaSection}
-    className="border-b border-1 last-of-type:border-0 border-surface-0-fg-muted py-6"
+    className="border-b border-1 last-of-type:border-0 border-surface-0-fg-muted py-4"
   >
     {children}
   </section>

--- a/libs/browser-wallet/src/frontend/hooks/persist-location/index.tsx
+++ b/libs/browser-wallet/src/frontend/hooks/persist-location/index.tsx
@@ -3,8 +3,6 @@ import { useLocation } from 'react-router-dom';
 
 import { FULL_ROUTES } from '../../routes/route-names';
 
-export const LOCATION_KEY = 'location';
-
 const IGNORED_PATHS = new Set([
   FULL_ROUTES.home,
   FULL_ROUTES.login,
@@ -15,6 +13,12 @@ const IGNORED_PATHS = new Set([
   FULL_ROUTES.importWallet,
 ]);
 
+export let previousLocation: string | null = null;
+
+export const setPreviousLocation = (val: string | null) => {
+  previousLocation = val;
+};
+
 export const usePersistLocation = () => {
   const location = useLocation();
 
@@ -24,7 +28,7 @@ export const usePersistLocation = () => {
     // to get them to the place they need to be. So if on home this is
     // an initial load we do not wish to persist
     if (!IGNORED_PATHS.has(location.pathname)) {
-      localStorage.setItem(LOCATION_KEY, location.pathname);
+      previousLocation = location.pathname;
     }
   }, [location]);
 };

--- a/libs/browser-wallet/src/frontend/hooks/persist-location/persist-location.spec.tsx
+++ b/libs/browser-wallet/src/frontend/hooks/persist-location/persist-location.spec.tsx
@@ -2,11 +2,11 @@ import { renderHook } from '@testing-library/react';
 import { type ReactNode, useEffect } from 'react';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 
-import { LOCATION_KEY, usePersistLocation } from '.';
+import { previousLocation, setPreviousLocation, usePersistLocation } from '.';
 
 describe('PersistLocation', () => {
   beforeEach(() => {
-    localStorage.clear();
+    setPreviousLocation(null);
   });
   it('sets the current location in local storage', () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -19,13 +19,13 @@ describe('PersistLocation', () => {
         const navigate = useNavigate();
         usePersistLocation();
         if (!initialRoute) {
-          initialRoute = localStorage.getItem(LOCATION_KEY);
+          initialRoute = previousLocation;
         }
         useEffect(() => {
           navigate('/bar');
         }, [navigate]);
 
-        secondRoute = localStorage.getItem(LOCATION_KEY);
+        secondRoute = previousLocation;
       },
       { wrapper }
     );
@@ -42,7 +42,7 @@ describe('PersistLocation', () => {
     renderHook(
       () => {
         usePersistLocation();
-        initialRoute = localStorage.getItem(LOCATION_KEY);
+        initialRoute = previousLocation;
       },
       { wrapper }
     );

--- a/libs/browser-wallet/src/frontend/hooks/redirect-path/index.tsx
+++ b/libs/browser-wallet/src/frontend/hooks/redirect-path/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useGlobalsStore } from '@/stores/globals';
 
 import { FULL_ROUTES } from '../../routes/route-names';
-import { LOCATION_KEY } from '../persist-location';
+import { previousLocation } from '../persist-location';
 
 interface State {
   loading: boolean;
@@ -29,7 +29,7 @@ export const useGetRedirectPath = () => {
       });
     } else if (globals.wallet) {
       // If the user has a path they were previously on then redirect to that
-      const path = localStorage.getItem(LOCATION_KEY);
+      const path = previousLocation;
       setResult({
         loading: false,
         path: path ?? FULL_ROUTES.wallets,

--- a/libs/browser-wallet/src/frontend/routes/auth/transactions/details/transaction-metadata.spec.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/transactions/details/transaction-metadata.spec.tsx
@@ -3,7 +3,6 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { locators as subHeaderLocators } from '@/components/sub-header';
 import { MockNetworkProvider } from '@/contexts/network/mock-network-provider';
-import { FULL_ROUTES } from '@/routes/route-names';
 import { type StoredTransaction, TransactionState } from '@/types/backend';
 
 import { testingNetwork } from '../../../../../config/well-known-networks';
@@ -75,28 +74,11 @@ describe('TransactionMeta', () => {
     ).toHaveTextContent('000000…0000');
 
     expect(
-      screen.getByTestId(locators.transactionMetadataNetwork)
-    ).toHaveTextContent(testingNetwork.id);
-    expect(
-      screen.getByTestId(locators.transactionMetadataNetwork)
-    ).toHaveAttribute(
-      'href',
-      `${FULL_ROUTES.networksSettings}/${testingNetwork.id}`
-    );
-
-    expect(
       screen.getByTestId(locators.transactionMetadataNode)
     ).toHaveTextContent('https://node.com');
     expect(
       screen.getByTestId(locators.transactionMetadataNode)
     ).toHaveAttribute('href', 'https://node.com');
-
-    expect(
-      screen.getByTestId(locators.transactionMetadataOrigin)
-    ).toHaveTextContent('https://foo.com');
-    expect(
-      screen.getByTestId(locators.transactionMetadataOrigin)
-    ).toHaveAttribute('href', 'https://foo.com');
 
     // TODO: Set explicit date format for tests
     // expect(

--- a/libs/browser-wallet/src/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -5,7 +5,6 @@ import {
   truncateMiddle,
 } from '@vegaprotocol/ui-toolkit';
 import type { ReactNode } from 'react';
-import { NavLink } from 'react-router-dom';
 
 import { DataTable } from '@/components/data-table';
 import { ExternalLink } from '@/components/external-link';
@@ -13,7 +12,6 @@ import { SubHeader } from '@/components/sub-header';
 import { VegaSection } from '@/components/vega-section';
 import { useNetwork } from '@/contexts/network/network-context';
 import { formatDateTime } from '@/lib/utils';
-import { FULL_ROUTES } from '@/routes/route-names';
 import type { StoredTransaction } from '@/types/backend';
 
 import { VegaTransactionState } from '../transactions-state';
@@ -62,17 +60,6 @@ export const TransactionMetadata = ({
         ]
       : null,
     [
-      'Network',
-      <NavLink
-        data-testid={locators.transactionMetadataNetwork}
-        key="transaction-details-network"
-        className="underline"
-        to={`${FULL_ROUTES.networksSettings}/${transaction.networkId}`}
-      >
-        {transaction.networkId}
-      </NavLink>,
-    ],
-    [
       'Node',
       <ExternalLink
         data-testid={locators.transactionMetadataNode}
@@ -80,16 +67,6 @@ export const TransactionMetadata = ({
         href={transaction.node}
       >
         {transaction.node}
-      </ExternalLink>,
-    ],
-    [
-      'Origin',
-      <ExternalLink
-        data-testid={locators.transactionMetadataOrigin}
-        key="transaction-details-origin"
-        href={transaction.origin}
-      >
-        {transaction.origin}
       </ExternalLink>,
     ],
     [

--- a/libs/browser-wallet/src/frontend/routes/auth/transactions/home/transactions-list/transactions-list.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/transactions/home/transactions-list/transactions-list.tsx
@@ -34,7 +34,7 @@ export const TransactionsList = ({
             <div className="flex flex-row items-center">
               <div
                 data-testid={locators.transactionListItemTransactionType}
-                className="ml-2 text-surface-0-fg"
+                className="text-surface-0-fg"
               >
                 {getTitle(transaction.transaction)}
               </div>

--- a/libs/browser-wallet/src/frontend/routes/auth/transactions/transaction-state.spec.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/transactions/transaction-state.spec.tsx
@@ -12,13 +12,13 @@ describe('TransactionState', () => {
   it('renders info color when transaction state is confirmed', () => {
     renderComponent(TransactionState.Confirmed);
     expect(screen.getByTestId(locators.transactionState)).toHaveClass(
-      'text-intent-info-background'
+      'text-intent-info'
     );
   });
   it('renders error color when transaction state is error', () => {
     renderComponent(TransactionState.Error);
     expect(screen.getByTestId(locators.transactionState)).toHaveClass(
-      'text-intent-danger-background'
+      'text-intent-danger'
     );
   });
   it('renders neutral color when transaction state is rejected', () => {

--- a/libs/browser-wallet/src/frontend/routes/auth/transactions/transactions-state.tsx
+++ b/libs/browser-wallet/src/frontend/routes/auth/transactions/transactions-state.tsx
@@ -5,9 +5,9 @@ export const locators = {
 };
 
 const TRANSACTION_STATE_COLOR = {
-  [TransactionState.Confirmed]: 'text-intent-info-background',
+  [TransactionState.Confirmed]: 'text-intent-info',
   [TransactionState.Rejected]: 'text-surface-0-fg-muted',
-  [TransactionState.Error]: 'text-intent-danger-background',
+  [TransactionState.Error]: 'text-intent-danger',
 };
 
 export const VegaTransactionState = ({


### PR DESCRIPTION
# Related issues 🔗

Closes #6935

# Description ℹ️

Reduces padding and rearrange tx receipt views to enable most receipts to be rendered without scrollbars.

Includes minor bug fixes:

- Colours for rejected and confirmed txs were nearly invisible
- Show price in terms of asset for stop order receipts 
- Adjust padding on tx list so it looks sensible

# Demo 📺

![Screenshot 2024-10-02 at 12 55 38](https://github.com/user-attachments/assets/49681fc8-f99c-4e2b-b5f6-dcec7f167558)

