### PR TITLE
fix(trading): only render feedback after loading has completed

### DIFF
--- a/apps/trading/components/ticket/derivative/feedback-stop.tsx
+++ b/apps/trading/components/ticket/derivative/feedback-stop.tsx
@@ -73,7 +73,7 @@ export const FeedbackStop = () => {
   }
 
   if (
-    !pubKey &&
+    !pubKey ||
     [
       estimateLoading,
       marketStateLoading,
@@ -81,8 +81,9 @@ export const FeedbackStop = () => {
       activeOrdersLoading,
       activeStopOrdersLoading,
     ].some((l) => l)
-  )
-    {return null;}
+  ) {
+    return null;
+  }
   if (!maxStopOrders) return null;
 
   if (ticket.marginMode.mode === MarginMode.MARGIN_MODE_CROSS_MARGIN) {

--- a/apps/trading/components/ticket/derivative/feedback-stop.tsx
+++ b/apps/trading/components/ticket/derivative/feedback-stop.tsx
@@ -27,16 +27,24 @@ export const FeedbackStop = () => {
     'spam_protection_max_stopOrdersPerMarket'
   );
 
-  const { data: positionEstimate } = useEstimatePosition();
-  const { data: marketState } = useMarketState(ticket.market.id);
-  const { data: marketTradingMode } = useMarketTradingMode(ticket.market.id);
-  const { data: activeStopOrders } = useActiveStopOrders(
-    pubKey,
-    ticket.market.id,
-    !form.formState.isDirty && !form.formState.submitCount
+  const { loading: estimateLoading, data: positionEstimate } =
+    useEstimatePosition();
+  const { loading: marketStateLoading, data: marketState } = useMarketState(
+    ticket.market.id
   );
+  const { loading: marketTradingModeLoading, data: marketTradingMode } =
+    useMarketTradingMode(ticket.market.id);
+  const { loading: activeOrdersLoading, data: activeOrders } = useActiveOrders(
+    pubKey,
+    ticket.market.id
+  );
+  const { loading: activeStopOrdersLoading, data: activeStopOrders } =
+    useActiveStopOrders(
+      pubKey,
+      ticket.market.id,
+      !form.formState.isDirty && !form.formState.submitCount
+    );
   const { openVolume } = useOpenVolume(pubKey, ticket.market.id) || {};
-  const { data: activeOrders } = useActiveOrders(pubKey, ticket.market.id);
 
   const side = form.watch('side');
   const oco = form.watch('oco');
@@ -64,7 +72,17 @@ export const FeedbackStop = () => {
     return <Msg.MarketClosed marketState={marketState} />;
   }
 
-  if (!pubKey) return null;
+  if (
+    !pubKey &&
+    [
+      estimateLoading,
+      marketStateLoading,
+      marketTradingModeLoading,
+      activeOrdersLoading,
+      activeStopOrdersLoading,
+    ].some((l) => l)
+  )
+    {return null;}
   if (!maxStopOrders) return null;
 
   if (ticket.marginMode.mode === MarginMode.MARGIN_MODE_CROSS_MARGIN) {

--- a/apps/trading/components/ticket/derivative/feedback.tsx
+++ b/apps/trading/components/ticket/derivative/feedback.tsx
@@ -16,9 +16,13 @@ export const Feedback = () => {
   const { pubKey } = useVegaWallet();
   const ticket = useTicketContext('default');
 
-  const { data: positionEstimate } = useEstimatePosition();
-  const { data: marketState } = useMarketState(ticket.market.id);
-  const { data: marketTradingMode } = useMarketTradingMode(ticket.market.id);
+  const { loading: estimateLoading, data: positionEstimate } =
+    useEstimatePosition();
+  const { loading: stateLoading, data: marketState } = useMarketState(
+    ticket.market.id
+  );
+  const { loading: tradingModeLoading, data: marketTradingMode } =
+    useMarketTradingMode(ticket.market.id);
 
   const requiredCollateral = toBigNum(
     positionEstimate?.estimatePosition?.collateralIncreaseEstimate.bestCase ||
@@ -44,7 +48,7 @@ export const Feedback = () => {
   }
 
   // Dont show any collateral/margin related warnings unless the user is connected
-  if (!pubKey) {
+  if (!pubKey || estimateLoading || stateLoading || tradingModeLoading) {
     return null;
   }
 

--- a/apps/trading/components/ticket/spot/feedback.tsx
+++ b/apps/trading/components/ticket/spot/feedback.tsx
@@ -36,8 +36,9 @@ export const Feedback = () => {
   const { data: marketTradingMode, loading: tradingModeLoading } =
     useMarketTradingMode(ticket.market.id);
 
-  if (!pubKey || priceLoading || stateLoading || tradingModeLoading)
-    {return null;}
+  if (!pubKey || priceLoading || stateLoading || tradingModeLoading) {
+    return null;
+  }
 
   const price =
     type === OrderType.TYPE_LIMIT

--- a/apps/trading/components/ticket/spot/feedback.tsx
+++ b/apps/trading/components/ticket/spot/feedback.tsx
@@ -27,11 +27,17 @@ export const Feedback = () => {
   const side = form.watch('side');
   const limitPrice = form.watch('price');
 
-  const { data: lastTradePrice } = useLastTradePrice(ticket.market.id);
-  const { data: marketState } = useMarketState(ticket.market.id);
-  const { data: marketTradingMode } = useMarketTradingMode(ticket.market.id);
+  const { data: lastTradePrice, loading: priceLoading } = useLastTradePrice(
+    ticket.market.id
+  );
+  const { data: marketState, loading: stateLoading } = useMarketState(
+    ticket.market.id
+  );
+  const { data: marketTradingMode, loading: tradingModeLoading } =
+    useMarketTradingMode(ticket.market.id);
 
-  if (!pubKey) return null;
+  if (!pubKey || priceLoading || stateLoading || tradingModeLoading)
+    {return null;}
 
   const price =
     type === OrderType.TYPE_LIMIT


### PR DESCRIPTION
# Related issues 🔗

Closes #6974

# Description ℹ️

Prevents the ticket from appearing to flash while loading, moving the deal ticket button around sometimes which can look fairly unpleasant.

# Technical 👨‍🔧

Do not show anything while loading to prevent previous state from causing flashes on the ticket while reloading.
