### PR TITLE
chore(trading): fix withdrawal delay notifications, fix incomplete withdrawals notifications

### DIFF
--- a/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
+++ b/apps/trading/components/asset-activity/withdrawal-status-cell.tsx
@@ -111,7 +111,7 @@ const WithdrawalStatusOpen = ({ data, openDialog }: Props) => {
   const { data: delay } = useReadContract({
     address: cfg.collateral_bridge_contract.address,
     abi: BRIDGE_ABI,
-    functionName: 'default_withdraw_delay',
+    functionName: 'defaultWithdrawDelay',
     chainId: Number(cfg.chain_id),
   });
 

--- a/apps/trading/components/withdraw-container/withdraw-container.tsx
+++ b/apps/trading/components/withdraw-container/withdraw-container.tsx
@@ -381,13 +381,13 @@ const useReadWithdrawalData = ({
       {
         abi: BRIDGE_ABI,
         address: bridgeAddress,
-        functionName: 'default_withdraw_delay',
+        functionName: 'defaultWithdrawDelay',
         chainId: Number(assetChainId),
       },
       {
         abi: BRIDGE_ABI,
         address: bridgeAddress,
-        functionName: 'get_withdraw_threshold',
+        functionName: 'getWithdrawThreshold',
         args: [assetAddress],
         chainId: Number(assetChainId),
       },

--- a/apps/trading/components/withdrawals-indicator/withdrawals-indicator.tsx
+++ b/apps/trading/components/withdrawals-indicator/withdrawals-indicator.tsx
@@ -11,7 +11,7 @@ export const WithdrawalsIndicator = () => {
   return (
     <Tooltip
       description={t('withdrawalsIncompleteTooltip', {
-        count: ready.length * 3,
+        count: ready.length,
       })}
     >
       <span className="p-1 text-2xs leading-none rounded bg-surface-3">

--- a/apps/trading/lib/hooks/use-incomplete-withdrawals.ts
+++ b/apps/trading/lib/hooks/use-incomplete-withdrawals.ts
@@ -22,7 +22,6 @@ export const useIncompleteWithdrawals = () => {
   const { configs } = useEVMBridgeConfigs();
 
   const allConfigs = [config, ...(configs || [])];
-
   const contracts = compact(
     allConfigs.map((c) => {
       if (!c) return null;
@@ -30,7 +29,7 @@ export const useIncompleteWithdrawals = () => {
       return {
         abi: BRIDGE_ABI as Abi,
         address: c.collateral_bridge_contract.address as `0x${string}`,
-        functionName: 'default_withdraw_delay',
+        functionName: 'defaultWithdrawDelay',
         chainId: Number(c.chain_id),
       };
     })

--- a/libs/smart-contracts/src/abis/erc20_bridge_abi.json
+++ b/libs/smart-contracts/src/abis/erc20_bridge_abi.json
@@ -1,539 +1,405 @@
 [
   {
-    "type": "function",
-    "name": "depositAsset",
     "inputs": [
       {
+        "internalType": "address payable",
+        "name": "erc20AssetPool",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "userAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
+        "type": "address"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
+        "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "bytes32",
         "name": "vegaPublicKey",
-        "type": "bytes32",
-        "internalType": "bytes32"
+        "type": "bytes32"
       }
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "exemptDepositor",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "getAssetDepositLifetimeLimit",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getAssetSource",
-    "inputs": [
-      {
-        "name": "vegaAssetId",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getMultisigControlAddress",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getVegaAssetId",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getWithdrawThreshold",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "globalResume",
-    "inputs": [
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "globalStop",
-    "inputs": [
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "isAssetListed",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "isExemptDepositor",
-    "inputs": [
-      {
-        "name": "depositor",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "listAsset",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "vegaAssetId",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "lifetimeLimit",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "withdrawThreshold",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "removeAsset",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "revokeExemptDepositor",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setAssetLimits",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "lifetimeLimit",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "threshold",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setWithdrawDelay",
-    "inputs": [
-      {
-        "name": "delay",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "withdrawAsset",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "target",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "creation",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "signatures",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "event",
     "name": "AssetDeposited",
-    "inputs": [
-      {
-        "name": "userAddress",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "assetSource",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "vegaPublicKey",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
+    "type": "event"
   },
   {
-    "type": "event",
-    "name": "AssetLimitsUpdated",
+    "anonymous": false,
     "inputs": [
       {
-        "name": "assetSource",
-        "type": "address",
         "indexed": true,
-        "internalType": "address"
+        "internalType": "address",
+        "name": "assetSource",
+        "type": "address"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "lifetimeLimit",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "withdrawThreshold",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        "type": "uint256"
       }
     ],
-    "anonymous": false
+    "name": "AssetLimitsUpdated",
+    "type": "event"
   },
   {
-    "type": "event",
-    "name": "AssetListed",
+    "anonymous": false,
     "inputs": [
       {
-        "name": "assetSource",
-        "type": "address",
         "indexed": true,
-        "internalType": "address"
+        "internalType": "address",
+        "name": "assetSource",
+        "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "bytes32",
         "name": "vegaAssetId",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
+        "type": "bytes32"
       },
       {
-        "name": "nonce",
-        "type": "uint256",
         "indexed": false,
-        "internalType": "uint256"
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
       }
     ],
-    "anonymous": false
+    "name": "AssetListed",
+    "type": "event"
   },
   {
-    "type": "event",
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "assetSource",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      }
+    ],
     "name": "AssetRemoved",
-    "inputs": [
-      {
-        "name": "assetSource",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "nonce",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
+    "type": "event"
   },
   {
-    "type": "event",
-    "name": "AssetWithdrawn",
+    "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
         "name": "userAddress",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "address",
         "name": "assetSource",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        "type": "address"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "nonce",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        "type": "uint256"
       }
     ],
-    "anonymous": false
+    "name": "AssetWithdrawn",
+    "type": "event"
   },
   {
-    "type": "event",
+    "anonymous": false,
+    "inputs": [],
     "name": "BridgeResumed",
-    "inputs": [],
-    "anonymous": false
+    "type": "event"
   },
   {
-    "type": "event",
+    "anonymous": false,
+    "inputs": [],
     "name": "BridgeStopped",
-    "inputs": [],
-    "anonymous": false
+    "type": "event"
   },
   {
-    "type": "event",
-    "name": "BridgeWithdrawDelaySet",
+    "anonymous": false,
     "inputs": [
       {
-        "name": "withdraw_delay",
-        "type": "uint256",
         "indexed": false,
-        "internalType": "uint256"
+        "internalType": "uint256",
+        "name": "withdraw_delay",
+        "type": "uint256"
       }
     ],
-    "anonymous": false
+    "name": "BridgeWithdrawDelaySet",
+    "type": "event"
   },
   {
-    "type": "event",
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      }
+    ],
     "name": "DepositorExempted",
-    "inputs": [
-      {
-        "name": "depositor",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
+    "type": "event"
   },
   {
-    "type": "event",
-    "name": "DepositorExemptionRevoked",
+    "anonymous": false,
     "inputs": [
       {
-        "name": "depositor",
-        "type": "address",
         "indexed": true,
-        "internalType": "address"
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
       }
     ],
-    "anonymous": false
+    "name": "DepositorExemptionRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "assetSourceToVegaAssetId",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "defaultWithdrawDelay",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "bytes32", "name": "vegaPublicKey", "type": "bytes32" }
+    ],
+    "name": "depositAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "erc20AssetPoolAddress",
+    "outputs": [
+      { "internalType": "address payable", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exemptDepositor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" }
+    ],
+    "name": "getAssetDepositLifetimeLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "vegaAssetId", "type": "bytes32" }
+    ],
+    "name": "getAssetSource",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMultisigControlAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" }
+    ],
+    "name": "getVegaAssetId",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" }
+    ],
+    "name": "getWithdrawThreshold",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "globalResume",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "globalStop",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" }
+    ],
+    "name": "isAssetListed",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "depositor", "type": "address" }
+    ],
+    "name": "isExemptDepositor",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "is_stopped",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" },
+      { "internalType": "bytes32", "name": "vegaAssetId", "type": "bytes32" },
+      { "internalType": "uint256", "name": "lifetimeLimit", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "withdrawThreshold",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "listAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "removeAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "revokeExemptDepositor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" },
+      { "internalType": "uint256", "name": "lifetimeLimit", "type": "uint256" },
+      { "internalType": "uint256", "name": "threshold", "type": "uint256" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "setAssetLimits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "delay", "type": "uint256" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "setWithdrawDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "vegaAssetIdsToSource",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetSource", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "target", "type": "address" },
+      { "internalType": "uint256", "name": "creation", "type": "uint256" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "withdrawAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]


### PR DESCRIPTION
# Related issues 🔗

Closes #6836 

# Description ℹ️

- Fix the witthdrawal delay notifications on the withdrawal form
- Fix the count of withdrawals that are ready, as the delay was not being found so being incorrectly reported
- Fix the amount of withdrawals being trippled in copy for no specific reason

# Technical

The ABIs were out of date and did not include the function defaultWithdrawalDelay. Moreover the contract function calls were still snake case rather than camelCase causing 2 separate issues.
