### PR TITLE
fix(trading): switch market name and instrument name and fix oi unit

### DIFF
--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -60,17 +60,35 @@ const OpenInterestCell = ({
   const openInterestData = data && openInterestValues(data);
   if (!openInterestData) return null;
   const { openInterest, openInterestNotional } = openInterestData;
-  const quoteName = getQuoteName(data);
+  const assetSymbol = getOpenInterestCellUnits(data);
   const openInterestNotionalFormatted =
-    quoteName === 'USDT'
+    assetSymbol.toUpperCase() === 'USDT'
       ? `$${formatNumber(openInterestNotional, 0)}`
-      : `${formatNumber(openInterestNotional, 0)} ${quoteName}`;
+      : `${formatNumber(openInterestNotional, 0)} ${assetSymbol}`;
   return (
     <StackedCell
       primary={openInterest}
       secondary={openInterestNotionalFormatted}
     />
   );
+};
+
+/**
+ * Open Interest should be expressed in settlement units as per:
+ * frontend-monorepo/issues/7024
+ */
+const getOpenInterestCellUnits = (
+  data: MarketMaybeWithData | undefined
+): string => {
+  if (!data) return '';
+
+  const p = data?.tradableInstrument?.instrument?.product;
+  if (p.__typename === 'Perpetual' || p.__typename === 'Future') {
+    return p.settlementAsset.symbol;
+  }
+
+  // Spot markets have no explicit settlement asset, so we use the quote instead
+  return getQuoteName(data);
 };
 
 export const priceChangeRenderer = (

--- a/apps/trading/client-pages/markets/use-column-defs.tsx
+++ b/apps/trading/client-pages/markets/use-column-defs.tsx
@@ -156,7 +156,7 @@ export const useMarketsColumnDefs = () => {
       {
         headerName: t('Market'),
         field: 'tradableInstrument.instrument.code',
-        minWidth: 150,
+        minWidth: 410,
         pinned: true,
         cellClass: 'text-base',
         cellRenderer: ({
@@ -178,12 +178,12 @@ export const useMarketsColumnDefs = () => {
                 <StackedCell
                   primary={
                     <span className="flex gap-1 items-center">
-                      {value}
+                      {data?.tradableInstrument?.instrument.name}
                       <MarketProductPill productType={productType} />
                       <MarketIcon data={data} />
                     </span>
                   }
-                  secondary={data?.tradableInstrument?.instrument.name}
+                  secondary={value}
                 />
               </span>
             </Tooltip>

--- a/apps/trading/components/fees-container/market-fees.tsx
+++ b/apps/trading/components/fees-container/market-fees.tsx
@@ -44,11 +44,11 @@ const useFeesTableColumnDefs = (): ColDef[] => {
                 <StackedCell
                   primary={
                     <span className="flex gap-1 items-center">
-                      {value}
+                      {data.name}
                       <MarketProductPill productType={productType} />
                     </span>
                   }
-                  secondary={data.name}
+                  secondary={value}
                 />
               </span>
             );


### PR DESCRIPTION
# Related issues 🔗

Closes #7024

# Description ℹ️

Various small tweaks, mainly on the markets list page

- update market page market name column to show name first, then code beneath
- update fees page market name column to match market page change
- update open interest column to format open interest in settlement asset


# Demo 📺

## Switch market name/code on markets page
<img width="511" alt="Screenshot 2024-10-15 at 16 12 51" src="https://github.com/user-attachments/assets/f0ee36d8-23c2-4249-a26d-fb3896c12c64">

## Switch market name/code on fees page
<img width="885" alt="Screenshot 2024-10-15 at 16 13 00" src="https://github.com/user-attachments/assets/2e141573-0a50-427b-ad1a-994a91b37aab">

## Update open interest unit
<img width="323" alt="Screenshot 2024-10-15 at 17 48 04" src="https://github.com/user-attachments/assets/35565016-b80e-4cbf-b584-be422bf14e6b">


# Technical 👨‍🔧

